### PR TITLE
feat: add configurable custom review types

### DIFF
--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -247,12 +247,14 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 		}
 		return fmt.Errorf("resolve trusted CI config ref: %w", refErr)
 	}
-	repoCfg, err := config.LoadRepoConfigFromRef(root, repoCfgRef)
+	repoConfig, err := config.LoadRepoConfigWithFallback(root, repoCfgRef)
 	if err != nil {
 		log.Printf(
 			"ci review: load repo config from %s: %v "+
 				"(using defaults)", repoCfgRef, err)
 	}
+	repoCfg := repoConfig.Config
+	repoCfgRef = repoConfig.Ref
 
 	// The Claude adapter strips ANTHROPIC_API_KEY from the inherited
 	// environment and re-injects only the key roborev was given, so hand

--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -144,12 +144,6 @@ type ciReviewOpts struct {
 func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 	// Validate flag-only inputs early (before git/config
 	// checks) so users get clear errors even outside a repo.
-	if opts.reviewTypes != "" {
-		if _, err := config.ValidateReviewTypes(
-			splitTrimmed(opts.reviewTypes)); err != nil {
-			return err
-		}
-	}
 	if opts.reasoning != "" {
 		if _, err := config.NormalizeReasoning(
 			opts.reasoning); err != nil {
@@ -268,8 +262,9 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 		return fmt.Errorf("no review types configured " +
 			"(check --review-types flag or config)")
 	}
-	reviewTypes, err = config.ValidateReviewTypes(
-		reviewTypes)
+	reviewTypes, err = config.ValidateReviewTypesFromConfig(
+		reviewTypes, repoCfg, globalCfg,
+	)
 	if err != nil {
 		return err
 	}
@@ -321,6 +316,7 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 		ReviewTypes:  reviewTypes,
 		Reasoning:    reasoningLevel,
 		GlobalConfig: globalCfg,
+		RepoConfig:   repoCfg,
 		MinSeverity:  reviewMinSev,
 	}
 

--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -209,6 +209,9 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 		}
 		gitRef = detected
 	}
+	if strings.HasPrefix(gitRef, "-") {
+		return fmt.Errorf("--ref must not start with '-' (got %q)", gitRef)
+	}
 
 	// Bind the range to the merge request before spending the review matrix
 	// on it. Posting checks again afterwards, to catch a force push that

--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -228,13 +228,30 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 		}
 	}
 
-	// Load configs (warn on error, don't fail)
+	// Load configs (warn on error, don't fail). Repository configuration and
+	// its relative custom-review files come from the trusted side of the
+	// reviewed range, never from the checkout under review.
 	globalCfg := loadCIGlobalConfig(root)
-	repoCfg, err := config.LoadRepoConfig(root)
+	repoCfgRef, refErr := trustedCIRepoConfigRef(root, gitRef)
+	if refErr != nil {
+		// Preserve the flag-validation diagnostic when a plainly unknown type
+		// and an invalid ref are supplied together. Repository-defined types
+		// cannot be established without a valid trusted ref, but built-in and
+		// global definitions can still be checked here.
+		if opts.reviewTypes != "" {
+			if _, validationErr := config.ValidateReviewTypesFromConfig(
+				splitTrimmed(opts.reviewTypes), nil, globalCfg,
+			); validationErr != nil {
+				return validationErr
+			}
+		}
+		return fmt.Errorf("resolve trusted CI config ref: %w", refErr)
+	}
+	repoCfg, err := config.LoadRepoConfigFromRef(root, repoCfgRef)
 	if err != nil {
 		log.Printf(
-			"ci review: load repo config: %v "+
-				"(using defaults)", err)
+			"ci review: load repo config from %s: %v "+
+				"(using defaults)", repoCfgRef, err)
 	}
 
 	// The Claude adapter strips ANTHROPIC_API_KEY from the inherited
@@ -310,14 +327,15 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 	// they are not, so file context comes from the protected branch. See
 	// docs/integrations/gitlab.md for the operator-side workaround.
 	batchCfg := review.BatchConfig{
-		RepoPath:     root,
-		GitRef:       gitRef,
-		Agents:       agents,
-		ReviewTypes:  reviewTypes,
-		Reasoning:    reasoningLevel,
-		GlobalConfig: globalCfg,
-		RepoConfig:   repoCfg,
-		MinSeverity:  reviewMinSev,
+		RepoPath:      root,
+		GitRef:        gitRef,
+		Agents:        agents,
+		ReviewTypes:   reviewTypes,
+		Reasoning:     opts.reasoning,
+		GlobalConfig:  globalCfg,
+		RepoConfig:    repoCfg,
+		RepoConfigRef: repoCfgRef,
+		MinSeverity:   reviewMinSev,
 	}
 
 	results := review.RunBatch(ctx, batchCfg)
@@ -562,6 +580,24 @@ func detectGitRefForForge(forge ciForge, repoPath string) (string, error) {
 		return detectGitLabGitRef(repoPath)
 	}
 	return detectGitRef()
+}
+
+// trustedCIRepoConfigRef returns the commit whose repository configuration is
+// allowed to control a daemon-free CI review. Ranges use their base commit. A
+// single-commit review uses its first parent, or the empty tree for a root
+// commit, so the reviewed commit cannot alter its own gate.
+func trustedCIRepoConfigRef(repoPath, gitRef string) (string, error) {
+	if git.IsRange(gitRef) {
+		return git.GetRangeStart(repoPath, gitRef)
+	}
+	parents, err := git.GetCommitParents(repoPath, gitRef)
+	if err != nil {
+		return "", err
+	}
+	if len(parents) == 0 {
+		return git.EmptyTreeSHA, nil
+	}
+	return parents[0], nil
 }
 
 // postForgeComment posts the synthesized review to the active forge.

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -475,6 +475,20 @@ func TestDetectGitRefForForge_UsesForgeSpecificEnv(t *testing.T) {
 	assert.Equal(t, "glbase..glhead", glRef)
 }
 
+func TestTrustedCIRepoConfigRefUsesPreReviewCommit(t *testing.T) {
+	repo := testutil.NewTestRepoWithCommit(t)
+	base := repo.HeadSHA()
+	head := repo.CommitFile("feature.txt", "feature", "feature work")
+
+	got, err := trustedCIRepoConfigRef(repo.Path(), base+".."+head)
+	require.NoError(t, err)
+	assert.Equal(t, base, got)
+
+	got, err = trustedCIRepoConfigRef(repo.Path(), head)
+	require.NoError(t, err)
+	assert.Equal(t, base, got)
+}
+
 // TestDetectGitLabGitRef_DivergedBranches covers the fallback bases, which are
 // branch tips rather than diff bases. When the target branch advanced after the
 // branches diverged, comparing tips would report target-only commits as

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -108,6 +108,7 @@ func TestCIReviewCmd_Validation(t *testing.T) {
 		{"InvalidReviewType", []string{"review", "--ref", "abc", "--review-types", "bogus"}, "invalid review_type", false},
 		{"InvalidReasoning", []string{"review", "--ref", "abc", "--reasoning", "bogus"}, "invalid reasoning", false},
 		{"InvalidMinSeverity", []string{"review", "--ref", "abc", "--min-severity", "bogus"}, "invalid min_severity", false},
+		{"OptionLikeRef", []string{"review", "--ref=--format=%H"}, "--ref must not start with '-'", false},
 		{"RequiresRef", []string{"review"}, "auto-detection", true},
 	}
 

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -113,13 +113,11 @@ func TestCIReviewCmd_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Review type validation may need repository configuration, so every
+			// case runs in an explicit test repository. Build sandboxes copy the
+			// source without its .git directory.
+			t.Chdir(testutil.InitTestRepo(t).Root)
 			if tt.clearEnv {
-				// Ref auto-detection runs after the repo-root check, so
-				// reaching it needs a git repo as the working directory.
-				// Without one the command fails earlier with "not a git
-				// repository" — which is what happens in a build sandbox
-				// that copies the source without .git.
-				t.Chdir(testutil.InitTestRepo(t).Root)
 				clearForgeCIEnv(t)
 			}
 			cmd := ciCmd()

--- a/cmd/roborev/completions.go
+++ b/cmd/roborev/completions.go
@@ -70,8 +70,10 @@ func registerReasoningCompletion(cmd *cobra.Command) {
 // registerReviewTypeCompletion registers shell completion for the --type flag.
 // Panics if the flag doesn't exist on the command (programming error).
 func registerReviewTypeCompletion(cmd *cobra.Command) {
-	if err := cmd.RegisterFlagCompletionFunc("type", func(_ *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
-		types := config.ExplicitReviewTypes()
+	if err := cmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, _ []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		globalCfg, _ := config.LoadGlobal()
+		repoCfg, _, _ := loadCommandRepoConfig(cmd)
+		types := config.ReviewTypesFromConfig(repoCfg, globalCfg)
 		completions := make([]cobra.Completion, len(types))
 		for i, t := range types {
 			completions[i] = cobra.Completion(t)

--- a/cmd/roborev/daemon_client.go
+++ b/cmd/roborev/daemon_client.go
@@ -118,7 +118,7 @@ func showReview(cmd *cobra.Command, ep daemon.DaemonEndpoint, jobID int64, quiet
 	}
 
 	// Return exit code based on verdict
-	verdict := storage.ParseVerdict(review.Output)
+	verdict := review.Verdict()
 	if verdict == "F" {
 		return &exitError{code: 1}
 	}

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -1025,15 +1025,6 @@ func firstLine(s string) string {
 	return truncateString(s, 80)
 }
 
-// jobVerdict returns the verdict for a job. Uses the stored verdict
-// if available, otherwise parses from the review output.
-func jobVerdict(job *storage.ReviewJob, review *storage.Review) string {
-	if job.Verdict != nil && *job.Verdict != "" {
-		return *job.Verdict
-	}
-	return storage.ParseVerdict(review.Output)
-}
-
 func fixSingleJob(cmd *cobra.Command, repoRoot string, jobID int64, opts fixOptions, tracker *fixSessionTracker) error {
 	if opts.classify == nil {
 		opts.classify = agent.ClassifyLimit
@@ -1065,7 +1056,7 @@ func fixSingleJob(cmd *cobra.Command, repoRoot string, jobID int64, opts fixOpti
 	}
 
 	// Skip reviews that passed — no findings to fix
-	if jobVerdict(job, review) == "P" {
+	if review.Verdict() == "P" {
 		if !opts.quiet {
 			cmd.Printf("Job %d: review passed, skipping fix\n", jobID)
 		}
@@ -1343,7 +1334,7 @@ func processFixBatch(ctx context.Context, cmd *cobra.Command, roots currentRepoR
 			}
 			continue
 		}
-		if jobVerdict(job, review) == "P" {
+		if review.Verdict() == "P" {
 			if !opts.quiet {
 				cmd.Printf("Skipping job %d (review passed)\n", id)
 			}

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -2826,53 +2826,6 @@ func TestResolveCurrentBranchFilter(t *testing.T) {
 	})
 }
 
-func TestJobVerdict(t *testing.T) {
-	pass := "P"
-	fail := "F"
-	empty := ""
-
-	tests := []struct {
-		name    string
-		verdict *string
-		output  string
-		want    string
-	}{
-		{
-			name:    "stored PASS verdict",
-			verdict: &pass,
-			output:  "some output",
-			want:    "P",
-		},
-		{
-			name:    "stored FAIL verdict",
-			verdict: &fail,
-			output:  "No issues found.",
-			want:    "F",
-		},
-		{
-			name:    "nil verdict falls back to parse",
-			verdict: nil,
-			output:  "No issues found.",
-			want:    "P",
-		},
-		{
-			name:    "empty verdict falls back to parse",
-			verdict: &empty,
-			output:  "## Issues\n- Bug in foo.go",
-			want:    "F",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job := &storage.ReviewJob{Verdict: tt.verdict}
-			review := &storage.Review{Output: tt.output}
-			got := jobVerdict(job, review)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestFixSingleJobSkipsPassVerdict(t *testing.T) {
 	repo := createTestRepo(t, map[string]string{
 		"main.go": "package main\n",

--- a/cmd/roborev/refine.go
+++ b/cmd/roborev/refine.go
@@ -493,7 +493,7 @@ func runRefine(runCtx RunContext, opts refineOptions) error {
 					fmt.Printf("Warning: review failed: %v\n", err)
 					continue // Loop back, will re-check
 				}
-				verdict := storage.ParseVerdict(review.Output)
+				verdict := review.Verdict()
 				if verdict == "F" && !review.Closed {
 					currentFailedReview = review
 				} else if verdict == "P" {
@@ -546,7 +546,7 @@ func runRefine(runCtx RunContext, opts refineOptions) error {
 					return fmt.Errorf("branch review failed: %w", err)
 				}
 
-				verdict := storage.ParseVerdict(review.Output)
+				verdict := review.Verdict()
 				if verdict == "P" {
 					fmt.Println("\nAll reviews passed! Branch is ready.")
 					return nil
@@ -791,7 +791,7 @@ func runRefine(runCtx RunContext, opts refineOptions) error {
 			continue
 		}
 
-		verdict := storage.ParseVerdict(review.Output)
+		verdict := review.Verdict()
 		if verdict == "P" {
 			fmt.Println("New commit passed review!")
 			if err := client.MarkReviewClosed(review.JobID); err != nil {
@@ -1131,7 +1131,7 @@ func findFailedReviewForBranch(client daemon.Client, commits []string, skip map[
 			continue
 		}
 
-		verdict := storage.ParseVerdict(review.Output)
+		verdict := review.Verdict()
 		if verdict == "F" {
 			return review, nil
 		}

--- a/cmd/roborev/refine_test.go
+++ b/cmd/roborev/refine_test.go
@@ -294,6 +294,15 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 			wantClosedIDs: []int64{100},
 		},
 		{
+			name: "stored verdict overrides rendered review text",
+			setup: func(c *mockDaemonClient) {
+				c.WithReview("commit1", 100, "No issues found.", false)
+				c.reviews["commit1"].VerdictBool = new(0)
+			},
+			commits:   []string{"commit1"},
+			wantJobID: 100,
+		},
+		{
 			name: "skips closed",
 			setup: func(c *mockDaemonClient) {
 				c.WithReview("commit1", 100, "Bug found.", false).

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -522,6 +522,9 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 			a = pa.WithProvider(provider)
 		}
 	}
+	if err := agent.ValidateStructuredReviewSelection(reviewType, a); err != nil {
+		return fmt.Errorf("invalid agent: %w", err)
+	}
 
 	// Use consistent output writer, respecting --quiet
 	out := cmd.OutOrStdout()

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -561,32 +561,10 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 		return fmt.Errorf("build prompt: %w", err)
 	}
 
-	// Run review with output writer. Custom types use the native schema path,
-	// then render Roborev's canonical review text.
-	if !config.IsBuiltInReviewType(reviewType) {
-		structuredAgent, ok := a.(agent.StructuredReviewAgent)
-		if !ok {
-			return fmt.Errorf(
-				"agent %q does not support schema-constrained reviews", a.Name(),
-			)
-		}
-		raw, reviewErr := structuredAgent.ReviewWithSchema(
-			cmd.Context(), repoPath, gitRef, reviewPrompt,
-			reviewpkg.CustomReviewSchema, out,
-		)
-		if reviewErr != nil {
-			return fmt.Errorf("review failed: %w", reviewErr)
-		}
-		structured, decodeErr := reviewpkg.DecodeStructuredReview(raw)
-		if decodeErr != nil {
-			return fmt.Errorf("review failed: %w", decodeErr)
-		}
-		if !quiet {
-			fmt.Fprintln(out, structured.Filter(resolvedMinSev).Markdown())
-		}
-	} else {
-		_, err = a.Review(cmd.Context(), repoPath, gitRef, reviewPrompt, out)
-	}
+	_, err = reviewpkg.RunAgentReview(
+		cmd.Context(), a, repoPath, gitRef, reviewPrompt, reviewType,
+		resolvedMinSev, out,
+	)
 	if err != nil {
 		return fmt.Errorf("review failed: %w", err)
 	}

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/kata"
 	"go.kenn.io/roborev/internal/prompt"
+	reviewpkg "go.kenn.io/roborev/internal/review"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -150,11 +151,25 @@ Examples:
 				return usageErr(cmd, fmt.Errorf("cannot specify commits with --since"))
 			}
 
-			// Validate --type flag
-			switch reviewType {
-			case "", config.ReviewTypeSecurity, config.ReviewTypeDesign, config.ReviewTypeLookahead:
-			default:
-				return usageErr(cmd, fmt.Errorf("invalid --type %q (valid: %s)", reviewType, config.ExplicitReviewTypesHelp()))
+			// Validate --type against the effective global and repository config.
+			if reviewType != "" {
+				globalCfg, loadErr := config.LoadGlobal()
+				if loadErr != nil {
+					return fmt.Errorf("load config: %w", loadErr)
+				}
+				repoCfg, loadErr := config.LoadRepoConfig(root)
+				if loadErr != nil {
+					return fmt.Errorf("load repository config: %w", loadErr)
+				}
+				canonical, validationErr := config.ValidateReviewTypesFromConfig(
+					[]string{reviewType}, repoCfg, globalCfg,
+				)
+				if validationErr != nil {
+					return usageErr(cmd, fmt.Errorf(
+						"invalid --type %q: %w", reviewType, validationErr,
+					))
+				}
+				reviewType = canonical[0]
 			}
 
 			// Auto-install/upgrade hooks when running from CLI
@@ -443,8 +458,15 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	repoCfg, err := config.LoadRepoConfig(repoPath)
+	if err != nil {
+		return fmt.Errorf("load repository config: %w", err)
+	}
+
 	// Resolve and validate reasoning (matches daemon behavior)
-	reasoning, err = config.ResolveReviewReasoning(reasoning, repoPath, cfg)
+	reasoning, err = config.ResolveReviewReasoningForTypeFromConfig(
+		reasoning, repoCfg, cfg, reviewType,
+	)
 	if err != nil {
 		return fmt.Errorf("invalid reasoning: %w", err)
 	}
@@ -512,7 +534,11 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 	}
 
 	// Build prompt
-	pb := prompt.NewBuilderWithConfig(nil, cfg).WithContext(ctx).ForRepo(repoPath, 0).WithKataClient(kata.NewCLIClient(repoPath))
+	pb := prompt.NewBuilderWithConfig(nil, cfg).
+		WithContext(ctx).
+		ForRepo(repoPath, 0).
+		WithRepoConfig(repoCfg, "").
+		WithKataClient(kata.NewCLIClient(repoPath))
 	var reviewPrompt string
 	var snapshotCleanup func()
 	if diffContent != "" || len(dirtyFiles) > 0 {
@@ -535,8 +561,32 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 		return fmt.Errorf("build prompt: %w", err)
 	}
 
-	// Run review with output writer
-	_, err = a.Review(cmd.Context(), repoPath, gitRef, reviewPrompt, out)
+	// Run review with output writer. Custom types use the native schema path,
+	// then render Roborev's canonical review text.
+	if !config.IsBuiltInReviewType(reviewType) {
+		structuredAgent, ok := a.(agent.StructuredReviewAgent)
+		if !ok {
+			return fmt.Errorf(
+				"agent %q does not support schema-constrained reviews", a.Name(),
+			)
+		}
+		raw, reviewErr := structuredAgent.ReviewWithSchema(
+			cmd.Context(), repoPath, gitRef, reviewPrompt,
+			reviewpkg.CustomReviewSchema, out,
+		)
+		if reviewErr != nil {
+			return fmt.Errorf("review failed: %w", reviewErr)
+		}
+		structured, decodeErr := reviewpkg.DecodeStructuredReview(raw)
+		if decodeErr != nil {
+			return fmt.Errorf("review failed: %w", decodeErr)
+		}
+		if !quiet {
+			fmt.Fprintln(out, structured.Filter(resolvedMinSev).Markdown())
+		}
+	} else {
+		_, err = a.Review(cmd.Context(), repoPath, gitRef, reviewPrompt, out)
+	}
 	if err != nil {
 		return fmt.Errorf("review failed: %w", err)
 	}

--- a/cmd/roborev/review_test.go
+++ b/cmd/roborev/review_test.go
@@ -141,7 +141,7 @@ func handleJobsDone(
 }
 
 func mockWaitableReview(
-	t *testing.T, mux *http.ServeMux, output string,
+	t *testing.T, mux *http.ServeMux, output string, verdict int,
 ) {
 	t.Helper()
 	mockEnqueueQueued(mux, "abc123")
@@ -155,6 +155,7 @@ func mockWaitableReview(
 	) {
 		respondJSON(w, http.StatusOK, storage.Review{
 			ID: 1, JobID: 1, Agent: "test", Output: output,
+			VerdictBool: new(verdict),
 		})
 	})
 }
@@ -253,7 +254,7 @@ func TestWaitQuietVerdictExitCode(t *testing.T) {
 	t.Run("passing review exits 0 with no output", func(t *testing.T) {
 		repo, mux := setupTestEnvironment(t)
 		repo.CommitFile("file.txt", "content", "initial commit")
-		mockWaitableReview(t, mux, "No issues found.")
+		mockWaitableReview(t, mux, "No issues found.", 1)
 
 		stdout, stderr, err := executeReviewCmd("--repo", repo.Dir, "--wait", "--quiet")
 
@@ -267,6 +268,7 @@ func TestWaitQuietVerdictExitCode(t *testing.T) {
 		repo.CommitFile("file.txt", "content", "initial commit")
 		mockWaitableReview(t, mux,
 			"Found 2 issues:\n1. Bug in foo.go\n2. Missing error handling",
+			0,
 		)
 
 		stdout, stderr, err := executeReviewCmd("--repo", repo.Dir, "--wait", "--quiet")
@@ -277,6 +279,18 @@ func TestWaitQuietVerdictExitCode(t *testing.T) {
 		require.Equal(t, 1, exitErr.code, "expected exit code 1")
 		assert.Empty(t, stdout)
 		assert.Empty(t, stderr)
+	})
+
+	t.Run("stored verdict overrides rendered review text", func(t *testing.T) {
+		repo, mux := setupTestEnvironment(t)
+		repo.CommitFile("file.txt", "content", "initial commit")
+		mockWaitableReview(t, mux, "No issues found.", 0)
+
+		_, _, err := executeReviewCmd("--repo", repo.Dir, "--wait", "--quiet")
+
+		var exitErr *exitError
+		require.ErrorAs(t, err, &exitErr)
+		assert.Equal(t, 1, exitErr.code)
 	})
 }
 

--- a/docs/advanced/custom-review-types.md
+++ b/docs/advanced/custom-review-types.md
@@ -1,0 +1,198 @@
+---
+title: Custom Review Types
+description: Define reusable schema-constrained reviews with Go templates
+---
+
+Custom review types let you give a domain-specific review a name and run it
+through the normal roborev workflows:
+
+```bash
+roborev review --type thermonuclear
+roborev review --branch --type thermonuclear
+```
+
+Define a type in `.roborev.toml` for one repository or in
+`~/.roborev/config.toml` to make it available globally:
+
+```toml
+[review.types.api-contract]
+template = ".roborev/reviews/api-contract.md"
+agent = "codex"
+reasoning = "thorough"
+```
+
+The template supplies the review rubric. Roborev still constructs the commit or
+range context, project guidelines, diff, and oversized-diff snapshot
+instructions. It also owns the output schema, severity filtering, pass/fail
+verdict, and final Markdown rendering.
+
+## Configuration reference
+
+Each `[review.types.<name>]` table supports these fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `template` | Yes | Path to the Go template containing the review rubric |
+| `includes` | No | Map of names to files made available through `.Includes` |
+| `agent` | No | Agent override for this type |
+| `model` | No | Model override for this type |
+| `reasoning` | No | Reasoning override for this type |
+
+Names must start with a lowercase letter and contain only lowercase letters,
+digits, and hyphens. Names may not replace built-in types or their aliases:
+`default`, `review`, `general`, `security`, `design`, and `lookahead`.
+
+A repository definition replaces a global definition with the same name. Its
+fields are not merged individually.
+
+## Paths and includes
+
+Repository configuration accepts only paths relative to the repository root.
+Absolute paths, home-relative paths, and paths that escape the repository are
+rejected. This keeps a checked-in configuration self-contained. CI reads both
+the configuration and its files from the trusted pull-request base branch.
+
+Global configuration accepts:
+
+- Repository-relative paths, resolved separately for the repository being
+    reviewed.
+- Absolute paths.
+- Home-relative paths beginning with `~/`.
+
+Roborev does not fetch URLs while running a review. Download or vendor remote
+rubrics first so reviews remain reproducible and do not depend on the network.
+
+Named includes are useful when a small wrapper template needs to combine a
+third-party rubric with local instructions:
+
+```toml
+[review.types.example]
+template = ".roborev/reviews/example.tmpl"
+
+[review.types.example.includes]
+rubric = ".roborev/reviews/upstream-rubric.md"
+policy = ".roborev/reviews/local-policy.md"
+```
+
+The wrapper can render them with Go's `index` function:
+
+```gotemplate
+# Example review
+
+{{ index .Includes "rubric" }}
+
+## Repository policy
+
+{{ index .Includes "policy" }}
+```
+
+## Template values
+
+Templates use Go's `text/template` syntax and receive these values:
+
+| Value | Type | Description |
+|-------|------|-------------|
+| `.ReviewType` | string | Configured type name, such as `thermonuclear` |
+| `.Includes` | map | Contents of every configured named include |
+
+Invalid template syntax and execution errors fail prompt construction with a
+configuration error. Template and include contents count toward the configured
+`max_prompt_size` budget.
+
+Do not put diff placeholders in the custom template. Roborev appends the review
+target and diff context after rendering it.
+
+## Structured results and compatible agents
+
+Custom types require an agent with native JSON Schema output support. Roborev
+currently supports custom reviews with `codex`, `claude-code`, `pi`, and `grok`.
+If the selected agent lacks that capability, the job fails instead of falling
+back to unconstrained prose.
+
+The schema is fixed by roborev. The agent must return:
+
+```json
+{
+  "summary": "Overall assessment",
+  "findings": [
+    {
+      "severity": "high",
+      "problem": "What is wrong and why it matters",
+      "fix": "A concrete correction",
+      "location": "optional/file.go:42"
+    }
+  ]
+}
+```
+
+`summary` and `findings` are required. Every finding requires `severity`,
+`problem`, and `fix`; `location` is optional. Native strict schemas represent a
+missing location as `null`. Severity must be one of `critical`, `high`,
+`medium`, or `low`.
+
+Roborev removes findings below `review_min_severity` or `--min-severity`. The
+review passes when no findings remain, and fails otherwise. Built-in review
+types keep their existing prose output path.
+
+## Writing useful severity guidance
+
+The schema guarantees that each finding has a valid severity label, but it
+cannot decide what severity means for your domain. Put a short, concrete rubric
+in the prompt. Explain impact rather than relying on adjectives. For example:
+
+```markdown
+Classify findings by impact:
+
+- critical: permits data loss, credential compromise, or remote code execution
+- high: breaks a primary workflow or creates a likely production incident
+- medium: causes incorrect behavior in a narrower or recoverable case
+- low: creates a concrete maintainability or usability cost without incorrect behavior
+```
+
+Tell the reviewer to report all real findings. Roborev applies the configured
+minimum after structured output is returned, so the template does not need to
+implement threshold filtering.
+
+## Thermonuclear example
+
+Download the Cursor Team Kit rubric into the repository:
+
+```bash
+mkdir -p .roborev/reviews
+curl -L \
+  https://raw.githubusercontent.com/cursor/plugins/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md \
+  -o .roborev/reviews/thermonuclear-skill.md
+```
+
+Create `.roborev/reviews/thermonuclear.tmpl`:
+
+```gotemplate
+# Thermonuclear maintainability review
+
+Apply the following rubric directly to the reviewed change. Treat its skill
+metadata as descriptive text; do not invoke or delegate to another skill.
+
+{{ index .Includes "rubric" }}
+
+For every actionable finding, choose one of roborev's severity levels. Reserve
+critical and high for concrete correctness, security, operability, or severe
+maintainability risks. Use medium or low for narrower maintainability costs.
+```
+
+Then add this configuration:
+
+```toml
+[review.types.thermonuclear]
+template = ".roborev/reviews/thermonuclear.tmpl"
+agent = "codex"
+reasoning = "thorough"
+
+[review.types.thermonuclear.includes]
+rubric = ".roborev/reviews/thermonuclear-skill.md"
+```
+
+Run it with:
+
+```bash
+roborev review --type thermonuclear --wait
+```

--- a/docs/advanced/custom-review-types.md
+++ b/docs/advanced/custom-review-types.md
@@ -97,10 +97,17 @@ Templates use Go's `text/template` syntax and receive these values:
 
 Invalid template syntax and execution errors fail prompt construction with a
 configuration error. Template and include contents count toward the configured
-`max_prompt_size` budget.
+`max_prompt_size` budget. Roborev always reserves 16 KiB of that budget for the
+review target, diff, or oversized-diff snapshot reference. A custom rubric that
+would consume the remainder is rejected instead of running without the code it
+is meant to review.
 
 Do not put diff placeholders in the custom template. Roborev appends the review
 target and diff context after rendering it.
+
+Queued reviews resolve their custom type when a worker starts them. If the type
+has been removed or renamed since the job was queued, the job fails with a
+configuration error; Roborev never substitutes the generic review prompt.
 
 ## Structured results and compatible agents
 
@@ -108,6 +115,13 @@ Custom types require an agent with native JSON Schema output support. Roborev
 currently supports custom reviews with `codex`, `claude-code`, `pi`, and `grok`.
 If the selected agent lacks that capability, the job fails instead of falling
 back to unconstrained prose.
+
+Roborev does not impose one shared minimum version across those independent
+CLIs. The installed command must support the schema mechanism used by its
+adapter: `--output-schema` for Codex, `--json-schema` for Claude Code and Grok,
+and the `pi-json-schema` extension for Pi. An unsupported flag or missing Pi
+extension is reported as an agent execution error; update the CLI or install the
+extension before retrying the review.
 
 The schema is fixed by roborev. The agent must return:
 
@@ -152,6 +166,10 @@ Classify findings by impact:
 Tell the reviewer to report all real findings. Roborev applies the configured
 minimum after structured output is returned, so the template does not need to
 implement threshold filtering.
+
+When CI has no command-line `--reasoning` value or repository `[ci].reasoning`,
+a custom type's `reasoning` field controls that type. An explicit CI value
+applies to every review in the matrix.
 
 ## Thermonuclear example
 

--- a/docs/advanced/custom-review-types.md
+++ b/docs/advanced/custom-review-types.md
@@ -49,17 +49,17 @@ fields are not merged individually.
 
 ## Paths and includes
 
-Repository configuration accepts only paths relative to the repository root.
-Absolute paths, home-relative paths, and paths that escape the repository are
-rejected. This keeps a checked-in configuration self-contained. CI reads both
-the configuration and its files from the trusted pull-request base branch.
-
-Global configuration accepts:
+Repository and global configuration accept:
 
 - Repository-relative paths, resolved separately for the repository being
     reviewed.
 - Absolute paths.
 - Home-relative paths beginning with `~/`.
+
+Paths containing `..` and symlinks may also point outside the repository.
+Roborev treats these paths as user-selected files, not as a security boundary.
+In CI, repository-relative files that remain inside the repository are read from
+the configured base ref. External paths are read from the filesystem.
 
 Roborev does not fetch URLs while running a review. Download or vendor remote
 rubrics first so reviews remain reproducible and do not depend on the network.
@@ -98,11 +98,8 @@ Templates use Go's `text/template` syntax and receive these values:
 | `.Includes` | map | Contents of every configured named include |
 
 Invalid template syntax and execution errors fail prompt construction with a
-configuration error. Template and include contents count toward the configured
-`max_prompt_size` budget. Roborev always reserves 16 KiB of that budget for the
-review target, diff, or oversized-diff snapshot reference. A custom rubric that
-would consume the remainder is rejected instead of running without the code it
-is meant to review.
+configuration error. Template and include contents use the same configured
+`max_prompt_size` budget as the rest of the review prompt.
 
 Do not put diff placeholders in the custom template. Roborev appends the review
 target and diff context after rendering it.

--- a/docs/advanced/custom-review-types.md
+++ b/docs/advanced/custom-review-types.md
@@ -112,8 +112,9 @@ configuration error; Roborev never substitutes the generic review prompt.
 
 Custom types require an agent with native JSON Schema output support. Roborev
 currently supports custom reviews with `codex`, `claude-code`, `pi`, and `grok`.
-If the selected agent lacks that capability, the job fails instead of falling
-back to unconstrained prose.
+If the resolved agent lacks that capability, Roborev rejects the review before
+enqueue instead of storing a job that can only fail or falling back to
+unconstrained prose.
 
 Roborev does not impose one shared minimum version across those independent
 CLIs. The installed command must support the schema mechanism used by its
@@ -126,6 +127,7 @@ The schema is fixed by roborev. The agent must return:
 
 ```json
 {
+  "schema_version": 1,
   "summary": "Overall assessment",
   "findings": [
     {
@@ -138,10 +140,10 @@ The schema is fixed by roborev. The agent must return:
 }
 ```
 
-`summary` and `findings` are required. Every finding requires `severity`,
-`problem`, and `fix`; `location` is optional. Native strict schemas represent a
-missing location as `null`. Severity must be one of `critical`, `high`,
-`medium`, or `low`.
+`schema_version`, `summary`, and `findings` are required. The current schema
+version is `1`; Roborev rejects missing or unsupported versions. Every finding
+requires `severity`, `problem`, `fix`, and `location`; use `null` when a finding
+has no location. Severity must be one of `critical`, `high`, `medium`, or `low`.
 
 Roborev removes findings below `review_min_severity` or `--min-severity`. The
 review passes when no findings remain, and fails otherwise. Built-in review

--- a/docs/advanced/custom-review-types.md
+++ b/docs/advanced/custom-review-types.md
@@ -40,7 +40,9 @@ Each `[review.types.<name>]` table supports these fields:
 
 Names must start with a lowercase letter and contain only lowercase letters,
 digits, and hyphens. Names may not replace built-in types or their aliases:
-`default`, `review`, `general`, `security`, `design`, and `lookahead`.
+`default`, `review`, `general`, `security`, `design`, and `lookahead`. Names
+used by other built-in workflows are also reserved: `fix`, `refine`, and
+`classify`.
 
 A repository definition replaces a global definition with the same name. Its
 fields are not merged individually.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -476,6 +476,14 @@ Types that have them — `review`, `refine`, `fix`, `security`, `design` — ign
 Reasoning is unaffected by this block for reviews; it follows `review_reasoning`
 (the block's `reasoning` field applies only to `roborev analyze <type>` runs).
 
+### Custom Review Types
+
+Custom domain-specific review types are configured under
+`[review.types.<name>]`. They support a Go template, named file includes, and
+optional agent, model, and reasoning overrides. See
+[Custom Review Types](/advanced/custom-review-types/) for path rules, template
+values, structured output, and examples.
+
 ### Review Panels
 
 Use `[review]` to configure subagent review panels. A panel fans one daemon

--- a/docs/guides/reviewing-code.md
+++ b/docs/guides/reviewing-code.md
@@ -166,6 +166,10 @@ model = "sonnet"
 
 When unset, it falls back to your repo or global default agent and model.
 
+You can also define schema-constrained review types backed by local Go
+templates, then use them anywhere `--type` or `review_type` is accepted. See
+[Custom Review Types](/advanced/custom-review-types/).
+
 ## Task Context from Kata
 
 If your repo is bound to a [Kata](https://github.com/kenn-io/kata) project,

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -37,6 +37,7 @@ nav = [
   {"Advanced Features" = [
     {"Background Tasks" = "advanced/background-tasks.md"},
     {"Subagent Review Panels" = "advanced/subagent-review-panels.md"},
+    {"Custom Review Types" = "advanced/custom-review-types.md"},
     {"Custom Tasks & Agentic Mode" = "advanced/custom-tasks.md"},
     {"Agent Client Protocol (ACP)" = "advanced/acp.md"},
     {"PostgreSQL Sync" = "advanced/postgres-sync.md"},

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -746,5 +746,71 @@ func (a *ClaudeAgent) ClassifyWithSchema(
 	return parseClaudeClassifyStream(strings.NewReader(string(buf)))
 }
 
+func (a *ClaudeAgent) ReviewWithSchema(
+	ctx context.Context,
+	repoPath, gitRef, prompt string,
+	schema json.RawMessage,
+	out io.Writer,
+) (json.RawMessage, error) {
+	model, baseURL, err := parseModel(a.Model)
+	if err != nil {
+		return nil, err
+	}
+	agenticMode := a.Agentic || AllowUnsafeAgents()
+	if agenticMode {
+		supported, supportErr := claudeSupportsDangerousFlag(ctx, a.Command)
+		if supportErr != nil {
+			return nil, supportErr
+		}
+		if !supported {
+			return nil, fmt.Errorf(
+				"claude does not support %s; upgrade claude or disable allow_unsafe_agents",
+				claudeDangerousFlag,
+			)
+		}
+	}
+	includeEffort := a.claudeEffort() != "" &&
+		claudeSupportsEffortFlag(ctx, a.Command)
+	args := a.buildArgs(agenticMode, includeEffort)
+	args = append(args, "--json-schema", string(schema))
+
+	cmd := exec.CommandContext(ctx, a.Command, args...)
+	configureSubprocess(cmd)
+	cmd.Dir = repoPath
+	env, err := buildClaudeEnv(cmd.Environ(), model, baseURL)
+	if err != nil {
+		return nil, err
+	}
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader(prompt)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start claude: %w", err)
+	}
+	buf, readErr := io.ReadAll(stdout)
+	if readErr != nil {
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("read stdout: %w", readErr)
+	}
+	if out != nil {
+		_, _ = out.Write(buf)
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf(
+			"claude exited: %w (stderr: %s)",
+			err, strings.TrimSpace(stderr.String()),
+		)
+	}
+	return parseClaudeClassifyStream(bytes.NewReader(buf))
+}
+
 // Compile-time assertion that ClaudeAgent implements SchemaAgent.
-var _ SchemaAgent = (*ClaudeAgent)(nil)
+var (
+	_ SchemaAgent           = (*ClaudeAgent)(nil)
+	_ StructuredReviewAgent = (*ClaudeAgent)(nil)
+)

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -175,11 +176,22 @@ func (a *CodexAgent) buildArgs(
 	repoPath string,
 	agenticMode, autoApprove, sandboxBroken bool,
 ) []string {
+	return a.buildArgsWithSchema(
+		repoPath, agenticMode, autoApprove, sandboxBroken, "",
+	)
+}
+
+func (a *CodexAgent) buildArgsWithSchema(
+	repoPath string,
+	agenticMode, autoApprove, sandboxBroken bool,
+	schemaPath string,
+) []string {
 	return a.commandArgs(codexArgOptions{
 		repoPath:      repoPath,
 		agenticMode:   agenticMode,
 		autoApprove:   autoApprove,
 		sandboxBroken: sandboxBroken,
+		schemaPath:    schemaPath,
 	})
 }
 
@@ -189,11 +201,13 @@ type codexArgOptions struct {
 	autoApprove   bool
 	sandboxBroken bool
 	preview       bool
+	schemaPath    string
 }
 
 func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
+	sessionID := sanitizedResumeSessionID(a.SessionID)
 	args := []string{"exec"}
-	if a.SessionID != "" {
+	if sessionID != "" {
 		args = append(args, "resume")
 	}
 	args = append(args, "--json")
@@ -213,13 +227,13 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 			// --full-auto still uses bwrap internally, so we
 			// need the full bypass flag on broken systems.
 			args = append(args, codexDangerousFlag)
-		} else if a.SessionID != "" {
+		} else if sessionID != "" {
 			args = append(args, "-c", codexReadOnlySandboxConfig)
 		} else {
 			args = append(args, "--sandbox", "read-only")
 		}
 	}
-	if a.SessionID == "" && !opts.preview {
+	if sessionID == "" && !opts.preview {
 		args = append(args, "-C", opts.repoPath)
 	}
 	if a.Model != "" {
@@ -231,8 +245,11 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 	if effort := a.codexReasoningEffort(); effort != "" {
 		args = append(args, "-c", fmt.Sprintf(`model_reasoning_effort="%s"`, effort))
 	}
-	if a.SessionID != "" {
-		args = append(args, a.SessionID)
+	if opts.schemaPath != "" {
+		args = append(args, "--output-schema", opts.schemaPath)
+	}
+	if sessionID != "" {
+		args = append(args, sessionID)
 	}
 	if !opts.preview {
 		// "-" must come after all flags to read prompt from stdin
@@ -324,6 +341,14 @@ func codexSupportsIgnoreUserConfig(ctx context.Context, command string) (bool, e
 }
 
 func (a *CodexAgent) Review(ctx context.Context, repoPath, commitSHA, prompt string, output io.Writer) (string, error) {
+	return a.review(ctx, repoPath, commitSHA, prompt, "", output)
+}
+
+func (a *CodexAgent) review(
+	ctx context.Context,
+	repoPath, commitSHA, prompt, schemaPath string,
+	output io.Writer,
+) (string, error) {
 	// Use agentic mode if either per-job setting or global setting enables it
 	agenticMode := a.Agentic || AllowUnsafeAgents()
 	runAgent := a
@@ -369,7 +394,9 @@ func (a *CodexAgent) Review(ctx context.Context, repoPath, commitSHA, prompt str
 	if sandboxBroken && autoApprove {
 		log.Printf("codex: sandbox disabled via config, using %s", codexAutoApproveFlag)
 	}
-	args := runAgent.buildArgs(repoPath, agenticMode, autoApprove, sandboxBroken)
+	args := runAgent.buildArgsWithSchema(
+		repoPath, agenticMode, autoApprove, sandboxBroken, schemaPath,
+	)
 	stdoutDiagnostics := newCodexDiagnosticCapture()
 
 	runResult, runErr := runStreamingCLI(ctx, streamingCLISpec{
@@ -544,6 +571,40 @@ func codexNoJSONDiagnostics(runResult streamingCLIResult) string {
 	}
 	return detail.String()
 }
+
+func (a *CodexAgent) ReviewWithSchema(
+	ctx context.Context,
+	repoPath, gitRef, prompt string,
+	schema json.RawMessage,
+	out io.Writer,
+) (json.RawMessage, error) {
+	schemaFile, err := os.CreateTemp("", "roborev-codex-review-schema-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("create codex review schema: %w", err)
+	}
+	schemaPath := schemaFile.Name()
+	defer os.Remove(schemaPath)
+	if _, err := schemaFile.Write(schema); err != nil {
+		schemaFile.Close()
+		return nil, fmt.Errorf("write codex review schema: %w", err)
+	}
+	if err := schemaFile.Close(); err != nil {
+		return nil, fmt.Errorf("close codex review schema: %w", err)
+	}
+	result, err := a.review(
+		ctx, repoPath, gitRef, prompt, schemaPath, out,
+	)
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(result)
+	if !json.Valid([]byte(trimmed)) || !strings.HasPrefix(trimmed, "{") {
+		return nil, fmt.Errorf("codex structured review output is not a JSON object")
+	}
+	return json.RawMessage(trimmed), nil
+}
+
+var _ StructuredReviewAgent = (*CodexAgent)(nil)
 
 // codexEvent represents a top-level event in codex's --json JSONL output.
 type codexEvent struct {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -205,9 +205,8 @@ type codexArgOptions struct {
 }
 
 func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
-	sessionID := sanitizedResumeSessionID(a.SessionID)
 	args := []string{"exec"}
-	if sessionID != "" {
+	if a.SessionID != "" {
 		args = append(args, "resume")
 	}
 	args = append(args, "--json")
@@ -227,13 +226,13 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 			// --full-auto still uses bwrap internally, so we
 			// need the full bypass flag on broken systems.
 			args = append(args, codexDangerousFlag)
-		} else if sessionID != "" {
+		} else if a.SessionID != "" {
 			args = append(args, "-c", codexReadOnlySandboxConfig)
 		} else {
 			args = append(args, "--sandbox", "read-only")
 		}
 	}
-	if sessionID == "" && !opts.preview {
+	if a.SessionID == "" && !opts.preview {
 		args = append(args, "-C", opts.repoPath)
 	}
 	if a.Model != "" {
@@ -248,8 +247,8 @@ func (a *CodexAgent) commandArgs(opts codexArgOptions) []string {
 	if opts.schemaPath != "" {
 		args = append(args, "--output-schema", opts.schemaPath)
 	}
-	if sessionID != "" {
-		args = append(args, sessionID)
+	if a.SessionID != "" {
+		args = append(args, a.SessionID)
 	}
 	if !opts.preview {
 		// "-" must come after all flags to read prompt from stdin

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -544,6 +544,71 @@ func (a *GrokAgent) ClassifyWithSchema(
 	return parseGrokClassifyJSON(stdoutBuf.Bytes())
 }
 
+func (a *GrokAgent) ReviewWithSchema(
+	ctx context.Context,
+	repoPath, gitRef, prompt string,
+	schema json.RawMessage,
+	out io.Writer,
+) (json.RawMessage, error) {
+	tmpFile, err := os.CreateTemp("", "roborev-grok-review-*.md")
+	if err != nil {
+		return nil, fmt.Errorf("create temp structured review prompt: %w", err)
+	}
+	promptPath := tmpFile.Name()
+	defer os.Remove(promptPath)
+	if _, err := tmpFile.WriteString(prompt); err != nil {
+		tmpFile.Close()
+		return nil, fmt.Errorf("write structured review prompt: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("close structured review prompt: %w", err)
+	}
+
+	args := []string{
+		"--no-auto-update",
+		"--output-format", "json",
+		"--json-schema", string(schema),
+	}
+	if model := strings.TrimSpace(a.Model); model != "" {
+		args = append(args, "-m", model)
+	}
+	if effort := a.grokReasoningEffort(); effort != "" {
+		args = append(args, "--reasoning-effort", effort)
+	}
+	if sessionID := sanitizedResumeSessionID(a.SessionID); sessionID != "" {
+		args = append(args, "--resume", sessionID)
+	}
+	if a.Agentic || AllowUnsafeAgents() {
+		args = append(args, "--always-approve")
+	} else {
+		args = appendGrokReviewSafetyArgs(args)
+	}
+	args = append(args, "--prompt-file", promptPath)
+
+	cmd := exec.CommandContext(ctx, a.Command, args...)
+	cmd.Dir = repoPath
+	tracker := configureSubprocess(cmd)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if out != nil {
+		sw := newSyncWriter(out)
+		cmd.Stdout = io.MultiWriter(&stdoutBuf, sw)
+		cmd.Stderr = io.MultiWriter(&stderrBuf, sw)
+	} else {
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+	}
+	if err := cmd.Run(); err != nil {
+		if ctxErr := contextProcessError(ctx, tracker, err, nil); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf(
+			"grok structured review failed: %w\nstderr: %s",
+			err, strings.TrimSpace(stderrBuf.String()),
+		)
+	}
+	return parseGrokClassifyJSON(stdoutBuf.Bytes())
+}
+
 // grokJSONResult is the single-object --output-format json payload.
 // Grok emits camelCase structuredOutput / structuredOutputError (see
 // xai-grok-pager headless reducer attach_structured_output).
@@ -598,6 +663,8 @@ func parseGrokClassifyJSON(raw []byte) (json.RawMessage, error) {
 	}
 	return validateGrokClassifyJSON("structuredOutput", so)
 }
+
+var _ StructuredReviewAgent = (*GrokAgent)(nil)
 
 func validateGrokClassifyJSON(label string, raw json.RawMessage) (json.RawMessage, error) {
 	trimmed := bytes.TrimSpace(raw)

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -575,8 +575,8 @@ func (a *GrokAgent) ReviewWithSchema(
 	if effort := a.grokReasoningEffort(); effort != "" {
 		args = append(args, "--reasoning-effort", effort)
 	}
-	if sessionID := sanitizedResumeSessionID(a.SessionID); sessionID != "" {
-		args = append(args, "--resume", sessionID)
+	if a.SessionID != "" {
+		args = append(args, "--resume", a.SessionID)
 	}
 	if a.Agentic || AllowUnsafeAgents() {
 		args = append(args, "--always-approve")

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -243,6 +243,83 @@ func (a *PiAgent) ClassifyWithSchema(
 	return json.RawMessage(result), nil
 }
 
+func (a *PiAgent) ReviewWithSchema(
+	ctx context.Context,
+	repoPath, gitRef, prompt string,
+	schema json.RawMessage,
+	out io.Writer,
+) (json.RawMessage, error) {
+	tmpDir, err := os.MkdirTemp("", "roborev-pi-review-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp structured review dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	promptPath := filepath.Join(tmpDir, "prompt.md")
+	if err := os.WriteFile(promptPath, []byte(prompt), 0o600); err != nil {
+		return nil, fmt.Errorf("write structured review prompt: %w", err)
+	}
+	outputPath := filepath.Join(tmpDir, "result.json")
+	args := slices.Clone(a.LaunchArgs)
+	args = append(args,
+		"--no-session",
+		"--extension", a.jsonSchemaExtension(),
+		"--json-schema", string(schema),
+		"--json-output", outputPath,
+		"--json-fallback", "none",
+		"-p",
+	)
+	if a.Provider != "" {
+		args = append(args, "--provider", a.Provider)
+	}
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	if level := a.thinkingLevel(); level != "" {
+		args = append(args, "--thinking", level)
+	}
+	args = append(args,
+		"@"+promptPath,
+		"Review the repository according to the attached instructions and write the result with the structured JSON output tool.",
+	)
+
+	cmd := exec.CommandContext(ctx, a.Command, args...)
+	cmd.Dir = repoPath
+	tracker := configureSubprocess(cmd)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if out != nil {
+		sw := newSyncWriter(out)
+		cmd.Stdout = io.MultiWriter(&stdoutBuf, sw)
+		cmd.Stderr = io.MultiWriter(&stderrBuf, sw)
+	} else {
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+	}
+	if err := cmd.Run(); err != nil {
+		if ctxErr := contextProcessError(ctx, tracker, err, nil); ctxErr != nil {
+			return nil, ctxErr
+		}
+		stderr := strings.TrimSpace(stderrBuf.String())
+		if piMissingJSONSchemaExtension(stderr) {
+			return nil, fmt.Errorf(
+				"pi structured review failed: %w\nstderr: %s\n\nPi JSON Schema extension is required. Install it with: %s",
+				err, stderr, piJSONSchemaInstallCommand,
+			)
+		}
+		return nil, fmt.Errorf(
+			"pi structured review failed: %w\nstderr: %s", err, stderr,
+		)
+	}
+	result, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("read pi structured review output: %w", err)
+	}
+	result = bytes.TrimSpace(result)
+	if !json.Valid(result) || len(result) == 0 || result[0] != '{' {
+		return nil, fmt.Errorf("pi structured review output is not a JSON object")
+	}
+	return json.RawMessage(result), nil
+}
+
 func piMissingJSONSchemaExtension(stderr string) bool {
 	msg := strings.ToLower(stderr)
 	if !strings.Contains(msg, "unknown option") && !strings.Contains(msg, "unrecognized option") {
@@ -252,6 +329,8 @@ func piMissingJSONSchemaExtension(stderr string) bool {
 		strings.Contains(msg, "--json-output") ||
 		strings.Contains(msg, "--json-fallback")
 }
+
+var _ StructuredReviewAgent = (*PiAgent)(nil)
 
 func (a *PiAgent) Review(
 	ctx context.Context,

--- a/internal/agent/schema_agent.go
+++ b/internal/agent/schema_agent.go
@@ -47,6 +47,54 @@ func IsStructuredReviewAgent(a Agent) bool {
 	return ok
 }
 
+// ValidateStructuredReviewSelection rejects a resolved agent that cannot run
+// a schema-constrained custom review. Built-in review types use prose output
+// and accept every Agent implementation.
+func ValidateStructuredReviewSelection(reviewType string, a Agent) error {
+	if config.IsBuiltInReviewType(reviewType) || IsStructuredReviewAgent(a) {
+		return nil
+	}
+	return fmt.Errorf(
+		"agent %q does not support schema-constrained reviews", a.Name(),
+	)
+}
+
+// ValidateStructuredReviewBackup rejects a distinct configured backup that
+// cannot run a schema-constrained custom review. Availability is deliberately
+// not checked: workers resolve workflow backups again at failover time, so a
+// configured backup that is unavailable during enqueue may still be selected
+// later.
+func ValidateStructuredReviewBackup(
+	reviewType string,
+	resolution WorkflowConfig,
+	selectedAgent string,
+) error {
+	backupName := strings.TrimSpace(resolution.BackupAgent)
+	if config.IsBuiltInReviewType(reviewType) || backupName == "" ||
+		resolution.AgentMatches(selectedAgent, backupName) {
+		return nil
+	}
+
+	var backup Agent
+	var err error
+	if isConfiguredACPAgentNameFromConfig(
+		backupName, resolution.GlobalConfig, resolution.RepoConfig,
+	) {
+		backup, err = configuredACPAgentFromConfig(
+			backupName, resolution.RepoConfig, resolution.GlobalConfig,
+		)
+	} else {
+		backup, err = Get(backupName)
+	}
+	if err != nil {
+		return fmt.Errorf("resolve backup agent %q: %w", backupName, err)
+	}
+	if err := ValidateStructuredReviewSelection(reviewType, backup); err != nil {
+		return fmt.Errorf("invalid backup agent: %w", err)
+	}
+	return nil
+}
+
 // IsSchemaAgent reports whether a is a SchemaAgent.
 func IsSchemaAgent(a Agent) bool {
 	_, ok := a.(SchemaAgent)

--- a/internal/agent/schema_agent.go
+++ b/internal/agent/schema_agent.go
@@ -27,6 +27,26 @@ type SchemaAgent interface {
 	) (json.RawMessage, error)
 }
 
+// StructuredReviewAgent is an optional Agent capability for reviews whose
+// final result is constrained by a JSON Schema. Unlike SchemaAgent's
+// classification turn, this mode retains the normal read-only repository
+// tools needed to inspect code.
+type StructuredReviewAgent interface {
+	Agent
+
+	ReviewWithSchema(
+		ctx context.Context,
+		repoPath, gitRef, prompt string,
+		schema json.RawMessage,
+		out io.Writer,
+	) (json.RawMessage, error)
+}
+
+func IsStructuredReviewAgent(a Agent) bool {
+	_, ok := a.(StructuredReviewAgent)
+	return ok
+}
+
 // IsSchemaAgent reports whether a is a SchemaAgent.
 func IsSchemaAgent(a Agent) bool {
 	_, ok := a.(SchemaAgent)

--- a/internal/agent/schema_agent_test.go
+++ b/internal/agent/schema_agent_test.go
@@ -62,6 +62,37 @@ func TestIsSchemaAgent(t *testing.T) {
 	assert.True(t, IsSchemaAgent(s))
 }
 
+func TestValidateStructuredReviewSelection(t *testing.T) {
+	require.NoError(t, ValidateStructuredReviewSelection("default", NewTestAgent()))
+
+	err := ValidateStructuredReviewSelection("custom", NewTestAgent())
+	require.ErrorContains(t, err, "does not support schema-constrained reviews")
+
+	require.NoError(t, ValidateStructuredReviewSelection(
+		"custom", NewClaudeAgent("claude"),
+	))
+}
+
+func TestValidateStructuredReviewBackup(t *testing.T) {
+	resolution := WorkflowConfig{
+		RepoConfig:     &config.RepoConfig{},
+		GlobalConfig:   config.DefaultConfig(),
+		PreferredAgent: "claude-code",
+		BackupAgent:    "test",
+	}
+
+	err := ValidateStructuredReviewBackup("custom", resolution, "claude-code")
+	require.ErrorContains(t, err, "invalid backup agent")
+	require.ErrorContains(t, err, "does not support schema-constrained reviews")
+
+	require.NoError(t, ValidateStructuredReviewBackup(
+		"default", resolution, "claude-code",
+	))
+	require.NoError(t, ValidateStructuredReviewBackup(
+		"custom", resolution, "test",
+	))
+}
+
 func TestValidateClassifyAgent_NotRegistered(t *testing.T) {
 	err := ValidateClassifyAgent("no-such-agent")
 	require.Error(t, err)

--- a/internal/agenthook/state.go
+++ b/internal/agenthook/state.go
@@ -1328,6 +1328,19 @@ func currentGitScopeContext(parent context.Context, cwd string) (gitScope, bool)
 	if cwd == "" {
 		return gitScope{}, false
 	}
+	if metadata, err := roborevgit.ReadCheckoutMetadata(cwd); err == nil {
+		return gitScope{
+			WorktreeRoot: metadata.WorktreeRoot,
+			GitDir:       metadata.GitDir,
+			CommonDir:    metadata.CommonDir,
+			Head:         metadata.Head,
+			Branch:       metadata.Branch,
+		}, true
+	}
+	return currentGitScopeSubprocess(parent, cwd)
+}
+
+func currentGitScopeSubprocess(parent context.Context, cwd string) (gitScope, bool) {
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	out, err := agentHookGit.Output(ctx, cwd,

--- a/internal/agenthook/state_test.go
+++ b/internal/agenthook/state_test.go
@@ -1674,6 +1674,18 @@ func TestRecordPostToolUseDetachedFailedReviewDedupeScopesByDetachedHead(t *test
 	assert.Equal("failed_reviews", second.TriggeredBy)
 }
 
+func TestCurrentGitScopeDoesNotRequireGitExecutable(t *testing.T) {
+	repo := testutil.NewGitRepo(t)
+	head := repo.CommitFile("main.go", "package main\n", "initial")
+	t.Setenv("PATH", t.TempDir())
+
+	scope, ok := currentGitScopeContext(t.Context(), repo.Path())
+
+	require.True(t, ok)
+	assert.Equal(t, repo.Path(), scope.WorktreeRoot)
+	assert.Equal(t, head, scope.Head)
+}
+
 func TestRecordPostToolUseCountsCommitInOtherRepoViaDashC(t *testing.T) {
 	assert := assert.New(t)
 	outer := testutil.NewGitRepo(t)

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -482,9 +482,16 @@ type RepoCIConfig struct {
 	IncludeCosts *bool `toml:"include_costs" comment:"Override whether CI PR comments include token cost estimates."`
 }
 
-func validateCIReviewTypes(reviewTypes []string, reviews map[string][]string) error {
+func validateCIReviewTypes(
+	reviewTypes []string,
+	reviews map[string][]string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+) error {
 	if len(reviewTypes) > 0 {
-		if _, err := ValidateReviewTypes(reviewTypes); err != nil {
+		if _, err := ValidateReviewTypesFromConfig(
+			reviewTypes, repoCfg, globalCfg,
+		); err != nil {
 			return fmt.Errorf("ci.review_types: %w", err)
 		}
 	}
@@ -492,7 +499,9 @@ func validateCIReviewTypes(reviewTypes []string, reviews map[string][]string) er
 		if len(reviews[agentName]) == 0 {
 			continue
 		}
-		if _, err := ValidateReviewTypes(reviews[agentName]); err != nil {
+		if _, err := ValidateReviewTypesFromConfig(
+			reviews[agentName], repoCfg, globalCfg,
+		); err != nil {
 			return fmt.Errorf("ci.reviews.%s: %w", agentName, err)
 		}
 	}

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -568,6 +568,33 @@ func ResolveCIReasoning(
 	return resolveNormalized("thorough", NormalizeReasoning, explicit, repoVal)
 }
 
+// ResolveCIReviewReasoningForType determines the reasoning level for one CI
+// review. An explicit CLI value or repository [ci].reasoning applies to every
+// type. Otherwise a custom type may supply its own reasoning before CI falls
+// back to "thorough".
+func ResolveCIReviewReasoningForType(
+	explicit string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+	reviewType string,
+) (string, error) {
+	var repoVal string
+	if repoCfg != nil {
+		repoVal = repoCfg.CI.Reasoning
+	}
+	if strings.TrimSpace(explicit) != "" || strings.TrimSpace(repoVal) != "" {
+		return resolveNormalized(
+			"thorough", NormalizeReasoning, explicit, repoVal,
+		)
+	}
+	if resolved, ok := ResolveCustomReviewTypeFromConfig(
+		reviewType, repoCfg, globalCfg,
+	); ok && strings.TrimSpace(resolved.Spec.Reasoning) != "" {
+		return NormalizeReasoning(resolved.Spec.Reasoning)
+	}
+	return "thorough", nil
+}
+
 // ResolveCIMinSeverity determines the synthesis severity filter for CI review execution.
 // Priority: explicit > repo [ci].min_severity > global [ci].min_severity > "".
 func ResolveCIMinSeverity(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1471,6 +1471,36 @@ func LoadRepoConfigFromRefWithRaw(repoPath, ref string) (*RepoConfig, map[string
 	return &cfg, raw, nil
 }
 
+// RepoConfigSource keeps repository configuration paired with the location
+// used to load its relative files. An empty Ref means Config came from the
+// filesystem.
+type RepoConfigSource struct {
+	Config *RepoConfig
+	Raw    map[string]any
+	Ref    string
+}
+
+// LoadRepoConfigWithFallback loads repository configuration from ref, then
+// falls back to the filesystem only when the ref has no .roborev.toml. Parse
+// and Git errors retain ref so callers that continue with global settings read
+// their relative custom-review files from the same trusted revision.
+func LoadRepoConfigWithFallback(
+	repoPath, ref string,
+) (RepoConfigSource, error) {
+	ref = strings.TrimSpace(ref)
+	if ref != "" {
+		cfg, raw, err := LoadRepoConfigFromRefWithRaw(repoPath, ref)
+		if err != nil {
+			return RepoConfigSource{Ref: ref}, err
+		}
+		if cfg != nil {
+			return RepoConfigSource{Config: cfg, Raw: raw, Ref: ref}, nil
+		}
+	}
+	cfg, raw, err := LoadRepoConfigWithRaw(repoPath)
+	return RepoConfigSource{Config: cfg, Raw: raw}, err
+}
+
 // resolve returns the first non-zero value from the candidates, or defaultVal
 // if all candidates are zero. This encapsulates the standard precedence logic
 // (explicit > repo > global > default) used throughout config resolution.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -524,6 +524,16 @@ func validateConfig(cfg any, acp ACPAgentConfigs) error {
 	if err := validateACPAgentConfigs(acp); err != nil {
 		return err
 	}
+	var review ReviewConfig
+	switch typed := cfg.(type) {
+	case *Config:
+		review = typed.Review
+	case *RepoConfig:
+		review = typed.Review
+	}
+	if err := validateCustomReviewTypes(review.Types); err != nil {
+		return err
+	}
 	return validateAgentReferences(cfg)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -587,9 +587,6 @@ func (c *Config) Validate() (err error) {
 	if err := validateConfig(c, c.ACP); err != nil {
 		return err
 	}
-	if err := validateCIReviewTypes(c.CI.ReviewTypes, c.CI.Reviews); err != nil {
-		return err
-	}
 	reasoning := []namedConfigValue{
 		{key: "review_reasoning", value: c.ReviewReasoning},
 		{key: "refine_reasoning", value: c.RefineReasoning},
@@ -804,9 +801,6 @@ func (c *RepoConfig) Validate() (err error) {
 		err = markConfigValidationError(err)
 	}()
 	if err := validateConfig(c, c.ACP); err != nil {
-		return err
-	}
-	if err := validateCIReviewTypes(c.CI.ReviewTypes, c.CI.Reviews); err != nil {
 		return err
 	}
 	reasoning := []namedConfigValue{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3736,6 +3736,35 @@ func TestLoadRepoConfigFromRef(t *testing.T) {
 	})
 }
 
+func TestLoadRepoConfigWithFallback(t *testing.T) {
+	dir := t.TempDir()
+	execGit(t, dir, "init")
+	execGit(t, dir, "config", "user.email", "test@example.com")
+	execGit(t, dir, "config", "user.name", "Test")
+	writeTestFile(t, dir, "README.md", "test\n")
+	execGit(t, dir, "add", "README.md")
+	execGit(t, dir, "commit", "-m", "initial")
+	refWithoutConfig := execGit(t, dir, "rev-parse", "HEAD")
+
+	writeTestFile(t, dir, ".roborev.toml", `review_guidelines = "Filesystem"`+"\n")
+	source, err := LoadRepoConfigWithFallback(dir, refWithoutConfig)
+	require.NoError(t, err)
+	require.NotNil(t, source.Config)
+	assert.Equal(t, "Filesystem", source.Config.ReviewGuidelines)
+	assert.Empty(t, source.Ref)
+
+	writeTestFile(t, dir, ".roborev.toml", "invalid = [\n")
+	execGit(t, dir, "add", ".roborev.toml")
+	execGit(t, dir, "commit", "-m", "add invalid config")
+	invalidRef := execGit(t, dir, "rev-parse", "HEAD")
+
+	source, err = LoadRepoConfigWithFallback(dir, invalidRef)
+	require.Error(t, err)
+	assert.True(t, IsConfigParseError(err))
+	assert.Nil(t, source.Config)
+	assert.Equal(t, invalidRef, source.Ref)
+}
+
 func TestValidateReviewTypes(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/experiments.go
+++ b/internal/config/experiments.go
@@ -154,6 +154,20 @@ func ValidateEffectiveReviewConfig(global *Config, effective *RepoConfig) error 
 	if err := effective.Validate(); err != nil {
 		return err
 	}
+	if global != nil {
+		if err := validateCIReviewTypes(
+			global.CI.ReviewTypes, global.CI.Reviews, nil, global,
+		); err != nil {
+			return err
+		}
+	}
+	if effective != nil {
+		if err := validateCIReviewTypes(
+			effective.CI.ReviewTypes, effective.CI.Reviews, effective, global,
+		); err != nil {
+			return err
+		}
+	}
 	if _, err := ResolveReviewReasoningFromConfig("", effective, global); err != nil {
 		return fmt.Errorf("review_reasoning: %w", err)
 	}

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -118,7 +118,9 @@ func (rc ReviewConfig) Validate() error {
 	var errs []error
 	for _, name := range slices.Sorted(maps.Keys(rc.Subagents)) {
 		spec := rc.Subagents[name]
-		if _, err := canonicalMemberReviewType(spec.ReviewType); err != nil {
+		if _, err := canonicalMemberReviewType(
+			spec.ReviewType, &RepoConfig{Review: rc}, nil,
+		); err != nil {
 			errs = append(errs, fmt.Errorf("subagent %q: %w", name, err))
 		}
 		if _, err := NormalizeReasoning(spec.Reasoning); err != nil {

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -42,10 +42,11 @@ type PanelSpec struct {
 // named subagent and panel maps. Present on both Config (global) and
 // RepoConfig (per-repo); MergeReviewConfig combines them.
 type ReviewConfig struct {
-	DefaultPanel string                  `toml:"default_panel"`
-	HookPanel    string                  `toml:"hook_review_panel"`
-	Subagents    map[string]SubagentSpec `toml:"subagents"`
-	Panels       map[string]PanelSpec    `toml:"panels"`
+	DefaultPanel string                    `toml:"default_panel"`
+	HookPanel    string                    `toml:"hook_review_panel"`
+	Types        map[string]ReviewTypeSpec `toml:"types"`
+	Subagents    map[string]SubagentSpec   `toml:"subagents"`
+	Panels       map[string]PanelSpec      `toml:"panels"`
 }
 
 // MergeReviewConfig returns the effective review config: the subagent and
@@ -55,8 +56,15 @@ func MergeReviewConfig(repo, global ReviewConfig) ReviewConfig {
 	merged := ReviewConfig{
 		DefaultPanel: resolve("", repo.DefaultPanel, global.DefaultPanel),
 		HookPanel:    resolve("", repo.HookPanel, global.HookPanel),
+		Types:        make(map[string]ReviewTypeSpec, len(global.Types)+len(repo.Types)),
 		Subagents:    make(map[string]SubagentSpec, len(global.Subagents)+len(repo.Subagents)),
 		Panels:       make(map[string]PanelSpec, len(global.Panels)+len(repo.Panels)),
+	}
+	for name, spec := range global.Types {
+		merged.Types[name] = spec.Clone()
+	}
+	for name, spec := range repo.Types {
+		merged.Types[name] = spec.Clone()
 	}
 	maps.Copy(merged.Subagents, global.Subagents)
 	maps.Copy(merged.Subagents, repo.Subagents)
@@ -332,11 +340,15 @@ func resolveMemberFromConfig(
 	repoCfg *RepoConfig,
 	globalCfg *Config,
 ) (ResolvedMember, error) {
-	reviewType, err := canonicalMemberReviewType(spec.ReviewType)
+	reviewType, err := canonicalMemberReviewType(
+		spec.ReviewType, repoCfg, globalCfg,
+	)
 	if err != nil {
 		return ResolvedMember{}, fmt.Errorf("subagent %q: %w", name, err)
 	}
-	reasoning, err := ResolveReviewReasoningFromConfig(spec.Reasoning, repoCfg, globalCfg)
+	reasoning, err := ResolveReviewReasoningForTypeFromConfig(
+		spec.Reasoning, repoCfg, globalCfg, reviewType,
+	)
 	if err != nil {
 		return ResolvedMember{}, fmt.Errorf("subagent %q: %w", name, err)
 	}
@@ -560,11 +572,17 @@ func globalPanelModelForWorkflow(
 
 // canonicalMemberReviewType canonicalizes a subagent's review_type, treating
 // empty as "default".
-func canonicalMemberReviewType(reviewType string) (string, error) {
+func canonicalMemberReviewType(
+	reviewType string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+) (string, error) {
 	if reviewType == "" {
 		return ReviewTypeDefault, nil
 	}
-	canonical, err := ValidateReviewTypes([]string{reviewType})
+	canonical, err := ValidateReviewTypesFromConfig(
+		[]string{reviewType}, repoCfg, globalCfg,
+	)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/review_types.go
+++ b/internal/config/review_types.go
@@ -89,13 +89,11 @@ func isReservedCustomReviewTypeName(name string) bool {
 	)
 }
 
-// ResolvedReviewType identifies the effective custom definition and whether it
-// came from repository config. A repository definition replaces the complete
-// same-name global definition.
+// ResolvedReviewType identifies the effective custom definition. A repository
+// definition replaces the complete same-name global definition.
 type ResolvedReviewType struct {
-	Name        string
-	Spec        ReviewTypeSpec
-	RepoDefined bool
+	Name string
+	Spec ReviewTypeSpec
 }
 
 func ResolveCustomReviewTypeFromConfig(
@@ -106,9 +104,7 @@ func ResolveCustomReviewTypeFromConfig(
 	name = strings.TrimSpace(name)
 	if repoCfg != nil {
 		if spec, ok := repoCfg.Review.Types[name]; ok {
-			return ResolvedReviewType{
-				Name: name, Spec: spec.Clone(), RepoDefined: true,
-			}, true
+			return ResolvedReviewType{Name: name, Spec: spec.Clone()}, true
 		}
 	}
 	if globalCfg != nil {

--- a/internal/config/review_types.go
+++ b/internal/config/review_types.go
@@ -1,0 +1,184 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+const customReviewTypeNameMaxLength = 64
+
+var (
+	customReviewTypeNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	customIncludeNamePattern    = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
+)
+
+// ReviewTypeSpec defines a schema-constrained custom review prompt. Template
+// and include paths are resolved when the prompt is built so one global type
+// may refer to files in each repository by relative path.
+type ReviewTypeSpec struct {
+	Template  string            `toml:"template" comment:"Go template containing the custom review rubric."`
+	Includes  map[string]string `toml:"includes" comment:"Named local files exposed to the template through .Includes."`
+	Agent     string            `toml:"agent" comment:"Structured-output agent override for this review type."`
+	Model     string            `toml:"model" comment:"Model override for this review type."`
+	Reasoning string            `toml:"reasoning" comment:"Reasoning level for this review type."`
+}
+
+func (s ReviewTypeSpec) Clone() ReviewTypeSpec {
+	cloned := s
+	cloned.Includes = maps.Clone(s.Includes)
+	return cloned
+}
+
+func (s ReviewTypeSpec) validate(name string) error {
+	var errs []error
+	if strings.TrimSpace(s.Template) == "" {
+		errs = append(errs, fmt.Errorf("review type %q has no template", name))
+	}
+	if reasoning := strings.TrimSpace(s.Reasoning); reasoning != "" {
+		if _, err := NormalizeReasoning(reasoning); err != nil {
+			errs = append(errs, fmt.Errorf("review type %q: %w", name, err))
+		}
+	}
+	for includeName, path := range s.Includes {
+		if !customIncludeNamePattern.MatchString(includeName) {
+			errs = append(errs, fmt.Errorf(
+				"review type %q include %q has an invalid name", name, includeName,
+			))
+		}
+		if strings.TrimSpace(path) == "" {
+			errs = append(errs, fmt.Errorf(
+				"review type %q include %q has no path", name, includeName,
+			))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func validateCustomReviewTypes(types map[string]ReviewTypeSpec) error {
+	var errs []error
+	for _, name := range slices.Sorted(maps.Keys(types)) {
+		switch {
+		case len(name) > customReviewTypeNameMaxLength:
+			errs = append(errs, fmt.Errorf(
+				"review type name %q exceeds %d characters",
+				name, customReviewTypeNameMaxLength,
+			))
+		case !customReviewTypeNamePattern.MatchString(name):
+			errs = append(errs, fmt.Errorf(
+				"review type name %q must match %s",
+				name, customReviewTypeNamePattern,
+			))
+		case IsBuiltInReviewType(name) || name == "general" || name == "review":
+			errs = append(errs, fmt.Errorf(
+				"review type name %q is reserved", name,
+			))
+		default:
+			errs = append(errs, types[name].validate(name))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// ResolvedReviewType identifies the effective custom definition and whether it
+// came from repository config. A repository definition replaces the complete
+// same-name global definition.
+type ResolvedReviewType struct {
+	Name        string
+	Spec        ReviewTypeSpec
+	RepoDefined bool
+}
+
+func ResolveCustomReviewTypeFromConfig(
+	name string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+) (ResolvedReviewType, bool) {
+	name = strings.TrimSpace(name)
+	if repoCfg != nil {
+		if spec, ok := repoCfg.Review.Types[name]; ok {
+			return ResolvedReviewType{
+				Name: name, Spec: spec.Clone(), RepoDefined: true,
+			}, true
+		}
+	}
+	if globalCfg != nil {
+		if spec, ok := globalCfg.Review.Types[name]; ok {
+			return ResolvedReviewType{Name: name, Spec: spec.Clone()}, true
+		}
+	}
+	return ResolvedReviewType{}, false
+}
+
+func CustomReviewTypeNamesFromConfig(
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+) []string {
+	names := make(map[string]struct{})
+	if globalCfg != nil {
+		for name := range globalCfg.Review.Types {
+			names[name] = struct{}{}
+		}
+	}
+	if repoCfg != nil {
+		for name := range repoCfg.Review.Types {
+			names[name] = struct{}{}
+		}
+	}
+	return slices.Sorted(maps.Keys(names))
+}
+
+func ReviewTypesFromConfig(
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+) []string {
+	types := ExplicitReviewTypes()
+	return append(types, CustomReviewTypeNamesFromConfig(repoCfg, globalCfg)...)
+}
+
+func ValidateReviewTypesFromConfig(
+	types []string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+) ([]string, error) {
+	custom := make(map[string]bool)
+	for _, name := range CustomReviewTypeNamesFromConfig(repoCfg, globalCfg) {
+		custom[name] = true
+	}
+	return validateReviewTypes(types, custom)
+}
+
+func ResolveReviewReasoningForTypeFromConfig(
+	explicit string,
+	repoCfg *RepoConfig,
+	globalCfg *Config,
+	reviewType string,
+) (string, error) {
+	if strings.TrimSpace(explicit) != "" {
+		return ResolveReviewReasoningFromConfig(explicit, repoCfg, globalCfg)
+	}
+	if resolved, ok := ResolveCustomReviewTypeFromConfig(
+		reviewType, repoCfg, globalCfg,
+	); ok && strings.TrimSpace(resolved.Spec.Reasoning) != "" {
+		return NormalizeReasoning(resolved.Spec.Reasoning)
+	}
+	return ResolveReviewReasoningFromConfig("", repoCfg, globalCfg)
+}
+
+func customReviewTypeField(
+	types map[string]ReviewTypeSpec,
+	name string,
+	isAgent bool,
+) string {
+	spec, ok := types[name]
+	if !ok {
+		return ""
+	}
+	if isAgent {
+		return strings.TrimSpace(spec.Agent)
+	}
+	return strings.TrimSpace(spec.Model)
+}

--- a/internal/config/review_types.go
+++ b/internal/config/review_types.go
@@ -72,7 +72,7 @@ func validateCustomReviewTypes(types map[string]ReviewTypeSpec) error {
 				"review type name %q must match %s",
 				name, customReviewTypeNamePattern,
 			))
-		case IsBuiltInReviewType(name) || name == "general" || name == "review":
+		case isReservedCustomReviewTypeName(name):
 			errs = append(errs, fmt.Errorf(
 				"review type name %q is reserved", name,
 			))
@@ -81,6 +81,12 @@ func validateCustomReviewTypes(types map[string]ReviewTypeSpec) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func isReservedCustomReviewTypeName(name string) bool {
+	return IsBuiltInReviewType(name) || slices.Contains(
+		[]string{"general", "review", "fix", "refine", "classify"}, name,
+	)
 }
 
 // ResolvedReviewType identifies the effective custom definition and whether it

--- a/internal/config/review_types_test.go
+++ b/internal/config/review_types_test.go
@@ -85,3 +85,31 @@ func TestMergeReviewConfigRepoTypeReplacesGlobalType(t *testing.T) {
 	assert.Equal(t, "repo.tmpl", merged.Types["thermonuclear"].Template)
 	assert.Empty(t, merged.Types["thermonuclear"].Includes)
 }
+
+func TestResolveCIReviewReasoningForType(t *testing.T) {
+	repoCfg := &RepoConfig{Review: ReviewConfig{Types: map[string]ReviewTypeSpec{
+		"thermonuclear": {
+			Template:  "review.tmpl",
+			Reasoning: "maximum",
+		},
+	}}}
+
+	got, err := ResolveCIReviewReasoningForType(
+		"", repoCfg, nil, "thermonuclear",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "maximum", got)
+
+	repoCfg.CI.Reasoning = "standard"
+	got, err = ResolveCIReviewReasoningForType(
+		"", repoCfg, nil, "thermonuclear",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "standard", got)
+
+	got, err = ResolveCIReviewReasoningForType(
+		"fast", repoCfg, nil, "thermonuclear",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "fast", got)
+}

--- a/internal/config/review_types_test.go
+++ b/internal/config/review_types_test.go
@@ -40,6 +40,27 @@ func TestReviewTypeDefinitionsValidateNamesAndTemplates(t *testing.T) {
 			wantErr: "reserved",
 		},
 		{
+			name: "fix workflow reserved",
+			types: map[string]ReviewTypeSpec{
+				"fix": {Template: "review.tmpl"},
+			},
+			wantErr: "reserved",
+		},
+		{
+			name: "refine workflow reserved",
+			types: map[string]ReviewTypeSpec{
+				"refine": {Template: "review.tmpl"},
+			},
+			wantErr: "reserved",
+		},
+		{
+			name: "classify workflow reserved",
+			types: map[string]ReviewTypeSpec{
+				"classify": {Template: "review.tmpl"},
+			},
+			wantErr: "reserved",
+		},
+		{
 			name: "missing template",
 			types: map[string]ReviewTypeSpec{
 				"api-contract": {},

--- a/internal/config/review_types_test.go
+++ b/internal/config/review_types_test.go
@@ -20,6 +20,69 @@ func TestValidateReviewTypesFromConfig(t *testing.T) {
 	assert.Equal(t, []string{"default", "thermonuclear"}, got)
 }
 
+func TestConfigValidateAllowsGlobalCustomCIReviewTypes(t *testing.T) {
+	globalCfg := &Config{
+		Review: ReviewConfig{Types: map[string]ReviewTypeSpec{
+			"thermonuclear": {Template: "review.tmpl"},
+		}},
+		CI: CIConfig{
+			ReviewTypes: []string{"thermonuclear"},
+			Reviews: map[string][]string{
+				"codex": {"thermonuclear"},
+			},
+		},
+	}
+
+	require.NoError(t, globalCfg.Validate())
+}
+
+func TestEffectiveConfigAllowsRepoCIToUseGlobalCustomReviewType(t *testing.T) {
+	globalCfg := &Config{Review: ReviewConfig{Types: map[string]ReviewTypeSpec{
+		"thermonuclear": {Template: "review.tmpl"},
+	}}}
+	repoCfg := &RepoConfig{CI: RepoCIConfig{
+		ReviewTypes: []string{"thermonuclear"},
+		Reviews: map[string][]string{
+			"codex": {"thermonuclear"},
+		},
+	}}
+
+	require.NoError(t, repoCfg.Validate())
+	require.NoError(t, ValidateEffectiveReviewConfig(globalCfg, repoCfg))
+}
+
+func TestEffectiveConfigRejectsUnknownRepoCIReviewTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		ci      RepoCIConfig
+		wantErr string
+	}{
+		{
+			name:    "flat list",
+			ci:      RepoCIConfig{ReviewTypes: []string{"mystery"}},
+			wantErr: "ci.review_types",
+		},
+		{
+			name: "matrix",
+			ci: RepoCIConfig{Reviews: map[string][]string{
+				"codex": {"mystery"},
+			}},
+			wantErr: "ci.reviews.codex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoCfg := &RepoConfig{CI: tt.ci}
+
+			require.NoError(t, repoCfg.Validate())
+			err := ValidateEffectiveReviewConfig(nil, repoCfg)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestReviewTypeDefinitionsValidateNamesAndTemplates(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/review_types_test.go
+++ b/internal/config/review_types_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateReviewTypesFromConfig(t *testing.T) {
+	repoCfg := &RepoConfig{Review: ReviewConfig{Types: map[string]ReviewTypeSpec{
+		"thermonuclear": {Template: "review.tmpl"},
+	}}}
+
+	got, err := ValidateReviewTypesFromConfig(
+		[]string{"review", "thermonuclear", "thermonuclear"},
+		repoCfg, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"default", "thermonuclear"}, got)
+}
+
+func TestReviewTypeDefinitionsValidateNamesAndTemplates(t *testing.T) {
+	tests := []struct {
+		name    string
+		types   map[string]ReviewTypeSpec
+		wantErr string
+	}{
+		{
+			name: "valid",
+			types: map[string]ReviewTypeSpec{
+				"api-contract": {Template: "review.tmpl"},
+			},
+		},
+		{
+			name: "reserved",
+			types: map[string]ReviewTypeSpec{
+				"security": {Template: "review.tmpl"},
+			},
+			wantErr: "reserved",
+		},
+		{
+			name: "missing template",
+			types: map[string]ReviewTypeSpec{
+				"api-contract": {},
+			},
+			wantErr: "has no template",
+		},
+		{
+			name: "invalid include name",
+			types: map[string]ReviewTypeSpec{
+				"api-contract": {
+					Template: "review.tmpl",
+					Includes: map[string]string{"bad.key": "rubric.md"},
+				},
+			},
+			wantErr: "invalid name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCustomReviewTypes(tt.types)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestMergeReviewConfigRepoTypeReplacesGlobalType(t *testing.T) {
+	global := ReviewConfig{Types: map[string]ReviewTypeSpec{
+		"thermonuclear": {
+			Template: "global.tmpl",
+			Includes: map[string]string{"rubric": "global.md"},
+		},
+	}}
+	repo := ReviewConfig{Types: map[string]ReviewTypeSpec{
+		"thermonuclear": {Template: "repo.tmpl"},
+	}}
+
+	merged := MergeReviewConfig(repo, global)
+	assert.Equal(t, "repo.tmpl", merged.Types["thermonuclear"].Template)
+	assert.Empty(t, merged.Types["thermonuclear"].Includes)
+}

--- a/internal/config/review_types_test.go
+++ b/internal/config/review_types_test.go
@@ -224,10 +224,16 @@ func TestCustomReviewTypeWorkflowOverrides(t *testing.T) {
 	repoCfg.Review.Types["thermonuclear"] = ReviewTypeSpec{
 		Template: "repo.tmpl",
 	}
-	assert.False(t, HasWorkflowAgentOverrideFromConfig(
+	assert.True(t, HasWorkflowAgentOverrideFromConfig(
 		repoCfg, globalCfg, "thermonuclear", "thorough",
 	))
-	assert.Empty(t, ResolveWorkflowModelFromConfig(
+	assert.Equal(t, "global-model", ResolveWorkflowModelFromConfig(
 		repoCfg, globalCfg, "thermonuclear", "thorough",
+	))
+	assert.Equal(t, "global-agent", ResolveAgentForWorkflowFromConfig(
+		"", repoCfg, globalCfg, "thermonuclear", "thorough",
+	))
+	assert.Equal(t, "global-model", ResolveModelForWorkflowFromConfig(
+		"", repoCfg, globalCfg, "thermonuclear", "thorough",
 	))
 }

--- a/internal/config/review_types_test.go
+++ b/internal/config/review_types_test.go
@@ -113,3 +113,37 @@ func TestResolveCIReviewReasoningForType(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "fast", got)
 }
+
+func TestCustomReviewTypeWorkflowOverrides(t *testing.T) {
+	globalCfg := &Config{Review: ReviewConfig{Types: map[string]ReviewTypeSpec{
+		"thermonuclear": {
+			Template: "global.tmpl",
+			Agent:    "global-agent",
+			Model:    "global-model",
+		},
+	}}}
+	repoCfg := &RepoConfig{Review: ReviewConfig{Types: map[string]ReviewTypeSpec{
+		"thermonuclear": {
+			Template: "repo.tmpl",
+			Agent:    "repo-agent",
+			Model:    "repo-model",
+		},
+	}}}
+
+	assert.True(t, HasWorkflowAgentOverrideFromConfig(
+		repoCfg, globalCfg, "thermonuclear", "thorough",
+	))
+	assert.Equal(t, "repo-model", ResolveWorkflowModelFromConfig(
+		repoCfg, globalCfg, "thermonuclear", "thorough",
+	))
+
+	repoCfg.Review.Types["thermonuclear"] = ReviewTypeSpec{
+		Template: "repo.tmpl",
+	}
+	assert.False(t, HasWorkflowAgentOverrideFromConfig(
+		repoCfg, globalCfg, "thermonuclear", "thorough",
+	))
+	assert.Empty(t, ResolveWorkflowModelFromConfig(
+		repoCfg, globalCfg, "thermonuclear", "thorough",
+	))
+}

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -560,10 +560,10 @@ func HasWorkflowAgentOverrideFromConfig(
 			return true
 		}
 		if allowAnalyzeFallback {
-			if repoCustomDefined {
-				return customReviewTypeField(
-					repoCfg.Review.Types, workflow, true,
-				) != ""
+			if repoCustomDefined && customReviewTypeField(
+				repoCfg.Review.Types, workflow, true,
+			) != "" {
+				return true
 			}
 			if !customDefined && analyzeField(repoCfg.Analyze, workflow, true) != "" {
 				return true
@@ -656,9 +656,11 @@ func ResolveWorkflowModelFromConfig(
 		}
 		if allowAnalyzeFallback {
 			if repoCustomDefined {
-				return customReviewTypeField(
+				if s := customReviewTypeField(
 					repoCfg.Review.Types, workflow, false,
-				)
+				); s != "" {
+					return s
+				}
 			}
 			if !customDefined {
 				if s := analyzeField(repoCfg.Analyze, workflow, false); s != "" {
@@ -863,10 +865,8 @@ func getWorkflowValue(repo *RepoConfig, global *Config, workflow, level string, 
 			return s
 		}
 		if allowAnalyzeFallback {
-			if !repoCustomDefined {
-				if s := customReviewTypeField(global.Review.Types, workflow, isAgent); s != "" {
-					return s
-				}
+			if s := customReviewTypeField(global.Review.Types, workflow, isAgent); s != "" {
+				return s
 			}
 			if !customDefined {
 				if s := analyzeField(global.Analyze, workflow, isAgent); s != "" {

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -545,13 +545,29 @@ func HasWorkflowAgentOverrideFromConfig(
 		return value != ""
 	}
 	allowAnalyzeFallback := workflowAllowsAnalyzeFallback(workflow)
+	repoCustomDefined := false
+	globalCustomDefined := false
+	if repoCfg != nil {
+		_, repoCustomDefined = repoCfg.Review.Types[workflow]
+	}
+	if globalCfg != nil {
+		_, globalCustomDefined = globalCfg.Review.Types[workflow]
+	}
+	customDefined := repoCustomDefined || globalCustomDefined
 	if repoCfg != nil {
 		if repoWorkflowField(repoCfg, workflow, level, true) != "" ||
 			repoWorkflowField(repoCfg, workflow, "", true) != "" {
 			return true
 		}
-		if allowAnalyzeFallback && analyzeField(repoCfg.Analyze, workflow, true) != "" {
-			return true
+		if allowAnalyzeFallback {
+			if repoCustomDefined {
+				return customReviewTypeField(
+					repoCfg.Review.Types, workflow, true,
+				) != ""
+			}
+			if !customDefined && analyzeField(repoCfg.Analyze, workflow, true) != "" {
+				return true
+			}
 		}
 		if strings.TrimSpace(repoCfg.Agent) != "" {
 			return false
@@ -562,8 +578,15 @@ func HasWorkflowAgentOverrideFromConfig(
 			globalWorkflowField(globalCfg, workflow, "", true) != "" {
 			return true
 		}
-		if allowAnalyzeFallback && analyzeField(globalCfg.Analyze, workflow, true) != "" {
-			return true
+		if allowAnalyzeFallback {
+			if globalCustomDefined {
+				return customReviewTypeField(
+					globalCfg.Review.Types, workflow, true,
+				) != ""
+			}
+			if !customDefined && analyzeField(globalCfg.Analyze, workflow, true) != "" {
+				return true
+			}
 		}
 	}
 	return false
@@ -615,6 +638,15 @@ func ResolveWorkflowModelFromConfig(
 		return s
 	}
 	allowAnalyzeFallback := workflowAllowsAnalyzeFallback(workflow)
+	repoCustomDefined := false
+	globalCustomDefined := false
+	if repoCfg != nil {
+		_, repoCustomDefined = repoCfg.Review.Types[workflow]
+	}
+	if globalCfg != nil {
+		_, globalCustomDefined = globalCfg.Review.Types[workflow]
+	}
+	customDefined := repoCustomDefined || globalCustomDefined
 	if repoCfg != nil {
 		if s := repoWorkflowField(repoCfg, workflow, level, false); s != "" {
 			return s
@@ -623,8 +655,15 @@ func ResolveWorkflowModelFromConfig(
 			return s
 		}
 		if allowAnalyzeFallback {
-			if s := analyzeField(repoCfg.Analyze, workflow, false); s != "" {
-				return s
+			if repoCustomDefined {
+				return customReviewTypeField(
+					repoCfg.Review.Types, workflow, false,
+				)
+			}
+			if !customDefined {
+				if s := analyzeField(repoCfg.Analyze, workflow, false); s != "" {
+					return s
+				}
 			}
 		}
 	}
@@ -636,8 +675,15 @@ func ResolveWorkflowModelFromConfig(
 			return s
 		}
 		if allowAnalyzeFallback {
-			if s := analyzeField(globalCfg.Analyze, workflow, false); s != "" {
-				return s
+			if globalCustomDefined {
+				return customReviewTypeField(
+					globalCfg.Review.Types, workflow, false,
+				)
+			}
+			if !customDefined {
+				if s := analyzeField(globalCfg.Analyze, workflow, false); s != "" {
+					return s
+				}
 			}
 		}
 	}

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -5,6 +5,7 @@ package config
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -24,11 +25,23 @@ func IsDefaultReviewType(rt string) bool {
 		rt == "general" || rt == "review"
 }
 
+func IsBuiltInReviewType(rt string) bool {
+	return IsDefaultReviewType(rt) || rt == ReviewTypeSecurity ||
+		rt == ReviewTypeDesign || rt == ReviewTypeLookahead
+}
+
 // ValidateReviewTypes canonicalizes, validates, and deduplicates
 // a list of review type strings. Aliases ("general", "review")
 // are normalized to "default". Returns an error if any type is
 // empty or unrecognized.
 func ValidateReviewTypes(types []string) ([]string, error) {
+	return validateReviewTypes(types, nil)
+}
+
+func validateReviewTypes(
+	types []string,
+	custom map[string]bool,
+) ([]string, error) {
 	validSpecial := map[string]bool{
 		ReviewTypeSecurity:  true,
 		ReviewTypeDesign:    true,
@@ -44,10 +57,10 @@ func ValidateReviewTypes(types []string) ([]string, error) {
 		}
 		if IsDefaultReviewType(rt) {
 			rt = ReviewTypeDefault
-		} else if !validSpecial[rt] {
+		} else if !validSpecial[rt] && !custom[rt] {
 			return nil, fmt.Errorf(
 				"invalid review_type %q "+
-					"(valid: default, security, design, lookahead)", rt)
+					"(valid: %s)", rt, validReviewTypesHelp(custom))
 		}
 		if !seen[rt] {
 			seen[rt] = true
@@ -55,6 +68,20 @@ func ValidateReviewTypes(types []string) ([]string, error) {
 		}
 	}
 	return canonical, nil
+}
+
+func validReviewTypesHelp(custom map[string]bool) string {
+	types := []string{
+		ReviewTypeDefault, ReviewTypeSecurity,
+		ReviewTypeDesign, ReviewTypeLookahead,
+	}
+	customTypes := make([]string, 0, len(custom))
+	for name := range custom {
+		customTypes = append(customTypes, name)
+	}
+	slices.Sort(customTypes)
+	types = append(types, customTypes...)
+	return strings.Join(types, ", ")
 }
 
 func ExplicitReviewTypes() []string {
@@ -747,6 +774,15 @@ func lookupFieldByTag(v reflect.Value, key string) string {
 // never reconfigure native workflows such as security or design reviews.
 func getWorkflowValue(repo *RepoConfig, global *Config, workflow, level string, isAgent bool) string {
 	allowAnalyzeFallback := workflowAllowsAnalyzeFallback(workflow)
+	repoCustomDefined := false
+	globalCustomDefined := false
+	if repo != nil {
+		_, repoCustomDefined = repo.Review.Types[workflow]
+	}
+	if global != nil {
+		_, globalCustomDefined = global.Review.Types[workflow]
+	}
+	customDefined := repoCustomDefined || globalCustomDefined
 	// Repo layer: level-specific > workflow-specific > analyze override > generic
 	if repo != nil {
 		if s := repoWorkflowField(repo, workflow, level, isAgent); s != "" {
@@ -756,8 +792,13 @@ func getWorkflowValue(repo *RepoConfig, global *Config, workflow, level string, 
 			return s
 		}
 		if allowAnalyzeFallback {
-			if s := analyzeField(repo.Analyze, workflow, isAgent); s != "" {
+			if s := customReviewTypeField(repo.Review.Types, workflow, isAgent); s != "" {
 				return s
+			}
+			if !customDefined {
+				if s := analyzeField(repo.Analyze, workflow, isAgent); s != "" {
+					return s
+				}
 			}
 		}
 		if isAgent && strings.TrimSpace(repo.Agent) != "" {
@@ -776,8 +817,15 @@ func getWorkflowValue(repo *RepoConfig, global *Config, workflow, level string, 
 			return s
 		}
 		if allowAnalyzeFallback {
-			if s := analyzeField(global.Analyze, workflow, isAgent); s != "" {
-				return s
+			if !repoCustomDefined {
+				if s := customReviewTypeField(global.Review.Types, workflow, isAgent); s != "" {
+					return s
+				}
+			}
+			if !customDefined {
+				if s := analyzeField(global.Analyze, workflow, isAgent); s != "" {
+					return s
+				}
 			}
 		}
 		if isAgent && strings.TrimSpace(global.DefaultAgent) != "" {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -137,11 +137,7 @@ type CIPoller struct {
 	eventsStopping bool
 }
 
-type ciRepoConfigSource struct {
-	Config *config.RepoConfig
-	Raw    map[string]any
-	Ref    string
-}
+type ciRepoConfigSource = config.RepoConfigSource
 
 // NewCIPoller creates a new CI poller.
 // If GitHub App is configured, it initializes a token provider so gh commands
@@ -3069,22 +3065,9 @@ func loadCIRepoConfig(repoPath string) (ciRepoConfigSource, error) {
 	if err != nil {
 		// Can't determine default branch (no origin, bare repo, etc.)
 		// — fall back to filesystem.
-		cfg, raw, loadErr := config.LoadRepoConfigWithRaw(repoPath)
-		return ciRepoConfigSource{Config: cfg, Raw: raw}, loadErr
+		return config.LoadRepoConfigWithFallback(repoPath, "")
 	}
-
-	cfg, raw, err := config.LoadRepoConfigFromRefWithRaw(repoPath, defaultBranch)
-	if err != nil {
-		// Config exists but is invalid — surface the error, don't
-		// silently fall back to a stale working-tree copy.
-		return ciRepoConfigSource{}, err
-	}
-	if cfg != nil {
-		return ciRepoConfigSource{Config: cfg, Raw: raw, Ref: defaultBranch}, nil
-	}
-	// No .roborev.toml on the default branch — fall back to filesystem.
-	cfg, raw, err = config.LoadRepoConfigWithRaw(repoPath)
-	return ciRepoConfigSource{Config: cfg, Raw: raw}, err
+	return config.LoadRepoConfigWithFallback(repoPath, defaultBranch)
 }
 
 // resolveCISynthesisMinSeverity resolves synthesis severity from the already

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -841,13 +841,17 @@ func (p *CIPoller) resolveCIMatrixMembers(
 
 	members := make([]config.ResolvedMember, 0, len(matrix))
 	for i, entry := range matrix {
-		memberReasoning, err := config.ResolveCIReviewReasoningForType(
-			"", repoCfg, cfg, entry.ReviewType,
-		)
-		if err != nil {
-			return nil, config.SynthesisSpec{}, fmt.Errorf(
-				"resolve reasoning for type %q: %w", entry.ReviewType, err,
+		memberReasoning := reasoning
+		if repoCfg == nil || strings.TrimSpace(repoCfg.CI.Reasoning) == "" {
+			var err error
+			memberReasoning, err = config.ResolveCIReviewReasoningForType(
+				"", repoCfg, cfg, entry.ReviewType,
 			)
+			if err != nil {
+				return nil, config.SynthesisSpec{}, fmt.Errorf(
+					"resolve reasoning for type %q: %w", entry.ReviewType, err,
+				)
+			}
 		}
 		resolvedAgent, resolvedModel, backupAgent, backupModel, err := p.resolveMatrixMemberAgent(repo, repoCfg, cfg, entry, memberReasoning)
 		if err != nil {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -94,22 +94,22 @@ type CIPoller struct {
 
 	// Test seams for mocking side effects (gh/git/LLM) in unit tests.
 	// Nil means use the real implementation.
-	listOpenPRsFn           func(context.Context, string) ([]ghPR, error)
-	listTrustedActorsFn     func(context.Context, string) (map[string]struct{}, error)
-	listPRDiscussionFn      func(context.Context, string, int) ([]ghpkg.PRDiscussionComment, error)
-	gitFetchFn              func(context.Context, string, []string) error
-	gitFetchPRHeadFn        func(context.Context, string, int, []string) error
-	gitCloneFn              func(ctx context.Context, ghRepo, targetPath string, env []string) error
-	mergeBaseFn             func(string, string, string) (string, error)
-	loadRepoConfigWithRawFn func(string) (*config.RepoConfig, map[string]any, error)
-	buildReviewPromptFn     func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error)
-	postPRCommentFn         func(string, int, string) error
-	setCommitStatusFn       func(ghRepo, sha, state, description string) error
-	setSkippedCheckFn       func(ghRepo, sha, summary string) error
-	agentResolverFn         func(name string) (string, error)      // returns resolved agent name
-	jobCancelFn             func(jobID int64)                      // kills running worker process (optional)
-	isPROpenFn              func(ghRepo string, prNumber int) bool // checks if a PR is still open
-	prPostTargetFn          func(context.Context, string, int) (panelPostTarget, error)
+	listOpenPRsFn       func(context.Context, string) ([]ghPR, error)
+	listTrustedActorsFn func(context.Context, string) (map[string]struct{}, error)
+	listPRDiscussionFn  func(context.Context, string, int) ([]ghpkg.PRDiscussionComment, error)
+	gitFetchFn          func(context.Context, string, []string) error
+	gitFetchPRHeadFn    func(context.Context, string, int, []string) error
+	gitCloneFn          func(ctx context.Context, ghRepo, targetPath string, env []string) error
+	mergeBaseFn         func(string, string, string) (string, error)
+	loadRepoConfigFn    func(string) (ciRepoConfigSource, error)
+	buildReviewPromptFn func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error)
+	postPRCommentFn     func(string, int, string) error
+	setCommitStatusFn   func(ghRepo, sha, state, description string) error
+	setSkippedCheckFn   func(ghRepo, sha, summary string) error
+	agentResolverFn     func(name string) (string, error)      // returns resolved agent name
+	jobCancelFn         func(jobID int64)                      // kills running worker process (optional)
+	isPROpenFn          func(ghRepo string, prNumber int) bool // checks if a PR is still open
+	prPostTargetFn      func(context.Context, string, int) (panelPostTarget, error)
 
 	repoResolver *RepoResolver
 
@@ -137,6 +137,12 @@ type CIPoller struct {
 	eventsStopping bool
 }
 
+type ciRepoConfigSource struct {
+	Config *config.RepoConfig
+	Raw    map[string]any
+	Ref    string
+}
+
 // NewCIPoller creates a new CI poller.
 // If GitHub App is configured, it initializes a token provider so gh commands
 // authenticate as the app bot instead of the user's personal account.
@@ -155,7 +161,7 @@ func NewCIPoller(db *storage.DB, cfgGetter ConfigGetter, broadcaster Broadcaster
 	p.gitFetchFn = gitFetchCtx
 	p.gitFetchPRHeadFn = gitFetchPRHead
 	p.mergeBaseFn = gitpkg.GetMergeBase
-	p.loadRepoConfigWithRawFn = loadCIRepoConfigWithRaw
+	p.loadRepoConfigFn = loadCIRepoConfig
 	// CI prompts deliberately carry no kata context. PR-creator trust does
 	// not extend to whoever controls the reviewed head SHA (any write
 	// collaborator can push to a same-repo PR branch), and GitHub's polling
@@ -524,13 +530,15 @@ func (p *CIPoller) enqueuePanelRun(ctx context.Context, ghRepo string, pr ghPR, 
 	}
 
 	// Load repo config off the PR's default branch (never the working tree, F1).
-	repoCfg, rawRepoCfg, err := p.loadCIRepoConfigFor(repo.RootPath, ghRepo)
+	repoConfig, err := p.loadCIRepoConfigFor(repo.RootPath, ghRepo)
 	if err != nil {
 		if config.IsExperimentConfigError(err) || config.IsConfigValidationError(err) {
 			return &ciConfigurationError{err: err}
 		}
 		return err
 	}
+	repoCfg := repoConfig.Config
+	rawRepoCfg := repoConfig.Raw
 	selection, err := config.SelectReviewExperiment(config.ExperimentSelectionInput{
 		Workflow: config.ExperimentWorkflowCI,
 		Subject: config.ExperimentSubject{
@@ -576,8 +584,11 @@ func (p *CIPoller) enqueuePanelRun(ctx context.Context, ghRepo string, pr ghPR, 
 	memberOpts, synthOpts, err := p.buildPanelOpts(
 		ctx,
 		buildPanelOptsInput{
-			repo: repo, repoCfg: repoCfg, cfg: cfg, ghRepo: ghRepo, gitRef: gitRef,
-			branch:     pr.HeadRefName,
+			repo: repo, repoCfg: repoCfg, repoCfgRef: repoConfig.Ref,
+			cfg: cfg, ghRepo: ghRepo, gitRef: gitRef,
+			branch: pr.HeadRefName,
+			// Gate hooks on the PR base (target) branch: it is maintainer-
+			// controlled, unlike the fork-author-controlled head ref.
 			baseBranch: pr.BaseRefName,
 			prNumber:   pr.Number, panelName: ciPanelName(repoCfg, cfg),
 			prDiscussionContext: prDiscussionContext,
@@ -658,20 +669,20 @@ func matchingCISkipLabel(prLabels, skipLabels []string) (string, bool) {
 // parse error is non-fatal — CI review falls back to global/default settings so
 // a broken repo override does not disable PR review entirely — but experiment
 // validation and other load failures are returned.
-func (p *CIPoller) loadCIRepoConfigFor(repoPath, ghRepo string) (*config.RepoConfig, map[string]any, error) {
-	load := p.loadRepoConfigWithRawFn
-	if load == nil {
-		load = loadCIRepoConfigWithRaw
+func (p *CIPoller) loadCIRepoConfigFor(repoPath, ghRepo string) (ciRepoConfigSource, error) {
+	loadRepoConfig := p.loadRepoConfigFn
+	if loadRepoConfig == nil {
+		loadRepoConfig = loadCIRepoConfig
 	}
-	repoCfg, rawRepoCfg, err := load(repoPath)
+	repoConfig, err := loadRepoConfig(repoPath)
 	if err != nil {
 		if config.IsConfigValidationError(err) || !config.IsConfigParseError(err) {
-			return nil, nil, fmt.Errorf("load repo config: %w", err)
+			return ciRepoConfigSource{}, fmt.Errorf("load repo config: %w", err)
 		}
 		log.Printf("CI poller: warning: failed to load repo config for %s: %v", ghRepo, err)
-		return nil, nil, nil
+		return ciRepoConfigSource{}, nil
 	}
-	return repoCfg, rawRepoCfg, nil
+	return repoConfig, nil
 }
 
 // alreadyReviewedPR reports whether this PR HEAD already has an in-flight,
@@ -1256,6 +1267,7 @@ func (p *CIPoller) commitWarrantsDesign(
 type buildPanelOptsInput struct {
 	repo                *storage.Repo
 	repoCfg             *config.RepoConfig
+	repoCfgRef          string
 	cfg                 *config.Config
 	ghRepo              string
 	gitRef              string
@@ -1283,7 +1295,7 @@ func (p *CIPoller) buildPanelOpts(ctx context.Context, in buildPanelOptsInput) (
 		storedPrompt, err := p.callBuildReviewPrompt(
 			ctx, in.repo.RootPath, in.gitRef, in.repo.ID, in.cfg.ReviewContextCount,
 			m.Agent, m.ReviewType, reviewMinSeverity, in.prDiscussionContext,
-			in.repoCfg, "origin/"+in.baseBranch, in.cfg,
+			in.repoCfg, in.repoCfgRef, in.cfg,
 		)
 		if err != nil {
 			// A canceled poller (Stop or shutdown) must abort the whole run
@@ -3052,30 +3064,27 @@ func isPermanentGitHubAccessError(err error) bool {
 	}
 }
 
-func loadCIRepoConfig(repoPath string) (*config.RepoConfig, error) {
-	cfg, _, err := loadCIRepoConfigWithRaw(repoPath)
-	return cfg, err
-}
-
-func loadCIRepoConfigWithRaw(repoPath string) (*config.RepoConfig, map[string]any, error) {
+func loadCIRepoConfig(repoPath string) (ciRepoConfigSource, error) {
 	defaultBranch, err := gitpkg.GetDefaultBranch(repoPath)
 	if err != nil {
 		// Can't determine default branch (no origin, bare repo, etc.)
 		// — fall back to filesystem.
-		return config.LoadRepoConfigWithRaw(repoPath)
+		cfg, raw, loadErr := config.LoadRepoConfigWithRaw(repoPath)
+		return ciRepoConfigSource{Config: cfg, Raw: raw}, loadErr
 	}
 
 	cfg, raw, err := config.LoadRepoConfigFromRefWithRaw(repoPath, defaultBranch)
 	if err != nil {
 		// Config exists but is invalid — surface the error, don't
 		// silently fall back to a stale working-tree copy.
-		return nil, nil, err
+		return ciRepoConfigSource{}, err
 	}
 	if cfg != nil {
-		return cfg, raw, nil
+		return ciRepoConfigSource{Config: cfg, Raw: raw, Ref: defaultBranch}, nil
 	}
 	// No .roborev.toml on the default branch — fall back to filesystem.
-	return config.LoadRepoConfigWithRaw(repoPath)
+	cfg, raw, err = config.LoadRepoConfigWithRaw(repoPath)
+	return ciRepoConfigSource{Config: cfg, Raw: raw}, err
 }
 
 // resolveCISynthesisMinSeverity resolves synthesis severity from the already
@@ -3795,10 +3804,10 @@ func (p *CIPoller) postPRComment(ghRepo string, prNumber int, body string) error
 func (p *CIPoller) resolveUpsertComments(ghRepo string) bool {
 	repo, err := p.findLocalRepo(ghRepo)
 	if err == nil && repo != nil {
-		repoCfg, err := loadCIRepoConfig(repo.RootPath)
-		if err == nil && repoCfg != nil &&
-			repoCfg.CI.UpsertComments != nil {
-			return *repoCfg.CI.UpsertComments
+		repoConfig, err := loadCIRepoConfig(repo.RootPath)
+		if err == nil && repoConfig.Config != nil &&
+			repoConfig.Config.CI.UpsertComments != nil {
+			return *repoConfig.Config.CI.UpsertComments
 		}
 	}
 	return p.cfgGetter.Config().CI.UpsertComments
@@ -3811,7 +3820,7 @@ func (p *CIPoller) resolveIncludeCosts(ghRepo string) bool {
 	repo, err := p.findLocalRepo(ghRepo)
 	if err == nil && repo != nil {
 		if loaded, loadErr := loadCIRepoConfig(repo.RootPath); loadErr == nil {
-			repoCfg = loaded
+			repoCfg = loaded.Config
 		}
 	}
 	return config.ResolveCIIncludeCosts(repoCfg, p.cfgGetter.Config())

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -3491,17 +3491,25 @@ func toReviewResult(
 	if br.VerdictBool != nil {
 		verdict = storage.VerdictFromPassed(*br.VerdictBool != 0)
 	}
-	return reviewpkg.ReviewResult{
-		Agent:        br.Agent,
-		ReviewType:   br.ReviewType,
-		Output:       br.Output,
-		Verdict:      verdict,
-		Status:       br.Status,
-		Error:        br.Error,
-		Skipped:      br.Status == string(storage.JobStatusSkipped),
-		SkipReason:   br.SkipReason,
-		AllowFailure: member.AllowFailure,
+	result := reviewpkg.ReviewResult{
+		Agent:            br.Agent,
+		ReviewType:       br.ReviewType,
+		Output:           br.Output,
+		Verdict:          verdict,
+		StructuredOutput: append(json.RawMessage(nil), br.StructuredOutput...),
+		Status:           br.Status,
+		Error:            br.Error,
+		Skipped:          br.Status == string(storage.JobStatusSkipped),
+		SkipReason:       br.SkipReason,
+		AllowFailure:     member.AllowFailure,
 	}
+	if len(br.StructuredOutput) != 0 {
+		if structured, err := reviewpkg.DecodeStructuredReview(br.StructuredOutput); err == nil {
+			result.Structured = &structured
+			result.StructuredMinSeverity = br.MinSeverity
+		}
+	}
+	return result
 }
 
 func formatPanelPRComment(review *storage.Review, verdict string, members []storage.BatchReviewResult, includeCosts bool) string {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -929,22 +929,35 @@ func (p *CIPoller) resolveCIPanelMemberExecution(
 			return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
 		}
 		resolvedAgent = name
-	} else if !strictWorkflowAgent {
-		resolved, err := agent.GetAvailableWithConfigFromConfig(
-			repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
-		)
+	} else {
+		var selected agent.Agent
+		if !strictWorkflowAgent {
+			selected, err = agent.GetAvailableWithConfigFromConfig(
+				repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
+			)
+		} else {
+			selected, err = agent.GetPreferredOrBackupWithConfigFromConfig(
+				repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
+			)
+		}
 		if err != nil {
 			return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
 		}
-		resolvedAgent = resolved.Name()
-	} else if resolved, err := agent.GetPreferredOrBackupWithConfigFromConfig(
-		repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
-	); err != nil {
-		return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
-	} else {
-		resolvedAgent = resolved.Name()
+		if err := agent.ValidateStructuredReviewSelection(
+			member.ReviewType, selected,
+		); err != nil {
+			return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, member.ReviewType, err)
+		}
+		resolvedAgent = selected.Name()
 	}
 	resolvedAgent = agent.StorageNameFromConfig(resolvedAgent, repoCfg, cfg)
+	if err := agent.ValidateStructuredReviewBackup(
+		member.ReviewType, resolution, resolvedAgent,
+	); err != nil {
+		return "", "", "", "", fmt.Errorf(
+			"%w for type=%s: %w", errNoCIAgent, member.ReviewType, err,
+		)
+	}
 	model := member.Model
 	if !member.ModelExplicit || !resolution.AgentMatches(resolvedAgent, member.Agent) {
 		model = resolution.ModelForSelectedAgent(resolvedAgent, "")
@@ -994,22 +1007,35 @@ func (p *CIPoller) resolveMatrixMemberAgent(
 			return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
 		}
 		resolvedAgent = name
-	} else if autoDetectAgent {
-		resolved, err := agent.GetAvailableWithConfigFromConfig(
-			repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
-		)
+	} else {
+		var selected agent.Agent
+		if autoDetectAgent {
+			selected, err = agent.GetAvailableWithConfigFromConfig(
+				repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
+			)
+		} else {
+			selected, err = agent.GetPreferredOrBackupWithConfigFromConfig(
+				repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
+			)
+		}
 		if err != nil {
 			return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
 		}
-		resolvedAgent = resolved.Name()
-	} else if resolved, err := agent.GetPreferredOrBackupWithConfigFromConfig(
-		repoCfg, resolvedAgent, cfg, resolution.BackupAgent,
-	); err != nil {
-		return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
-	} else {
-		resolvedAgent = resolved.Name()
+		if err := agent.ValidateStructuredReviewSelection(
+			entry.ReviewType, selected,
+		); err != nil {
+			return "", "", "", "", fmt.Errorf("%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err)
+		}
+		resolvedAgent = selected.Name()
 	}
 	resolvedAgent = agent.StorageNameFromConfig(resolvedAgent, repoCfg, cfg)
+	if err := agent.ValidateStructuredReviewBackup(
+		entry.ReviewType, resolution, resolvedAgent,
+	); err != nil {
+		return "", "", "", "", fmt.Errorf(
+			"%w for type=%s: %w", errNoCIAgent, entry.ReviewType, err,
+		)
+	}
 	backupAgent, backupModel := backupExecutionForSelectedAgent(
 		resolution, resolvedAgent, repoCfg, cfg,
 	)

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -841,7 +841,15 @@ func (p *CIPoller) resolveCIMatrixMembers(
 
 	members := make([]config.ResolvedMember, 0, len(matrix))
 	for i, entry := range matrix {
-		resolvedAgent, resolvedModel, backupAgent, backupModel, err := p.resolveMatrixMemberAgent(repo, repoCfg, cfg, entry, reasoning)
+		memberReasoning, err := config.ResolveCIReviewReasoningForType(
+			"", repoCfg, cfg, entry.ReviewType,
+		)
+		if err != nil {
+			return nil, config.SynthesisSpec{}, fmt.Errorf(
+				"resolve reasoning for type %q: %w", entry.ReviewType, err,
+			)
+		}
+		resolvedAgent, resolvedModel, backupAgent, backupModel, err := p.resolveMatrixMemberAgent(repo, repoCfg, cfg, entry, memberReasoning)
 		if err != nil {
 			return nil, config.SynthesisSpec{}, err
 		}
@@ -851,7 +859,7 @@ func (p *CIPoller) resolveCIMatrixMembers(
 			Agent:       resolvedAgent,
 			Model:       resolvedModel,
 			ReviewType:  entry.ReviewType,
-			Reasoning:   reasoning,
+			Reasoning:   memberReasoning,
 			BackupAgent: backupAgent,
 			BackupModel: backupModel,
 		})

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -2398,7 +2398,9 @@ func (p *CIPoller) panelCommentBody(row *storage.CIPanel, members []storage.Batc
 		return appendPanelPRFooter(rev.Output, rev, members, includeCosts)
 	}
 	verdict := rev.Verdict()
-	return formatPanelPRCommentWithHead(rev, verdict, members, includeCosts, row.HeadSHA)
+	return formatPanelPRCommentWithHead(
+		rev, string(verdict), members, includeCosts, row.HeadSHA,
+	)
 }
 
 // handlePanelPostError resolves a failed comment post: a permanent GitHub access
@@ -3485,10 +3487,9 @@ func toReviewResult(
 	if br.PanelMemberConfigJSON != "" {
 		_ = json.Unmarshal([]byte(br.PanelMemberConfigJSON), &member)
 	}
-	var verdict *bool
+	verdict := storage.VerdictUnknown
 	if br.VerdictBool != nil {
-		passed := *br.VerdictBool != 0
-		verdict = &passed
+		verdict = storage.VerdictFromPassed(*br.VerdictBool != 0)
 	}
 	return reviewpkg.ReviewResult{
 		Agent:        br.Agent,

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -102,7 +102,7 @@ type CIPoller struct {
 	gitCloneFn              func(ctx context.Context, ghRepo, targetPath string, env []string) error
 	mergeBaseFn             func(string, string, string) (string, error)
 	loadRepoConfigWithRawFn func(string) (*config.RepoConfig, map[string]any, error)
-	buildReviewPromptFn     func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error)
+	buildReviewPromptFn     func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error)
 	postPRCommentFn         func(string, int, string) error
 	setCommitStatusFn       func(ghRepo, sha, state, description string) error
 	setSkippedCheckFn       func(ghRepo, sha, summary string) error
@@ -163,8 +163,11 @@ func NewCIPoller(db *storage.DB, cfgGetter ConfigGetter, broadcaster Broadcaster
 	// task-ledger content stays out of CI prompts entirely (it could
 	// otherwise surface in publicly posted PR comments). Kata context is a
 	// local-review feature; the worker also skips it for CI jobs.
-	p.buildReviewPromptFn = func(ctx context.Context, repoPath, gitRef string, repoID int64, contextCount int, agentName, reviewType, minSeverity, additionalContext string, cfg *config.Config) (string, error) {
-		builder := prompt.NewBuilderWithConfig(p.db, cfg).WithContext(ctx).ForRepo(repoPath, repoID)
+	p.buildReviewPromptFn = func(ctx context.Context, repoPath, gitRef string, repoID int64, contextCount int, agentName, reviewType, minSeverity, additionalContext string, repoCfg *config.RepoConfig, repoCfgRef string, cfg *config.Config) (string, error) {
+		builder := prompt.NewBuilderWithConfig(p.db, cfg).
+			WithContext(ctx).
+			ForRepo(repoPath, repoID).
+			WithRepoConfig(repoCfg, repoCfgRef)
 		return builder.BuildWithAdditionalContextAndDiffFile(
 			gitRef,
 			contextCount,
@@ -829,7 +832,7 @@ func (p *CIPoller) resolveCIMatrixMembers(
 	cfg *config.Config, ghRepo string,
 ) ([]config.ResolvedMember, config.SynthesisSpec, error) {
 	matrix, reasoning := resolveCIMatrix(repoCfg, rawRepoCfg, cfg, ghRepo)
-	if err := validateMatrixReviewTypes(matrix); err != nil {
+	if err := validateMatrixReviewTypes(matrix, repoCfg, cfg); err != nil {
 		return nil, config.SynthesisSpec{}, err
 	}
 	if len(matrix) == 0 {
@@ -1068,7 +1071,11 @@ func canonicalizeMatrix(matrix []config.AgentReviewType) []config.AgentReviewTyp
 
 // validateMatrixReviewTypes returns an error if the matrix names an invalid
 // review type, matching the pre-panel validation.
-func validateMatrixReviewTypes(matrix []config.AgentReviewType) error {
+func validateMatrixReviewTypes(
+	matrix []config.AgentReviewType,
+	repoCfg *config.RepoConfig,
+	globalCfg *config.Config,
+) error {
 	rtSet := make(map[string]bool, len(matrix))
 	for _, m := range matrix {
 		rtSet[m.ReviewType] = true
@@ -1077,7 +1084,9 @@ func validateMatrixReviewTypes(matrix []config.AgentReviewType) error {
 	for rt := range rtSet {
 		rtList = append(rtList, rt)
 	}
-	_, err := config.ValidateReviewTypes(rtList)
+	_, err := config.ValidateReviewTypesFromConfig(
+		rtList, repoCfg, globalCfg,
+	)
 	return err
 }
 
@@ -1261,7 +1270,8 @@ func (p *CIPoller) buildPanelOpts(ctx context.Context, in buildPanelOptsInput) (
 	for i, m := range in.members {
 		storedPrompt, err := p.callBuildReviewPrompt(
 			ctx, in.repo.RootPath, in.gitRef, in.repo.ID, in.cfg.ReviewContextCount,
-			m.Agent, m.ReviewType, reviewMinSeverity, in.prDiscussionContext, in.cfg,
+			m.Agent, m.ReviewType, reviewMinSeverity, in.prDiscussionContext,
+			in.repoCfg, "origin/"+in.baseBranch, in.cfg,
 		)
 		if err != nil {
 			// A canceled poller (Stop or shutdown) must abort the whole run
@@ -3136,11 +3146,14 @@ func (p *CIPoller) callMergeBase(repoPath, baseRef, headRef string) (string, err
 	return gitpkg.GetMergeBase(repoPath, baseRef, headRef)
 }
 
-func (p *CIPoller) callBuildReviewPrompt(ctx context.Context, repoPath, gitRef string, repoID int64, contextCount int, agentName, reviewType, minSeverity, additionalContext string, cfg *config.Config) (string, error) {
+func (p *CIPoller) callBuildReviewPrompt(ctx context.Context, repoPath, gitRef string, repoID int64, contextCount int, agentName, reviewType, minSeverity, additionalContext string, repoCfg *config.RepoConfig, repoCfgRef string, cfg *config.Config) (string, error) {
 	if p.buildReviewPromptFn != nil {
-		return p.buildReviewPromptFn(ctx, repoPath, gitRef, repoID, contextCount, agentName, reviewType, minSeverity, additionalContext, cfg)
+		return p.buildReviewPromptFn(ctx, repoPath, gitRef, repoID, contextCount, agentName, reviewType, minSeverity, additionalContext, repoCfg, repoCfgRef, cfg)
 	}
-	builder := prompt.NewBuilderWithConfig(p.db, cfg).WithContext(ctx).ForRepo(repoPath, repoID)
+	builder := prompt.NewBuilderWithConfig(p.db, cfg).
+		WithContext(ctx).
+		ForRepo(repoPath, repoID).
+		WithRepoConfig(repoCfg, repoCfgRef)
 	return builder.BuildWithAdditionalContextAndDiffFile(
 		gitRef,
 		contextCount,

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -3488,10 +3488,16 @@ func toReviewResult(
 	if br.PanelMemberConfigJSON != "" {
 		_ = json.Unmarshal([]byte(br.PanelMemberConfigJSON), &member)
 	}
+	var verdict *bool
+	if br.VerdictBool != nil {
+		passed := *br.VerdictBool != 0
+		verdict = &passed
+	}
 	return reviewpkg.ReviewResult{
 		Agent:        br.Agent,
 		ReviewType:   br.ReviewType,
 		Output:       br.Output,
+		Verdict:      verdict,
 		Status:       br.Status,
 		Error:        br.Error,
 		Skipped:      br.Status == string(storage.JobStatusSkipped),

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -2397,10 +2397,7 @@ func (p *CIPoller) panelCommentBody(row *storage.CIPanel, members []storage.Batc
 	if strings.HasPrefix(strings.TrimSpace(rev.Output), "## roborev:") {
 		return appendPanelPRFooter(rev.Output, rev, members, includeCosts)
 	}
-	verdict := storage.ParseVerdict(rev.Output)
-	if rev.Job != nil && rev.Job.Verdict != nil {
-		verdict = *rev.Job.Verdict
-	}
+	verdict := rev.Verdict()
 	return formatPanelPRCommentWithHead(rev, verdict, members, includeCosts, row.HeadSHA)
 }
 

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -3240,6 +3240,33 @@ func TestResolveCIMatrixMembersUsesCustomTypeReasoning(t *testing.T) {
 	assert.Equal(t, "maximum", members[0].Reasoning)
 }
 
+func TestResolveCIMatrixMembersInvalidCIReasoningUsesFallback(t *testing.T) {
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	h.Poller.agentResolverFn = func(name string) (string, error) {
+		return name, nil
+	}
+	repoCfg := &config.RepoConfig{
+		Review: config.ReviewConfig{Types: map[string]config.ReviewTypeSpec{
+			"thermonuclear": {
+				Template:  "review.tmpl",
+				Reasoning: "maximum",
+			},
+		}},
+		CI: config.RepoCIConfig{
+			Agents:      []string{"codex"},
+			ReviewTypes: []string{"thermonuclear"},
+			Reasoning:   "invalid",
+		},
+	}
+
+	members, _, err := h.Poller.resolveCIMatrixMembers(
+		h.Repo, repoCfg, h.Cfg, "acme/api",
+	)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "thorough", members[0].Reasoning)
+}
+
 func TestResolveMatrixMemberAgentBlankAgentAutoDetectsAvailableAgent(t *testing.T) {
 	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
 	t.Setenv("PATH", "")

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2438,8 +2438,8 @@ func TestCIPollerProcessPR_RepoConfigLoadFailureDoesNotSetConfigurationStatus(t 
 	h.stubProcessPRGit()
 	statuses := h.CaptureCommitStatuses()
 	h.Poller.mergeBaseFn = func(_, _, _ string) (string, error) { return "base-sha", nil }
-	h.Poller.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
-		return nil, nil, errors.New("read .roborev.toml at origin/main: git show failed")
+	h.Poller.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+		return ciRepoConfigSource{}, errors.New("read .roborev.toml at origin/main: git show failed")
 	}
 
 	err := h.Poller.processPR(context.Background(), "acme/api", ghPR{
@@ -2631,14 +2631,15 @@ func TestLoadCIRepoConfig_LoadsFromDefaultBranch(t *testing.T) {
 	runGit("commit", "-m", "add config")
 	runGit("fetch", "origin")
 
-	cfg, err := loadCIRepoConfig(dir)
+	repoConfig, err := loadCIRepoConfig(dir)
 	if err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "loadCIRepoConfig: %v", err)
 	}
-	require.NotNil(t, cfg, "expected non-nil config")
-	assert.Equal(t, []string{"claude"}, cfg.CI.Agents, "agents")
+	require.NotNil(t, repoConfig.Config, "expected non-nil config")
+	assert.Equal(t, []string{"claude"}, repoConfig.Config.CI.Agents, "agents")
+	assert.Equal(t, "origin/main", repoConfig.Ref)
 }
 
 func TestLoadCIRepoConfig_FallsBackWhenNoConfigOnDefaultBranch(t *testing.T) {
@@ -2652,14 +2653,15 @@ func TestLoadCIRepoConfig_FallsBackWhenNoConfigOnDefaultBranch(t *testing.T) {
 		}, "write .roborev.toml: %v", err)
 	}
 
-	cfg, err := loadCIRepoConfig(dir)
+	repoConfig, err := loadCIRepoConfig(dir)
 	if err != nil {
 		require.Condition(t, func() bool {
 			return false
 		}, "loadCIRepoConfig: %v", err)
 	}
-	require.NotNil(t, cfg, "expected filesystem fallback config")
-	assert.Equal(t, []string{"codex"}, cfg.CI.Agents, "agents from filesystem fallback")
+	require.NotNil(t, repoConfig.Config, "expected filesystem fallback config")
+	assert.Equal(t, []string{"codex"}, repoConfig.Config.CI.Agents, "agents from filesystem fallback")
+	assert.Empty(t, repoConfig.Ref)
 }
 
 func TestLoadCIRepoConfig_PropagatesParseError(t *testing.T) {
@@ -2684,11 +2686,11 @@ func TestLoadCIRepoConfig_PropagatesParseError(t *testing.T) {
 		}, "write .roborev.toml: %v", err)
 	}
 
-	cfg, err := loadCIRepoConfig(dir)
+	repoConfig, err := loadCIRepoConfig(dir)
 	if err == nil {
 		require.Condition(t, func() bool {
 			return false
-		}, "expected parse error, got cfg=%+v", cfg)
+		}, "expected parse error, got cfg=%+v", repoConfig.Config)
 	}
 	if !config.IsConfigParseError(err) {
 		assert.Condition(t, func() bool {
@@ -3766,8 +3768,8 @@ func TestCIPollerProcessPR_RepoExperimentValidationFailureSetsConfigurationStatu
 		},
 	}, nil, nil)
 	require.Error(t, validationErr)
-	h.Poller.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
-		return nil, nil, validationErr
+	h.Poller.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+		return ciRepoConfigSource{}, validationErr
 	}
 	statuses := h.CaptureCommitStatuses()
 
@@ -3884,11 +3886,11 @@ func designMemberCount(members []storage.ReviewJob) int {
 func TestProcessPRCreatesPanelRun(t *testing.T) {
 	assert := assert.New(t)
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		enabled := true
 		rc := &config.RepoConfig{}
 		rc.AutoDesignReview.Enabled = &enabled
-		return rc, nil, nil
+		return ciRepoConfigSource{Config: rc}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -3932,11 +3934,11 @@ func TestProcessPRAutoDesignUsesConfiguredBackupModel(t *testing.T) {
 	cfg.DesignAgent = primaryAgent
 	cfg.DesignBackupAgent = "test"
 	cfg.DesignBackupModel = "design-backup-model"
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		enabled := true
 		rc := &config.RepoConfig{}
 		rc.AutoDesignReview.Enabled = &enabled
-		return rc, nil, nil
+		return ciRepoConfigSource{Config: rc}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -3975,11 +3977,11 @@ func TestProcessPRAutoDesignPersistsNamedACPBackupSnapshot(t *testing.T) {
 	cfg.ACP = config.ACPAgentConfigs{
 		"goose": {Command: "goose-design-backup-acp"},
 	}
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		enabled := true
 		rc := &config.RepoConfig{}
 		rc.AutoDesignReview.Enabled = &enabled
-		return rc, nil, nil
+		return ciRepoConfigSource{Config: rc}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4016,11 +4018,11 @@ func TestProcessPRAutoDesignUsesCIModelOverride(t *testing.T) {
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
 	cfg.CI.Model = "ci-model-override"
 	cfg.DesignAgent = "test"
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		enabled := true
 		rc := &config.RepoConfig{}
 		rc.AutoDesignReview.Enabled = &enabled
-		return rc, nil, nil
+		return ciRepoConfigSource{Config: rc}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4116,8 +4118,8 @@ func TestProcessPRSynthesisAndMembersUseSeparateMinSeverity(t *testing.T) {
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
 	cfg.CI.MinSeverity = "high"
 	cfg.ReviewMinSeverity = "medium"
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
-		return &config.RepoConfig{}, nil, nil
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+		return ciRepoConfigSource{Config: &config.RepoConfig{}}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4149,9 +4151,9 @@ func TestProcessPRSynthesisAndMembersUseSeparateMinSeverity(t *testing.T) {
 func TestProcessPRMemberMinSeverityInvalidRepoReportsConfigurationError(t *testing.T) {
 	p, _, _, repo, cfg := newCIPanelGitHarness(t)
 	cfg.ReviewMinSeverity = "medium"
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		repoCfg := &config.RepoConfig{ReviewMinSeverity: "not-a-severity"}
-		return repoCfg, nil, repoCfg.Validate()
+		return ciRepoConfigSource{Config: repoCfg}, repoCfg.Validate()
 	}
 	var statuses []capturedStatus
 	p.setCommitStatusFn = func(repo, sha, state, desc string) error {
@@ -4187,8 +4189,8 @@ func TestProcessPRNamedPanelMembers(t *testing.T) {
 			"ci": {Members: []string{"sec", "rev"}, SynthesisAgent: "test"},
 		},
 	}
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
-		return &config.RepoConfig{}, nil, nil
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+		return ciRepoConfigSource{Config: &config.RepoConfig{}}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4228,8 +4230,8 @@ func TestProcessPRNamedPanelACPMemberReplacesInheritedWorkflowModel(t *testing.T
 			"ci": {Members: []string{"rev"}, SynthesisAgent: "test"},
 		},
 	}
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
-		return &config.RepoConfig{}, nil, nil
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+		return ciRepoConfigSource{Config: &config.RepoConfig{}}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4273,8 +4275,8 @@ func TestProcessPRNamedPanelMemberUsesBackupModelWhenPreferredUnavailable(t *tes
 			"ci": {Members: []string{"rev"}, SynthesisAgent: "test"},
 		},
 	}
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
-		return &config.RepoConfig{}, nil, nil
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+		return ciRepoConfigSource{Config: &config.RepoConfig{}}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4320,8 +4322,8 @@ func TestProcessPRNamedPanelOmittedAgentAutoDetectsAvailableAgent(t *testing.T) 
 			"ci": {Members: []string{"rev"}, SynthesisAgent: "test"},
 		},
 	}
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
-		return &config.RepoConfig{}, nil, nil
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+		return ciRepoConfigSource{Config: &config.RepoConfig{}}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4347,11 +4349,11 @@ func TestProcessPRNamedPanelOmittedAgentAutoDetectsAvailableAgent(t *testing.T) 
 // warrants one (a trivial doc/test change that the heuristics skip).
 func TestProcessPRAutoDesignAppendsNoneWhenNotWarranted(t *testing.T) {
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		enabled := true
 		rc := &config.RepoConfig{}
 		rc.AutoDesignReview.Enabled = &enabled
-		return rc, nil, nil
+		return ciRepoConfigSource{Config: rc}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4378,11 +4380,11 @@ func TestProcessPRAutoDesignAppendsNoneWhenNotWarranted(t *testing.T) {
 // design member rather than dropping it.
 func TestProcessPRAutoDesignFailsOpenOnAmbiguous(t *testing.T) {
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		enabled := true
 		rc := &config.RepoConfig{}
 		rc.AutoDesignReview.Enabled = &enabled
-		return rc, nil, nil
+		return ciRepoConfigSource{Config: rc}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4420,11 +4422,11 @@ func TestProcessPRAutoDesignFailsOpenOnAmbiguous(t *testing.T) {
 func TestProcessPRAutoDesignMultiCommitEarlierWarrants(t *testing.T) {
 	assert := assert.New(t)
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
-	p.loadRepoConfigWithRawFn = func(string) (*config.RepoConfig, map[string]any, error) {
+	p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
 		enabled := true
 		rc := &config.RepoConfig{}
 		rc.AutoDesignReview.Enabled = &enabled
-		return rc, nil, nil
+		return ciRepoConfigSource{Config: rc}, nil
 	}
 
 	base := repo.HeadSHA()
@@ -4832,12 +4834,15 @@ func TestReconcileStuckAttempt(t *testing.T) {
 
 func TestBuildPanelOpts_RecordsPRBranchOnJobs(t *testing.T) {
 	p := &CIPoller{}
-	p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error) {
+	var promptConfigRef string
+	p.buildReviewPromptFn = func(_ context.Context, _, _ string, _ int64, _ int, _, _, _, _ string, _ *config.RepoConfig, configRef string, _ *config.Config) (string, error) {
+		promptConfigRef = configRef
 		return "prebuilt prompt", nil
 	}
 
 	memberOpts, synthOpts, panelErr := p.buildPanelOpts(context.Background(), buildPanelOptsInput{
 		repo:       &storage.Repo{ID: 1, RootPath: t.TempDir()},
+		repoCfgRef: "origin/main",
 		cfg:        config.DefaultConfig(),
 		ghRepo:     "kenn-io/roborev",
 		gitRef:     "base..head",
@@ -4851,6 +4856,8 @@ func TestBuildPanelOpts_RecordsPRBranchOnJobs(t *testing.T) {
 
 	require.Len(t, memberOpts, 1)
 	assert.Equal(t, storage.JobSourceCI, memberOpts[0].Source)
+	assert.Equal(t, "origin/main", promptConfigRef,
+		"prompt files must use the same ref that supplied repository config")
 	assert.Equal(t, "release/2.0", memberOpts[0].CIBaseBranch,
 		"CI member jobs must record the PR base (target) branch so branch-filtered hooks fire")
 	assert.Equal(t, "feature/review", memberOpts[0].Branch)

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2697,6 +2697,8 @@ func TestLoadCIRepoConfig_PropagatesParseError(t *testing.T) {
 			return false
 		}, "expected ConfigParseError, got: %v", err)
 	}
+	assert.Nil(t, repoConfig.Config)
+	assert.Equal(t, "origin/main", repoConfig.Ref)
 }
 
 func TestCIPollerProcessPR_SetsPendingCommitStatus(t *testing.T) {
@@ -3235,7 +3237,7 @@ func TestResolveCIMatrixMembersUsesCustomTypeReasoning(t *testing.T) {
 	}
 
 	members, _, err := h.Poller.resolveCIMatrixMembers(
-		h.Repo, repoCfg, h.Cfg, "acme/api",
+		h.Repo, repoCfg, nil, h.Cfg, "acme/api",
 	)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
@@ -3262,7 +3264,7 @@ func TestResolveCIMatrixMembersInvalidCIReasoningUsesFallback(t *testing.T) {
 	}
 
 	members, _, err := h.Poller.resolveCIMatrixMembers(
-		h.Repo, repoCfg, h.Cfg, "acme/api",
+		h.Repo, repoCfg, nil, h.Cfg, "acme/api",
 	)
 	require.NoError(t, err)
 	require.Len(t, members, 1)

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -3237,7 +3237,11 @@ func TestResolveCIMatrixMembersUsesCustomTypeReasoning(t *testing.T) {
 	}
 
 	members, _, err := h.Poller.resolveCIMatrixMembers(
-		h.Repo, repoCfg, nil, h.Cfg, "acme/api",
+		h.Repo, repoCfg, map[string]any{
+			"ci": map[string]any{
+				"agents": []any{""}, "review_types": []any{"thermonuclear"},
+			},
+		}, h.Cfg, "acme/api",
 	)
 	require.NoError(t, err)
 	require.Len(t, members, 1)
@@ -3264,7 +3268,11 @@ func TestResolveCIMatrixMembersInvalidCIReasoningUsesFallback(t *testing.T) {
 	}
 
 	members, _, err := h.Poller.resolveCIMatrixMembers(
-		h.Repo, repoCfg, nil, h.Cfg, "acme/api",
+		h.Repo, repoCfg, map[string]any{
+			"ci": map[string]any{
+				"agents": []any{"codex"}, "review_types": []any{"thermonuclear"},
+			},
+		}, h.Cfg, "acme/api",
 	)
 	require.NoError(t, err)
 	require.Len(t, members, 1)

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -1321,7 +1321,7 @@ func TestCIPollerProcessPR_FallsBackWhenPromptPrebuildFails(t *testing.T) {
 			CreatedAt: time.Date(2026, time.March, 27, 12, 0, 0, 0, time.UTC),
 		}}, nil
 	}
-	h.Poller.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error) {
+	h.Poller.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error) {
 		return "", errors.New("prompt prebuild exploded")
 	}
 
@@ -4778,7 +4778,7 @@ func TestReconcileStuckAttempt(t *testing.T) {
 
 func TestBuildPanelOpts_RecordsPRBranchOnJobs(t *testing.T) {
 	p := &CIPoller{}
-	p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error) {
+	p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error) {
 		return "prebuilt prompt", nil
 	}
 
@@ -4808,7 +4808,7 @@ func TestBuildPanelOpts_RecordsPRBranchOnJobs(t *testing.T) {
 
 func TestBuildPanelOptsSnapshotsEffectiveACPExecutionConfig(t *testing.T) {
 	p := &CIPoller{}
-	p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error) {
+	p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error) {
 		return "prebuilt prompt", nil
 	}
 	cfg := config.DefaultConfig()
@@ -4906,7 +4906,7 @@ func TestBuildPanelOptsRejectsACPReferencesMissingFromDefaultBranch(t *testing.T
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &CIPoller{}
-			p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error) {
+			p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error) {
 				return "prebuilt prompt", nil
 			}
 			memberOpts, synthOpts, err := p.buildPanelOpts(
@@ -4991,7 +4991,7 @@ func TestCIPromptPrebuildNeverIncludesKataContext(t *testing.T) {
 	cfg.KataContext.Mode = config.KataModeOpen
 	p := NewCIPoller(nil, NewStaticConfig(cfg), nil)
 
-	out, err := p.callBuildReviewPrompt(context.Background(), repo.Path(), sha, 0, 0, "test", "", "", "", cfg)
+	out, err := p.callBuildReviewPrompt(context.Background(), repo.Path(), sha, 0, 0, "test", "", "", "", nil, "", cfg)
 	require.NoError(t, err)
 	assert.NotContains(t, out, "Task Context (kata)",
 		"CI prompt prebuilds must never include kata task-ledger content")
@@ -5011,7 +5011,7 @@ func TestBuildPanelOptsAbortsOnCanceledPrebuild(t *testing.T) {
 
 	t.Run("cancellation aborts the run", func(t *testing.T) {
 		p := &CIPoller{}
-		p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error) {
+		p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error) {
 			return "", fmt.Errorf("building prompt: %w", context.Canceled)
 		}
 		_, _, err := p.buildPanelOpts(context.Background(), in)
@@ -5020,7 +5020,7 @@ func TestBuildPanelOptsAbortsOnCanceledPrebuild(t *testing.T) {
 
 	t.Run("other prebuild errors still enqueue without stored prompt", func(t *testing.T) {
 		p := &CIPoller{}
-		p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error) {
+		p.buildReviewPromptFn = func(context.Context, string, string, int64, int, string, string, string, string, *config.RepoConfig, string, *config.Config) (string, error) {
 			return "", errors.New("prompt prebuild exploded")
 		}
 		memberOpts, _, err := p.buildPanelOpts(context.Background(), in)

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -3213,6 +3213,33 @@ func TestResolveCIMatrixMembersUsesPassedRepoConfigForAgentModel(t *testing.T) {
 	assert.Equal(t, "default-branch-model", members[0].Model)
 }
 
+func TestResolveCIMatrixMembersUsesCustomTypeReasoning(t *testing.T) {
+	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
+	h.Cfg.DefaultAgent = "global-agent"
+	h.Poller.agentResolverFn = func(name string) (string, error) {
+		return name, nil
+	}
+	repoCfg := &config.RepoConfig{
+		Review: config.ReviewConfig{Types: map[string]config.ReviewTypeSpec{
+			"thermonuclear": {
+				Template:  "review.tmpl",
+				Reasoning: "maximum",
+			},
+		}},
+		CI: config.RepoCIConfig{
+			Agents:      []string{""},
+			ReviewTypes: []string{"thermonuclear"},
+		},
+	}
+
+	members, _, err := h.Poller.resolveCIMatrixMembers(
+		h.Repo, repoCfg, h.Cfg, "acme/api",
+	)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "maximum", members[0].Reasoning)
+}
+
 func TestResolveMatrixMemberAgentBlankAgentAutoDetectsAvailableAgent(t *testing.T) {
 	h := newCIPollerHarness(t, "git@github.com:acme/api.git")
 	t.Setenv("PATH", "")

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -232,7 +232,7 @@ func TestCleanCompactOutputsParseAsPassVerdicts(t *testing.T) {
 	for _, output := range outputs {
 		t.Run(output, func(t *testing.T) {
 			require.True(t, IsValidCompactOutput(output))
-			assert.Equal(t, "P", storage.ParseVerdict(output))
+			assert.Equal(t, storage.VerdictPass, storage.ParseVerdict(output))
 		})
 	}
 }

--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -557,7 +557,13 @@ func (s *Server) enqueuePanelRun(ctx context.Context, in panelRunInputs) (*RawJS
 	}
 
 	runUUID := uuid.NewString()
-	memberOpts := panelMemberOpts(in.descriptor, in.panelName, runUUID, members, in.repoCfg, in.cfg)
+	memberOpts, err := panelMemberOpts(
+		in.descriptor, in.panelName, runUUID, members,
+		in.repoCfg, in.cfg,
+	)
+	if err != nil {
+		return rawJSONOutput(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+	}
 	synthOpts := panelSynthesisOpts(
 		in.descriptor, in.panelName, runUUID, synth, in.repoCfg, in.cfg,
 	)
@@ -657,14 +663,18 @@ func panelHasDesignMember(members []config.ResolvedMember) bool {
 func panelMemberOpts(
 	descriptor targetDescriptor, panelName, runUUID string, members []config.ResolvedMember,
 	repoCfg *config.RepoConfig, cfg *config.Config,
-) []storage.EnqueueOpts {
+) ([]storage.EnqueueOpts, error) {
 	out := make([]storage.EnqueueOpts, len(members))
 	for i, m := range members {
 		o := descriptor.baseOpts()
 		cfgJSON, _ := json.Marshal(m)
-		o.Agent, o.Model, o.BackupAgent, o.BackupModel = resolvePanelMemberExecution(
+		var err error
+		o.Agent, o.Model, o.BackupAgent, o.BackupModel, err = resolvePanelMemberExecution(
 			m, descriptor, repoCfg, cfg,
 		)
+		if err != nil {
+			return nil, fmt.Errorf("panel member %q: %w", m.Name, err)
+		}
 		o.Provider = m.Provider
 		o.Reasoning, o.ReviewType = m.Reasoning, m.ReviewType
 		o.PanelRunUUID, o.PanelRole = runUUID, storage.PanelRoleMember
@@ -672,19 +682,18 @@ func panelMemberOpts(
 		o.PanelMemberConfigJSON = string(cfgJSON)
 		out[i] = o
 	}
-	return out
+	return out, nil
 }
 
 func resolvePanelMemberExecution(
 	m config.ResolvedMember, descriptor targetDescriptor, repoCfg *config.RepoConfig, cfg *config.Config,
-) (string, string, string, string) {
-	agentName := agent.StorageNameFromConfig(m.Agent, repoCfg, cfg)
+) (string, string, string, string, error) {
 	model := m.Model
 	resolution, err := agent.ResolveWorkflowConfigFromConfig(
 		m.Agent, repoCfg, cfg, workflowForPanelReviewType(m.ReviewType), m.Reasoning,
 	)
 	if err != nil {
-		return agentName, model, "", ""
+		return "", "", "", "", err
 	}
 	strictWorkflowAgent := m.AgentExplicit ||
 		config.HasWorkflowAgentOverrideFromConfig(
@@ -702,16 +711,24 @@ func resolvePanelMemberExecution(
 		)
 	}
 	if err != nil {
-		return agentName, model, "", ""
+		return "", "", "", "", err
+	}
+	if err := agent.ValidateStructuredReviewSelection(m.ReviewType, selected); err != nil {
+		return "", "", "", "", err
 	}
 	selectedName := agent.StorageNameFromConfig(selected.Name(), repoCfg, cfg)
+	if err := agent.ValidateStructuredReviewBackup(
+		m.ReviewType, resolution, selectedName,
+	); err != nil {
+		return "", "", "", "", err
+	}
 	if !m.ModelExplicit || !resolution.AgentMatches(selectedName, m.Agent) {
 		model = resolution.ModelForSelectedAgent(selectedName, "")
 	}
 	backupAgent, backupModel := backupExecutionForSelectedAgent(
 		resolution, selectedName, repoCfg, cfg,
 	)
-	return selectedName, model, backupAgent, backupModel
+	return selectedName, model, backupAgent, backupModel, nil
 }
 
 func workflowForPanelReviewType(reviewType string) string {

--- a/internal/daemon/panel_enqueue_test.go
+++ b/internal/daemon/panel_enqueue_test.go
@@ -657,7 +657,7 @@ members = ["only"]
 	assert.Equal(t, "goose-model", synth.Model)
 }
 
-func TestEnqueuePanelUnavailableNamedACPStoresNamespacedIdentity(t *testing.T) {
+func TestEnqueuePanelRejectsUnavailableNamedACPMember(t *testing.T) {
 	server, db, _ := newTestServer(t)
 	repo := testutil.NewGitRepo(t)
 	repo.WriteFile(".roborev.toml", `
@@ -677,13 +677,16 @@ synthesis_agent = "test"
 `)
 	repo.CommitFile("a.txt", "a", "add a")
 
-	resp := enqueuePanelViaHTTP(t, server, EnqueueRequest{
+	req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", EnqueueRequest{
 		RepoPath: repo.Path(), GitRef: "HEAD", Agent: "test",
 	})
-	members, err := db.GetPanelMembers(resp.PanelRunUUID)
+	w := httptest.NewRecorder()
+	server.httpServer.Handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	jobs, err := db.ListJobs("", "", 0, 0)
 	require.NoError(t, err)
-	require.Len(t, members, 1)
-	assert.Equal(t, "acp.goose", members[0].Agent)
+	assert.Empty(t, jobs)
 }
 
 func TestEnqueuePanelNamedACPMemberPreservesExplicitModel(t *testing.T) {

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -618,6 +618,21 @@ func TestPanelWrapperNoDoubleHeader(t *testing.T) {
 		assert.Contains(t, body, "- Medium finding")
 	})
 
+	t.Run("stored verdict controls plain output", func(t *testing.T) {
+		h.Cfg.CI.IncludeCosts = false
+		comments := h.CaptureComments()
+		_, synth, _ := h.seedCIPanelRun(t, "acme/api", 24, "headsha999", "base..headsha999",
+			[]jobSpec{{Agent: "test", ReviewType: "review", Status: "done", Output: "x"}})
+		h.completeSynthesisWithReview(t, synth.ID, "No issues found in the summary.\n\n- High finding")
+		_, err := h.DB.Exec(`UPDATE reviews SET verdict_bool = 0 WHERE job_id = ?`, synth.ID)
+		require.NoError(t, err)
+
+		h.Poller.handleReviewCompleted(ciEvent(synth.ID, "review.completed"))
+
+		require.Len(t, *comments, 1)
+		assert.Contains(t, (*comments)[0].Body, "- High finding")
+	})
+
 	t.Run("plain output footer includes reviewer summary", func(t *testing.T) {
 		h.Cfg.CI.IncludeCosts = false
 		comments := h.CaptureComments()

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2511,16 +2511,6 @@ func (s *Server) humaEnqueue(
 	if req.ReviewType == "" {
 		req.ReviewType = config.ReviewTypeDefault
 	}
-	canonical, err := config.ValidateReviewTypes(
-		[]string{req.ReviewType},
-	)
-	if err != nil {
-		return rawJSONOutput(
-			http.StatusBadRequest,
-			ErrorResponse{Error: err.Error()},
-		)
-	}
-	req.ReviewType = canonical[0]
 
 	metadata := git.OpenEnqueueMetadataReader(ctx, req.RepoPath)
 	checkoutRoot, err := metadata.Root()
@@ -2543,6 +2533,24 @@ func (s *Server) humaEnqueue(
 	if filepath.Clean(checkoutRoot) != filepath.Clean(repoRoot) {
 		worktreePath = filepath.Clean(checkoutRoot)
 	}
+	cfg := s.configWatcher.Config()
+	repoCfg, err := config.LoadRepoConfig(checkoutRoot)
+	if err != nil {
+		return rawJSONOutput(
+			http.StatusBadRequest,
+			ErrorResponse{Error: fmt.Sprintf("resolve workflow config: %v", err)},
+		)
+	}
+	canonical, err := config.ValidateReviewTypesFromConfig(
+		[]string{req.ReviewType}, repoCfg, cfg,
+	)
+	if err != nil {
+		return rawJSONOutput(
+			http.StatusBadRequest,
+			ErrorResponse{Error: err.Error()},
+		)
+	}
+	req.ReviewType = canonical[0]
 
 	currentBranch := metadata.CurrentBranch()
 	// A post-commit request's explicit branch names the branch being
@@ -2590,7 +2598,6 @@ func (s *Server) humaEnqueue(
 	}
 
 	workflow := workflowForJob(req.JobType, req.ReviewType)
-	cfg := s.configWatcher.Config()
 	resolutionPath := repoRoot
 	if worktreePath != "" {
 		resolutionPath = worktreePath
@@ -2703,7 +2710,9 @@ func (s *Server) humaEnqueue(
 	if workflow == "fix" {
 		reasoning, err = config.ResolveFixReasoningFromConfig(req.Reasoning, repoCfg, cfg)
 	} else {
-		reasoning, err = config.ResolveReviewReasoningFromConfig(req.Reasoning, repoCfg, cfg)
+		reasoning, err = config.ResolveReviewReasoningForTypeFromConfig(
+			req.Reasoning, repoCfg, cfg, req.ReviewType,
+		)
 	}
 	if err != nil {
 		return rawJSONOutput(http.StatusBadRequest, ErrorResponse{Error: err.Error()})

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2816,7 +2816,25 @@ func (s *Server) resolveSingleAgent(
 		)
 		return resolvedSingleAgent{}, out
 	}
+	if err := agent.ValidateStructuredReviewSelection(
+		in.req.ReviewType, resolved,
+	); err != nil {
+		out, _ := rawJSONOutput(
+			http.StatusBadRequest,
+			ErrorResponse{Error: fmt.Sprintf("invalid agent: %v", err)},
+		)
+		return resolvedSingleAgent{}, out
+	}
 	agentName = resolved.Name()
+	if err := agent.ValidateStructuredReviewBackup(
+		in.req.ReviewType, resolution, agentName,
+	); err != nil {
+		out, _ := rawJSONOutput(
+			http.StatusBadRequest,
+			ErrorResponse{Error: fmt.Sprintf("invalid agent: %v", err)},
+		)
+		return resolvedSingleAgent{}, out
+	}
 	backupAgent, backupModel := backupExecutionForSelectedAgent(
 		resolution, agentName, in.repoCfg, in.cfg,
 	)

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
 	daemonclient "go.kenn.io/roborev/internal/daemon_client"
 	gitpkg "go.kenn.io/roborev/internal/git"
@@ -2589,6 +2590,65 @@ func TestHandleEnqueueCompactReasoning(t *testing.T) {
 		}, "compact job reasoning = %q, want %q (fix default)",
 			job.Reasoning, "standard")
 	}
+}
+
+func TestHandleEnqueueRejectsCustomReviewWithUnsupportedAgent(t *testing.T) {
+	repoDir := t.TempDir()
+	testutil.InitTestGitRepo(t, repoDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, ".roborev.toml"),
+		[]byte("[review.types.custom]\ntemplate = \"custom.tmpl\"\n"),
+		0o644,
+	))
+
+	db, _ := testutil.OpenTestDBWithDir(t)
+	server := NewServer(db, config.DefaultConfig(), "")
+	req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", EnqueueRequest{
+		RepoPath:   repoDir,
+		GitRef:     "HEAD",
+		Agent:      "test",
+		ReviewType: "custom",
+	})
+	w := httptest.NewRecorder()
+	server.httpServer.Handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "does not support schema-constrained reviews")
+	queued, _, _, _, _, _, _, _, _ := db.GetJobCounts()
+	assert.Zero(t, queued)
+}
+
+func TestHandleEnqueueRejectsCustomReviewWithUnsupportedBackupAgent(t *testing.T) {
+	const primaryName = "structured-enqueue-primary"
+	agent.Register(&structuredWorkerTestAgent{name: primaryName})
+	t.Cleanup(func() { agent.Unregister(primaryName) })
+
+	repoDir := t.TempDir()
+	testutil.InitTestGitRepo(t, repoDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoDir, ".roborev.toml"),
+		[]byte("[review.types.custom]\ntemplate = \"custom.tmpl\"\n"),
+		0o644,
+	))
+
+	db, _ := testutil.OpenTestDBWithDir(t)
+	cfg := config.DefaultConfig()
+	cfg.ReviewAgent = primaryName
+	cfg.DefaultBackupAgent = "test"
+	server := NewServer(db, cfg, "")
+	req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", EnqueueRequest{
+		RepoPath:   repoDir,
+		GitRef:     "HEAD",
+		Agent:      primaryName,
+		ReviewType: "custom",
+	})
+	w := httptest.NewRecorder()
+	server.httpServer.Handler.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "invalid backup agent")
+	queued, _, _, _, _, _, _, _, _ := db.GetJobCounts()
+	assert.Zero(t, queued)
 }
 
 func TestHandleEnqueueUsesConfiguredReviewReasoning(t *testing.T) {

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -38,6 +38,9 @@ func (wp *WorkerPool) processSynthesisJob(
 		return
 	}
 	results := toReviewResults(rows)
+	for i := range results {
+		results[i] = results[i].FilterStructured(job.MinSeverity)
+	}
 	succeeded := filterSucceeded(results)
 
 	switch len(succeeded) {
@@ -254,8 +257,10 @@ func (wp *WorkerPool) completeSynthesisLocked(
 	agentName, prompt, output := res.agentName, res.prompt, res.output
 	var completeErr error
 	if res.verdict != storage.VerdictUnknown {
-		completeErr = wp.db.CompleteJobWithVerdict(
-			job.ID, agentName, prompt, output, res.verdict,
+		completeErr = wp.db.CompleteJobResult(
+			job.ID, agentName, prompt, storage.ReviewCompletion{
+				Output: output, Verdict: res.verdict,
+			},
 		)
 	} else {
 		completeErr = wp.db.CompleteJob(job.ID, agentName, prompt, output)

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -63,7 +63,7 @@ func (wp *WorkerPool) processSynthesisJob(
 			wp.completeSynthesisContext(workerID, job, synthesisResult{
 				agentName: succeeded[0].Agent,
 				output:    "No issues found.",
-				passed:    succeeded[0].Verdict,
+				verdict:   succeeded[0].Verdict,
 			})
 			return
 		}
@@ -75,14 +75,14 @@ func (wp *WorkerPool) processSynthesisJob(
 		wp.completeSynthesisContext(workerID, job, synthesisResult{
 			agentName: succeeded[0].Agent,
 			output:    succeeded[0].Output,
-			passed:    succeeded[0].Verdict,
+			verdict:   succeeded[0].Verdict,
 		})
 	default:
 		if allMembersPassed(results, succeeded) {
 			wp.completeSynthesisContext(workerID, job, synthesisResult{
 				agentName: job.Agent,
 				output:    "No issues found.",
-				passed:    new(true),
+				verdict:   storage.VerdictPass,
 			})
 			return
 		}
@@ -232,7 +232,7 @@ type synthesisResult struct {
 	agentName       string
 	prompt          string
 	output          string
-	passed          *bool
+	verdict         storage.Verdict
 	capturedSession string
 	captureUsage    bool
 }
@@ -253,9 +253,9 @@ func (wp *WorkerPool) completeSynthesisLocked(
 ) {
 	agentName, prompt, output := res.agentName, res.prompt, res.output
 	var completeErr error
-	if res.passed != nil {
+	if res.verdict != storage.VerdictUnknown {
 		completeErr = wp.db.CompleteJobWithVerdict(
-			job.ID, agentName, prompt, output, *res.passed,
+			job.ID, agentName, prompt, output, res.verdict,
 		)
 	} else {
 		completeErr = wp.db.CompleteJob(job.ID, agentName, prompt, output)
@@ -282,12 +282,9 @@ func (wp *WorkerPool) completeSynthesisLocked(
 			context.Background(), workerID, job, res.capturedSession,
 		)
 	}
-	verdict := storage.ParseVerdict(output)
-	if res.passed != nil {
-		verdict = "F"
-		if *res.passed {
-			verdict = "P"
-		}
+	verdict := res.verdict
+	if verdict == storage.VerdictUnknown {
+		verdict = storage.ParseVerdict(output)
 	}
 	wp.autoClosePassingReview(workerID, job, verdict)
 
@@ -304,7 +301,7 @@ func (wp *WorkerPool) completeSynthesisLocked(
 		SHA:      job.GitRef,
 		Branch:   job.HookBranch(),
 		Agent:    agentName,
-		Verdict:  verdict,
+		Verdict:  string(verdict),
 		Findings: output,
 	})
 }

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -266,7 +266,8 @@ func (wp *WorkerPool) completeSynthesisLocked(
 			context.Background(), workerID, job, res.capturedSession,
 		)
 	}
-	wp.autoClosePassingReview(workerID, job, output)
+	verdict := storage.ParseVerdict(output)
+	wp.autoClosePassingReview(workerID, job, verdict)
 
 	log.Printf("[%s] Completed synthesis job %d %s panel=%s",
 		workerID, job.ID, job.RepoName, job.PanelName)
@@ -281,7 +282,7 @@ func (wp *WorkerPool) completeSynthesisLocked(
 		SHA:      job.GitRef,
 		Branch:   job.HookBranch(),
 		Agent:    agentName,
-		Verdict:  storage.ParseVerdict(output),
+		Verdict:  verdict,
 		Findings: output,
 	})
 }

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -58,24 +58,31 @@ func (wp *WorkerPool) processSynthesisJob(
 		// label the review with that member's agent when no panel-level severity
 		// filter needs to be applied, or when the member already passed and
 		// there are no findings to filter.
-		if config.IsMarkerOnlyOutput(succeeded[0].Output) {
+		if config.IsMarkerOnlyOutput(succeeded[0].Output) &&
+			succeeded[0].Passed() {
 			wp.completeSynthesisContext(workerID, job, synthesisResult{
-				agentName: succeeded[0].Agent, output: "No issues found.",
+				agentName: succeeded[0].Agent,
+				output:    "No issues found.",
+				passed:    succeeded[0].Verdict,
 			})
 			return
 		}
 		if !singleSuccessCanPassthrough(job.MinSeverity) &&
-			storage.ParseVerdict(succeeded[0].Output) != "P" {
+			!succeeded[0].Passed() {
 			wp.synthesizeSucceededResults(ctx, workerID, job, succeeded)
 			return
 		}
 		wp.completeSynthesisContext(workerID, job, synthesisResult{
-			agentName: succeeded[0].Agent, output: succeeded[0].Output,
+			agentName: succeeded[0].Agent,
+			output:    succeeded[0].Output,
+			passed:    succeeded[0].Verdict,
 		})
 	default:
 		if allMembersPassed(results, succeeded) {
 			wp.completeSynthesisContext(workerID, job, synthesisResult{
-				agentName: job.Agent, output: "No issues found.",
+				agentName: job.Agent,
+				output:    "No issues found.",
+				passed:    new(true),
 			})
 			return
 		}
@@ -178,7 +185,7 @@ func allMembersPassed(
 		return false
 	}
 	for _, r := range succeeded {
-		if storage.ParseVerdict(r.Output) != "P" {
+		if !r.Passed() {
 			return false
 		}
 	}
@@ -225,6 +232,7 @@ type synthesisResult struct {
 	agentName       string
 	prompt          string
 	output          string
+	passed          *bool
 	capturedSession string
 	captureUsage    bool
 }
@@ -244,8 +252,16 @@ func (wp *WorkerPool) completeSynthesisLocked(
 	workerID string, job *storage.ReviewJob, res synthesisResult,
 ) {
 	agentName, prompt, output := res.agentName, res.prompt, res.output
-	if err := wp.db.CompleteJob(job.ID, agentName, prompt, output); err != nil {
-		log.Printf("[%s] Error storing synthesis review for job %d: %v", workerID, job.ID, err)
+	var completeErr error
+	if res.passed != nil {
+		completeErr = wp.db.CompleteJobWithVerdict(
+			job.ID, agentName, prompt, output, *res.passed,
+		)
+	} else {
+		completeErr = wp.db.CompleteJob(job.ID, agentName, prompt, output)
+	}
+	if completeErr != nil {
+		log.Printf("[%s] Error storing synthesis review for job %d: %v", workerID, job.ID, completeErr)
 		return
 	}
 
@@ -267,6 +283,12 @@ func (wp *WorkerPool) completeSynthesisLocked(
 		)
 	}
 	verdict := storage.ParseVerdict(output)
+	if res.passed != nil {
+		verdict = "F"
+		if *res.passed {
+			verdict = "P"
+		}
+	}
 	wp.autoClosePassingReview(workerID, job, verdict)
 
 	log.Printf("[%s] Completed synthesis job %d %s panel=%s",

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -112,7 +112,7 @@ func TestAllMembersPassedIgnoresAllowedFailure(t *testing.T) {
 		{
 			Status:  reviewpkg.ResultDone,
 			Output:  "High: no actionable findings.",
-			Verdict: new(true),
+			Verdict: storage.VerdictPass,
 		},
 		{Status: reviewpkg.ResultFailed, Error: "pi host disappeared", AllowFailure: true},
 	}
@@ -599,7 +599,7 @@ func TestSynthesisSingleSuccessPassthrough(t *testing.T) {
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
 	assert.Equal(memberAOutput, review.Output, "passthrough must emit member output verbatim")
-	assert.Equal("P", storage.ParseVerdict(review.Output), "verdict carried from member output")
+	assert.Equal(storage.VerdictPass, storage.ParseVerdict(review.Output), "verdict carried from member output")
 	assert.Equal(memberAgent, review.Agent, "review labeled with the surviving member's agent")
 	assert.False(synthCalled, "passthrough must not invoke an agent")
 }
@@ -673,7 +673,7 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	const memberOutput = "High: no actionable findings."
 	markMemberRunning(t, tc, members[0].ID)
 	require.NoError(t, tc.DB.CompleteJobWithVerdict(
-		members[0].ID, memberAgent, "", memberOutput, true,
+		members[0].ID, memberAgent, "", memberOutput, storage.VerdictPass,
 	))
 	failMember(t, tc, members[1].ID)
 
@@ -751,7 +751,7 @@ func TestSynthesisAllPassingSkipsAgent(t *testing.T) {
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
 	assert.Equal("No issues found.", review.Output, "stored synthesis output is body content; renderers add headers and footers")
-	assert.Equal("P", storage.ParseVerdict(review.Output))
+	assert.Equal(storage.VerdictPass, storage.ParseVerdict(review.Output))
 	assert.False(synthCalled, "clean panels must not invoke an extra synthesis agent")
 }
 

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -666,14 +666,24 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	})
 	setSynthesisAgent(t, tc, runUUID, synthAgent)
 	_, err := tc.DB.Exec(
-		"UPDATE review_jobs SET min_severity = ? WHERE id = ?",
-		"medium", synthJob.ID,
+		"UPDATE review_jobs SET min_severity = CASE WHEN id = ? THEN 'low' ELSE 'medium' END WHERE id IN (?, ?)",
+		members[0].ID, members[0].ID, synthJob.ID,
 	)
 	require.NoError(t, err)
-	const memberOutput = "High: no actionable findings."
+	const memberOutput = "## Review Findings\n\nThe summary claims a high issue.\n\n### 1. Low\n\n**Problem:** low-only\n\n**Fix:** low fix"
+	structured := json.RawMessage(`{
+  "summary": "The summary claims a high issue.",
+  "findings": [
+    {"severity":"low","problem":"low-only","fix":"low fix","location":null}
+  ]
+}`)
 	markMemberRunning(t, tc, members[0].ID)
-	require.NoError(t, tc.DB.CompleteJobWithVerdict(
-		members[0].ID, memberAgent, "", memberOutput, storage.VerdictPass,
+	require.NoError(t, tc.DB.CompleteJobResult(
+		members[0].ID, memberAgent, "", storage.ReviewCompletion{
+			Output:           memberOutput,
+			Verdict:          storage.VerdictFail,
+			StructuredOutput: structured,
+		},
 	))
 	failMember(t, tc, members[1].ID)
 
@@ -683,11 +693,15 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	tc.assertJobStatus(t, synth.ID, storage.JobStatusDone)
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
-	assert.Equal(memberOutput, review.Output, "passing single-success output needs no severity filter")
+	assert.Contains(review.Output, "No findings at or above the configured severity threshold.")
+	assert.NotContains(review.Output, "low-only")
 	require.NotNil(t, review.VerdictBool)
-	assert.Equal(1, *review.VerdictBool, "passthrough must preserve the structured verdict")
+	assert.Equal(1, *review.VerdictBool, "panel threshold must use the structured findings")
 	assert.Equal(memberAgent, review.Agent, "passthrough remains labeled with the surviving member")
 	assert.False(synthCalled, "passing single-success min-severity panel must not invoke synthesis")
+	memberReview, err := tc.DB.GetReviewByJobID(members[0].ID)
+	require.NoError(t, err)
+	assert.JSONEq(string(structured), string(memberReview.StructuredOutput))
 }
 
 func TestSynthesisSingleMarkerOnlySuccessWithMinSeverityNormalizesOutput(t *testing.T) {

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -701,7 +701,7 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	assert.False(synthCalled, "passing single-success min-severity panel must not invoke synthesis")
 	memberReview, err := tc.DB.GetReviewByJobID(members[0].ID)
 	require.NoError(t, err)
-	assert.JSONEq(string(structured), string(memberReview.StructuredOutput))
+	assert.Equal("The summary claims a high issue.", memberReview.StructuredOutput["summary"])
 }
 
 func TestSynthesisSingleMarkerOnlySuccessWithMinSeverityNormalizesOutput(t *testing.T) {

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -109,7 +109,11 @@ func registerNeverCalledAgent(t *testing.T, name string, called *bool) {
 
 func TestAllMembersPassedIgnoresAllowedFailure(t *testing.T) {
 	results := []reviewpkg.ReviewResult{
-		{Status: reviewpkg.ResultDone, Output: "No issues found."},
+		{
+			Status:  reviewpkg.ResultDone,
+			Output:  "High: no actionable findings.",
+			Verdict: new(true),
+		},
 		{Status: reviewpkg.ResultFailed, Error: "pi host disappeared", AllowFailure: true},
 	}
 	succeeded := filterSucceeded(results)
@@ -666,8 +670,11 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 		"medium", synthJob.ID,
 	)
 	require.NoError(t, err)
-	const memberOutput = "## Review\n\nNo issues found."
-	completeMember(t, tc, members[0].ID, memberAgent, memberOutput)
+	const memberOutput = "High: no actionable findings."
+	markMemberRunning(t, tc, members[0].ID)
+	require.NoError(t, tc.DB.CompleteJobWithVerdict(
+		members[0].ID, memberAgent, "", memberOutput, true,
+	))
 	failMember(t, tc, members[1].ID)
 
 	synth := releaseAndClaimSynthesis(t, tc, runUUID)
@@ -677,6 +684,8 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
 	assert.Equal(memberOutput, review.Output, "passing single-success output needs no severity filter")
+	require.NotNil(t, review.VerdictBool)
+	assert.Equal(1, *review.VerdictBool, "passthrough must preserve the structured verdict")
 	assert.Equal(memberAgent, review.Agent, "passthrough remains labeled with the surviving member")
 	assert.False(synthCalled, "passing single-success min-severity panel must not invoke synthesis")
 }

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -672,6 +672,7 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	require.NoError(t, err)
 	const memberOutput = "## Review Findings\n\nThe summary claims a high issue.\n\n### 1. Low\n\n**Problem:** low-only\n\n**Fix:** low fix"
 	structured := json.RawMessage(`{
+  "schema_version": 1,
   "summary": "The summary claims a high issue.",
   "findings": [
     {"severity":"low","problem":"low-only","fix":"low fix","location":null}

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -555,6 +555,37 @@ func (wp *WorkerPool) prepareJobCheckout(
 	}, nil
 }
 
+func (wp *WorkerPool) promptBuilderForJob(
+	ctx context.Context,
+	checkout preparedJobCheckout,
+	job *storage.ReviewJob,
+	cfg *config.Config,
+) (*prompt.Builder, error) {
+	builder := prompt.NewBuilderWithConfig(wp.db, cfg).
+		WithContext(ctx).
+		ForRepo(checkout.promptRepoPath, job.RepoID)
+	if job.IsCIReview() && strings.TrimSpace(job.CIBaseBranch) != "" {
+		repoCfg, err := loadCIRepoConfig(checkout.promptRepoPath)
+		if err != nil {
+			if !config.IsConfigParseError(err) {
+				return nil, fmt.Errorf("load CI review config: %w", err)
+			}
+			log.Printf("worker: warning: failed to load CI review config: %v", err)
+			repoCfg = nil
+		}
+		builder = builder.WithRepoConfig(
+			repoCfg,
+			"origin/"+strings.TrimSpace(job.CIBaseBranch),
+		)
+	}
+	if !job.IsCIReview() {
+		builder = builder.WithKataClient(
+			kata.NewCLIClient(checkout.promptRepoPath),
+		)
+	}
+	return builder, nil
+}
+
 // markAgentInvoked records that an agent is being invoked for this attempt. Call
 // it only after all pre-agent gates pass, immediately before the agent runs, so
 // a job that fails a gate is never counted as an agent run. This is the synced
@@ -839,15 +870,13 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	}
 
 	// Build the prompt (or use pre-stored prompt for task/compact jobs).
-	// Create a per-job builder with the snapshotted config so exclude
-	// patterns are resolved consistently.
-	pb := prompt.NewBuilderWithConfig(wp.db, cfg).WithContext(ctx).ForRepo(checkout.promptRepoPath, job.RepoID)
-	// CI jobs normally carry a prebuilt prompt whose kata context was gated
-	// on PR author trust by the poller. This rebuild fallback has no author
-	// information, so it must not resolve kata refs from fork-controlled
-	// commit messages (or leak backlog content) — skip kata context entirely.
-	if !job.IsCIReview() {
-		pb = pb.WithKataClient(kata.NewCLIClient(checkout.promptRepoPath))
+	// CI rebuilds use the same default-branch config and base-ref template
+	// files as enqueue-time prompt construction.
+	pb, err := wp.promptBuilderForJob(ctx, checkout, job, cfg)
+	if err != nil {
+		log.Printf("[%s] Error configuring prompt builder: %v", workerID, err)
+		wp.failOrRetryContext(ctx, workerID, job, job.Agent, fmt.Sprintf("configure prompt builder: %v", err))
+		return
 	}
 	if err := pb.CleanupStaleSnapshots(prompt.DefaultStaleSnapshotAge); err != nil {
 		log.Printf("[%s] Warning: cleanup stale snapshots for job %d: %v", workerID, job.ID, err)

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -565,17 +565,17 @@ func (wp *WorkerPool) promptBuilderForJob(
 		WithContext(ctx).
 		ForRepo(checkout.promptRepoPath, job.RepoID)
 	if job.IsCIReview() && strings.TrimSpace(job.CIBaseBranch) != "" {
-		repoCfg, err := loadCIRepoConfig(checkout.promptRepoPath)
+		repoConfig, err := loadCIRepoConfig(checkout.promptRepoPath)
 		if err != nil {
 			if !config.IsConfigParseError(err) {
 				return nil, fmt.Errorf("load CI review config: %w", err)
 			}
 			log.Printf("worker: warning: failed to load CI review config: %v", err)
-			repoCfg = nil
+			repoConfig = ciRepoConfigSource{}
 		}
 		builder = builder.WithRepoConfig(
-			repoCfg,
-			"origin/"+strings.TrimSpace(job.CIBaseBranch),
+			repoConfig.Config,
+			repoConfig.Ref,
 		)
 	}
 	if !job.IsCIReview() {
@@ -870,7 +870,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	}
 
 	// Build the prompt (or use pre-stored prompt for task/compact jobs).
-	// CI rebuilds use the same default-branch config and base-ref template
+	// CI rebuilds use the same default-branch config and template
 	// files as enqueue-time prompt construction.
 	pb, err := wp.promptBuilderForJob(ctx, checkout, job, cfg)
 	if err != nil {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1091,42 +1091,11 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// Run the review
 	log.Printf("[%s] Running %s %sreview (job %d)...",
 		workerID, agentName, rtTag, job.ID)
-	customReview := !config.IsBuiltInReviewType(job.ReviewType)
-	var output string
-	var explicitPassed *bool
-	if customReview {
-		structuredAgent, ok := a.(agent.StructuredReviewAgent)
-		if !ok {
-			wp.failOrRetryAgentContext(
-				ctx, workerID, job, agentName,
-				fmt.Sprintf(
-					"agent %q does not support schema-constrained reviews",
-					agentName,
-				),
-			)
-			return
-		}
-		rawResult, reviewErr := structuredAgent.ReviewWithSchema(
-			ctx, reviewRepoPath, job.GitRef, reviewPrompt,
-			review.CustomReviewSchema, agentOutput,
-		)
-		err = reviewErr
-		if err == nil {
-			structured, decodeErr := review.DecodeStructuredReview(rawResult)
-			if decodeErr != nil {
-				err = decodeErr
-			} else {
-				structured = structured.Filter(effectiveMinSeverity)
-				output = structured.Markdown()
-				passed := structured.Passed()
-				explicitPassed = &passed
-			}
-		}
-	} else {
-		output, err = a.Review(
-			ctx, reviewRepoPath, job.GitRef, reviewPrompt, agentOutput,
-		)
-	}
+	agentReview, err := review.RunAgentReview(
+		ctx, a, reviewRepoPath, job.GitRef, reviewPrompt, job.ReviewType,
+		effectiveMinSeverity, agentOutput,
+	)
+	output := agentReview.Output
 	sessionWriter.Flush()
 	if sessionID := sessionWriter.SessionID(); sessionID != "" {
 		if saveErr := wp.db.SaveJobSessionID(job.ID, workerID, sessionID); saveErr != nil {
@@ -1213,11 +1182,12 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 				log.Printf("[%s] Error storing fix review: %v", workerID, err)
 				return
 			}
-		} else if explicitPassed != nil {
+		} else if job.IsReviewJob() &&
+			agentReview.Verdict != storage.VerdictUnknown {
 			if err := wp.db.CompleteJobWithVerdict(
-				job.ID, agentName, reviewPrompt, output, *explicitPassed,
+				job.ID, agentName, reviewPrompt, output, agentReview.Verdict,
 			); err != nil {
-				log.Printf("[%s] Error storing structured review: %v", workerID, err)
+				log.Printf("[%s] Error storing review verdict: %v", workerID, err)
 				return
 			}
 		} else if err := wp.db.CompleteJob(job.ID, agentName, reviewPrompt, output); err != nil {
@@ -1248,12 +1218,9 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			}
 		}
 
-		verdict := storage.ParseVerdict(output)
-		if explicitPassed != nil {
-			verdict = "F"
-			if *explicitPassed {
-				verdict = "P"
-			}
+		verdict := agentReview.Verdict
+		if verdict == storage.VerdictUnknown {
+			verdict = storage.ParseVerdict(output)
 		}
 		wp.autoClosePassingReview(workerID, job, verdict)
 
@@ -1289,7 +1256,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			SHA:          job.GitRef,
 			Branch:       job.HookBranch(),
 			Agent:        agentName,
-			Verdict:      verdict,
+			Verdict:      string(verdict),
 			Findings:     output,
 			WorktreePath: eventWorktreePath,
 		})
@@ -1306,7 +1273,9 @@ func (wp *WorkerPool) finishRunningJob(workerID string, jobID int64) {
 	}
 }
 
-func (wp *WorkerPool) autoClosePassingReview(workerID string, job *storage.ReviewJob, verdict string) {
+func (wp *WorkerPool) autoClosePassingReview(
+	workerID string, job *storage.ReviewJob, verdict storage.Verdict,
+) {
 	if !job.IsReviewJob() && !job.IsSynthesisJob() {
 		return
 	}

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1184,8 +1184,12 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			}
 		} else if job.IsReviewJob() &&
 			agentReview.Verdict != storage.VerdictUnknown {
-			if err := wp.db.CompleteJobWithVerdict(
-				job.ID, agentName, reviewPrompt, output, agentReview.Verdict,
+			if err := wp.db.CompleteJobResult(
+				job.ID, agentName, reviewPrompt, storage.ReviewCompletion{
+					Output:           output,
+					Verdict:          agentReview.Verdict,
+					StructuredOutput: agentReview.StructuredOutput,
+				},
 			); err != nil {
 				log.Printf("[%s] Error storing review verdict: %v", workerID, err)
 				return

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1091,7 +1091,42 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// Run the review
 	log.Printf("[%s] Running %s %sreview (job %d)...",
 		workerID, agentName, rtTag, job.ID)
-	output, err := a.Review(ctx, reviewRepoPath, job.GitRef, reviewPrompt, agentOutput)
+	customReview := !config.IsBuiltInReviewType(job.ReviewType)
+	var output string
+	var explicitPassed *bool
+	if customReview {
+		structuredAgent, ok := a.(agent.StructuredReviewAgent)
+		if !ok {
+			wp.failOrRetryAgentContext(
+				ctx, workerID, job, agentName,
+				fmt.Sprintf(
+					"agent %q does not support schema-constrained reviews",
+					agentName,
+				),
+			)
+			return
+		}
+		rawResult, reviewErr := structuredAgent.ReviewWithSchema(
+			ctx, reviewRepoPath, job.GitRef, reviewPrompt,
+			review.CustomReviewSchema, agentOutput,
+		)
+		err = reviewErr
+		if err == nil {
+			structured, decodeErr := review.DecodeStructuredReview(rawResult)
+			if decodeErr != nil {
+				err = decodeErr
+			} else {
+				structured = structured.Filter(job.MinSeverity)
+				output = structured.Markdown()
+				passed := structured.Passed()
+				explicitPassed = &passed
+			}
+		}
+	} else {
+		output, err = a.Review(
+			ctx, reviewRepoPath, job.GitRef, reviewPrompt, agentOutput,
+		)
+	}
 	sessionWriter.Flush()
 	if sessionID := sessionWriter.SessionID(); sessionID != "" {
 		if saveErr := wp.db.SaveJobSessionID(job.ID, workerID, sessionID); saveErr != nil {
@@ -1176,6 +1211,13 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		if job.IsFixJob() {
 			if err := wp.db.CompleteFixJob(job.ID, agentName, reviewPrompt, output, fixPatch); err != nil {
 				log.Printf("[%s] Error storing fix review: %v", workerID, err)
+				return
+			}
+		} else if explicitPassed != nil {
+			if err := wp.db.CompleteJobWithVerdict(
+				job.ID, agentName, reviewPrompt, output, *explicitPassed,
+			); err != nil {
+				log.Printf("[%s] Error storing structured review: %v", workerID, err)
 				return
 			}
 		} else if err := wp.db.CompleteJob(job.ID, agentName, reviewPrompt, output); err != nil {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1248,7 +1248,14 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			}
 		}
 
-		wp.autoClosePassingReview(workerID, job, output)
+		verdict := storage.ParseVerdict(output)
+		if explicitPassed != nil {
+			verdict = "F"
+			if *explicitPassed {
+				verdict = "P"
+			}
+		}
+		wp.autoClosePassingReview(workerID, job, verdict)
 
 		wp.captureTokenUsageForSession(context.Background(), workerID, job, sessionWriter.SessionID())
 
@@ -1272,7 +1279,6 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		}
 
 		// Broadcast completion event
-		verdict := storage.ParseVerdict(output)
 		wp.broadcaster.Broadcast(Event{
 			Type:         "review.completed",
 			TS:           time.Now(),
@@ -1300,11 +1306,11 @@ func (wp *WorkerPool) finishRunningJob(workerID string, jobID int64) {
 	}
 }
 
-func (wp *WorkerPool) autoClosePassingReview(workerID string, job *storage.ReviewJob, output string) {
+func (wp *WorkerPool) autoClosePassingReview(workerID string, job *storage.ReviewJob, verdict string) {
 	if !job.IsReviewJob() && !job.IsSynthesisJob() {
 		return
 	}
-	if storage.ParseVerdict(output) != "P" {
+	if verdict != "P" {
 		return
 	}
 	cfg := wp.cfgGetter.Config()

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -854,6 +854,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	}
 	var reviewPrompt string
 	var promptToPersist string
+	effectiveMinSeverity := job.MinSeverity
 	storedPromptValue := job.Prompt
 	if job.PromptPrebuilt && storedPromptValue != "" {
 		// CI-enqueued review with prebuilt prompt (includes PR
@@ -893,15 +894,14 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	} else {
 		// Attributed jobs use the frozen plan verbatim, including an explicit
 		// empty value. Ordinary jobs keep the legacy config cascade.
-		minSev := job.MinSeverity
-		if minSev == "" && job.FrozenExperimentPlan == nil {
+		if effectiveMinSeverity == "" && job.FrozenExperimentPlan == nil {
 			resolved, resErr := config.ResolveReviewMinSeverity("", checkout.promptRepoPath, cfg)
 			if resErr != nil {
 				log.Printf("[%s] Error resolving min-severity: %v", workerID, resErr)
 				wp.failOrRetryContext(ctx, workerID, job, job.Agent, fmt.Sprintf("resolve min-severity: %v", resErr))
 				return
 			}
-			minSev = resolved
+			effectiveMinSeverity = resolved
 		}
 
 		if job.IsDirtyJob() {
@@ -911,7 +911,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 				diffContent = *job.DiffContent
 			}
 			dirtyResult, dirtyErr := pb.BuildDirtyWithSnapshotTargetAndFiles(
-				diffContent, job.DirtyFiles, cfg.ReviewContextCount, job.Agent, job.ReviewType, minSev,
+				diffContent, job.DirtyFiles, cfg.ReviewContextCount, job.Agent, job.ReviewType, effectiveMinSeverity,
 				checkout.snapshotTarget,
 			)
 			if dirtyResult.Cleanup != nil {
@@ -927,7 +927,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			)
 			snapResult, snapErr := pb.BuildWithSnapshotTarget(
 				job.GitRef, cfg.ReviewContextCount, job.Agent,
-				job.ReviewType, minSev, excludes, checkout.snapshotTarget,
+				job.ReviewType, effectiveMinSeverity, excludes, checkout.snapshotTarget,
 			)
 			if snapResult.Cleanup != nil {
 				defer snapResult.Cleanup()
@@ -1116,7 +1116,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 			if decodeErr != nil {
 				err = decodeErr
 			} else {
-				structured = structured.Filter(job.MinSeverity)
+				structured = structured.Filter(effectiveMinSeverity)
 				output = structured.Markdown()
 				passed := structured.Passed()
 				explicitPassed = &passed

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -561,9 +561,7 @@ func (wp *WorkerPool) promptBuilderForJob(
 	job *storage.ReviewJob,
 	cfg *config.Config,
 ) (*prompt.Builder, error) {
-	builder := prompt.NewBuilderWithConfig(wp.db, cfg).
-		WithContext(ctx).
-		ForRepo(checkout.promptRepoPath, job.RepoID)
+	builder := wp.basePromptBuilderForJob(ctx, checkout, job, cfg)
 	if job.IsCIReview() && strings.TrimSpace(job.CIBaseBranch) != "" {
 		repoConfig, err := loadCIRepoConfig(checkout.promptRepoPath)
 		if err != nil {
@@ -571,19 +569,31 @@ func (wp *WorkerPool) promptBuilderForJob(
 				return nil, fmt.Errorf("load CI review config: %w", err)
 			}
 			log.Printf("worker: warning: failed to load CI review config: %v", err)
-			repoConfig = ciRepoConfigSource{}
+			repoConfig.Config = nil
 		}
 		builder = builder.WithRepoConfig(
 			repoConfig.Config,
 			repoConfig.Ref,
 		)
 	}
+	return builder, nil
+}
+
+func (wp *WorkerPool) basePromptBuilderForJob(
+	ctx context.Context,
+	checkout preparedJobCheckout,
+	job *storage.ReviewJob,
+	cfg *config.Config,
+) *prompt.Builder {
+	builder := prompt.NewBuilderWithConfig(wp.db, cfg).
+		WithContext(ctx).
+		ForRepo(checkout.promptRepoPath, job.RepoID)
 	if !job.IsCIReview() {
 		builder = builder.WithKataClient(
 			kata.NewCLIClient(checkout.promptRepoPath),
 		)
 	}
-	return builder, nil
+	return builder
 }
 
 // markAgentInvoked records that an agent is being invoked for this attempt. Call
@@ -869,15 +879,9 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		return
 	}
 
-	// Build the prompt (or use pre-stored prompt for task/compact jobs).
-	// CI rebuilds use the same default-branch config and template
-	// files as enqueue-time prompt construction.
-	pb, err := wp.promptBuilderForJob(ctx, checkout, job, cfg)
-	if err != nil {
-		log.Printf("[%s] Error configuring prompt builder: %v", workerID, err)
-		wp.failOrRetryContext(ctx, workerID, job, job.Agent, fmt.Sprintf("configure prompt builder: %v", err))
-		return
-	}
+	// Prompt-independent cleanup must not force a prebuilt CI job to reload
+	// repository review configuration that it no longer needs.
+	pb := wp.basePromptBuilderForJob(ctx, checkout, job, cfg)
 	if err := pb.CleanupStaleSnapshots(prompt.DefaultStaleSnapshotAge); err != nil {
 		log.Printf("[%s] Warning: cleanup stale snapshots for job %d: %v", workerID, job.ID, err)
 	}
@@ -921,6 +925,15 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		// of trying to build a prompt from a non-git label.
 		err = fmt.Errorf("%s job %d has no stored prompt (git_ref=%q); restart the daemon with 'roborev daemon restart'", job.JobType, job.ID, job.GitRef)
 	} else {
+		// CI rebuilds use the same default-branch config and template files as
+		// enqueue-time prompt construction.
+		pb, err = wp.promptBuilderForJob(ctx, checkout, job, cfg)
+		if err != nil {
+			log.Printf("[%s] Error configuring prompt builder: %v", workerID, err)
+			wp.failOrRetryContext(ctx, workerID, job, job.Agent, fmt.Sprintf("configure prompt builder: %v", err))
+			return
+		}
+
 		// Attributed jobs use the frozen plan verbatim, including an explicit
 		// empty value. Ordinary jobs keep the legacy config cascade.
 		if effectiveMinSeverity == "" && job.FrozenExperimentPlan == nil {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1189,6 +1189,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 					Output:           output,
 					Verdict:          agentReview.Verdict,
 					StructuredOutput: agentReview.StructuredOutput,
+					MinSeverity:      effectiveMinSeverity,
 				},
 			); err != nil {
 				log.Printf("[%s] Error storing review verdict: %v", workerID, err)

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -47,6 +47,34 @@ type workerTestContext struct {
 	Broadcaster Broadcaster
 }
 
+type structuredWorkerTestAgent struct {
+	name   string
+	result json.RawMessage
+}
+
+func (a *structuredWorkerTestAgent) Name() string { return a.name }
+func (a *structuredWorkerTestAgent) Review(
+	context.Context, string, string, string, io.Writer,
+) (string, error) {
+	return "", errors.New("unexpected prose review call")
+}
+
+func (a *structuredWorkerTestAgent) ReviewWithSchema(
+	_ context.Context,
+	_, _, _ string,
+	_ json.RawMessage,
+	_ io.Writer,
+) (json.RawMessage, error) {
+	return a.result, nil
+}
+
+func (a *structuredWorkerTestAgent) WithReasoning(agent.ReasoningLevel) agent.Agent {
+	return a
+}
+func (a *structuredWorkerTestAgent) WithAgentic(bool) agent.Agent { return a }
+func (a *structuredWorkerTestAgent) WithModel(string) agent.Agent { return a }
+func (a *structuredWorkerTestAgent) CommandLine() string          { return a.name }
+
 // newWorkerTestContext creates a DB, repo, broadcaster, and worker pool with
 // the given number of workers. Pass 0 to use the config default.
 func newWorkerTestContext(t *testing.T, workers int) *workerTestContext {
@@ -293,6 +321,51 @@ func TestWorkerPoolPendingCancellationAfterDBCancel(t *testing.T) {
 			return false
 		}, "Job should have been canceled immediately on registration")
 	}
+}
+
+func TestWorkerStoresFilteredStructuredCustomReview(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	agentName := "structured-review-test"
+	agent.Register(&structuredWorkerTestAgent{
+		name: agentName,
+		result: json.RawMessage(`{
+  "summary":"Review complete.",
+  "findings":[
+    {"severity":"high","problem":"State diverges.","fix":"Use one owner."},
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+  ]
+}`),
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tc.TmpDir, "custom-review.md"),
+		[]byte("Review state ownership."), 0o644,
+	))
+	cfg := config.DefaultConfig()
+	cfg.Review.Types = map[string]config.ReviewTypeSpec{
+		"custom-state": {Template: "custom-review.md"},
+	}
+	tc.Pool.cfgGetter = NewStaticConfig(cfg)
+
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createJobWithAgent(t, sha, agentName)
+	_, err := tc.DB.Exec(
+		`UPDATE review_jobs SET review_type = ?, min_severity = ? WHERE id = ?`,
+		"custom-state", "high", job.ID,
+	)
+	require.NoError(t, err)
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	stored, err := tc.DB.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	assert.Contains(t, stored.Output, "State diverges.")
+	assert.NotContains(t, stored.Output, "Name is vague.")
+	require.NotNil(t, stored.VerdictBool)
+	assert.Equal(t, 0, *stored.VerdictBool)
 }
 
 func TestCanceledJobCannotRerunUntilBlockedAgentExits(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1284,9 +1284,10 @@ func TestCaptureTokenUsageForSessionStopsRetryingAtContextDeadline(t *testing.T)
 	assert.False(t, usage.HasCost)
 }
 
-func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {
+func TestProcessJob_CIPrebuiltPromptDoesNotLoadRepoConfig(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	require.NoError(t, os.Mkdir(filepath.Join(tc.TmpDir, ".roborev.toml"), 0o755))
 
 	commit, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, sha, "Author", "Subject", time.Now())
 	require.NoError(t, err)
@@ -1306,6 +1307,7 @@ func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {
 		RepoID:         tc.Repo.ID,
 		CommitID:       commit.ID,
 		GitRef:         sha,
+		CIBaseBranch:   "main",
 		Agent:          agentName,
 		Prompt:         "review body\n<untrusted-pr-discussion>\n<comment>latest</comment>\n</untrusted-pr-discussion>\n",
 		PromptPrebuilt: true,
@@ -1377,6 +1379,63 @@ template = "default-review.md"
 	require.NoError(t, err)
 	assert.Contains(t, stored.Prompt, "Review the default branch contract.")
 	assert.Contains(t, stored.Output, "Default-branch review instructions loaded.")
+}
+
+func TestProcessJob_CIPromptFallbackKeepsDefaultRefAfterConfigParseError(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	agentName := "ci-custom-review-invalid-config-test"
+	agent.Register(&structuredWorkerTestAgent{
+		name: agentName,
+		result: json.RawMessage(`{
+  "summary":"Global review instructions loaded from the default branch.",
+  "findings":[]
+}`),
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	sha := tc.GitRepo.CommitFiles(map[string]string{
+		".roborev.toml":    "invalid = [\n",
+		"global-review.md": "Review the default branch global contract.\n",
+	}, "add invalid config and global review template")
+	tc.GitRepo.Run("update-ref", "refs/remotes/origin/main", sha)
+	tc.GitRepo.Run(
+		"symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main",
+	)
+	require.NoError(t, os.Remove(filepath.Join(tc.TmpDir, ".roborev.toml")))
+	require.NoError(t, os.Remove(filepath.Join(tc.TmpDir, "global-review.md")))
+
+	cfg := config.DefaultConfig()
+	cfg.Review.Types = map[string]config.ReviewTypeSpec{
+		"global-review": {Template: "global-review.md"},
+	}
+	tc.reconfigurePool(cfg)
+
+	commit, err := tc.DB.GetOrCreateCommit(
+		tc.Repo.ID, sha, "Author", "Subject", time.Now(),
+	)
+	require.NoError(t, err)
+	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+		RepoID:       tc.Repo.ID,
+		CommitID:     commit.ID,
+		GitRef:       sha,
+		CIBaseBranch: "main",
+		Agent:        agentName,
+		ReviewType:   "global-review",
+		JobType:      storage.JobTypeReview,
+		Source:       storage.JobSourceCI,
+	})
+	require.NoError(t, err)
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	stored, err := tc.DB.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	assert.Contains(t, stored.Prompt, "Review the default branch global contract.")
+	assert.Contains(t, stored.Output, "Global review instructions loaded from the default branch.")
 }
 
 func TestProcessJob_BuildsDirtyPromptFromPersistedDirtyFiles(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -374,7 +374,7 @@ func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
-  "summary":"Review complete.",
+  "summary":"High: no actionable findings.",
   "findings":[
     {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
   ]
@@ -387,10 +387,12 @@ func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
 	))
 	cfg := config.DefaultConfig()
 	cfg.ReviewMinSeverity = "high"
+	cfg.AutoClosePassingReviews = true
 	cfg.Review.Types = map[string]config.ReviewTypeSpec{
 		"custom-state": {Template: "custom-review.md"},
 	}
 	tc.Pool.cfgGetter = NewStaticConfig(cfg)
+	_, eventCh := tc.Broadcaster.Subscribe("")
 
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)
 	job := tc.createJobWithAgent(t, sha, agentName)
@@ -409,6 +411,13 @@ func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, stored.VerdictBool)
 	assert.Equal(t, 1, *stored.VerdictBool)
+	assert.True(t, stored.Closed)
+
+	_, ok := waitForEvent(t, eventCh, time.Second)
+	require.True(t, ok, "expected review.started event")
+	completed, ok := waitForEvent(t, eventCh, time.Second)
+	require.True(t, ok, "expected review.completed event")
+	assert.Equal(t, "P", completed.Verdict)
 }
 
 func TestCanceledJobCannotRerunUntilBlockedAgentExits(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1324,6 +1324,59 @@ func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {
 	assert.Equal(t, job.Prompt, updated.Prompt)
 }
 
+func TestProcessJob_CIPromptFallbackUsesBaseReviewTypeConfig(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	agentName := "ci-custom-review-config-test"
+	agent.Register(&structuredWorkerTestAgent{
+		name: agentName,
+		result: json.RawMessage(`{
+  "summary":"Base review instructions loaded.",
+  "findings":[]
+}`),
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	sha := tc.GitRepo.CommitFiles(map[string]string{
+		".roborev.toml": `[review.types.base-review]
+template = "base-review.md"
+`,
+		"base-review.md": "Review the base branch contract.\n",
+	}, "add base review type")
+	tc.GitRepo.Run("update-ref", "refs/remotes/origin/main", sha)
+	tc.GitRepo.Run(
+		"symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main",
+	)
+	require.NoError(t, os.Remove(filepath.Join(tc.TmpDir, ".roborev.toml")))
+	require.NoError(t, os.Remove(filepath.Join(tc.TmpDir, "base-review.md")))
+
+	commit, err := tc.DB.GetOrCreateCommit(
+		tc.Repo.ID, sha, "Author", "Subject", time.Now(),
+	)
+	require.NoError(t, err)
+	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+		RepoID:       tc.Repo.ID,
+		CommitID:     commit.ID,
+		GitRef:       sha,
+		CIBaseBranch: "main",
+		Agent:        agentName,
+		ReviewType:   "base-review",
+		JobType:      storage.JobTypeReview,
+		Source:       storage.JobSourceCI,
+	})
+	require.NoError(t, err)
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	stored, err := tc.DB.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	assert.Contains(t, stored.Prompt, "Review the base branch contract.")
+	assert.Contains(t, stored.Output, "Base review instructions loaded.")
+}
+
 func TestProcessJob_BuildsDirtyPromptFromPersistedDirtyFiles(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -368,6 +368,49 @@ func TestWorkerStoresFilteredStructuredCustomReview(t *testing.T) {
 	assert.Equal(t, 0, *stored.VerdictBool)
 }
 
+func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+	agentName := "structured-review-config-severity-test"
+	agent.Register(&structuredWorkerTestAgent{
+		name: agentName,
+		result: json.RawMessage(`{
+  "summary":"Review complete.",
+  "findings":[
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+  ]
+}`),
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tc.TmpDir, "custom-review.md"),
+		[]byte("Review state ownership."), 0o644,
+	))
+	cfg := config.DefaultConfig()
+	cfg.ReviewMinSeverity = "high"
+	cfg.Review.Types = map[string]config.ReviewTypeSpec{
+		"custom-state": {Template: "custom-review.md"},
+	}
+	tc.Pool.cfgGetter = NewStaticConfig(cfg)
+
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createJobWithAgent(t, sha, agentName)
+	_, err := tc.DB.Exec(
+		`UPDATE review_jobs SET review_type = ? WHERE id = ?`,
+		"custom-state", job.ID,
+	)
+	require.NoError(t, err)
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	stored, err := tc.DB.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stored.VerdictBool)
+	assert.Equal(t, 1, *stored.VerdictBool)
+}
+
 func TestCanceledJobCannotRerunUntilBlockedAgentExits(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	started := make(chan struct{})

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -412,6 +412,7 @@ func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
 	require.NotNil(t, stored.VerdictBool)
 	assert.Equal(t, 1, *stored.VerdictBool)
 	assert.True(t, stored.Closed)
+	assert.Equal(t, "high", stored.Job.MinSeverity)
 
 	_, ok := waitForEvent(t, eventCh, time.Second)
 	require.True(t, ok, "expected review.started event")

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -329,10 +329,11 @@ func TestWorkerStoresFilteredStructuredCustomReview(t *testing.T) {
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
+  "schema_version":1,
   "summary":"Review complete.",
   "findings":[
-    {"severity":"high","problem":"State diverges.","fix":"Use one owner."},
-    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+    {"severity":"high","problem":"State diverges.","fix":"Use one owner.","location":null},
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
   ]
 }`),
 	})
@@ -374,9 +375,10 @@ func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
-  "summary":"High: no actionable findings.",
+	  "schema_version":1,
+	  "summary":"High: no actionable findings.",
   "findings":[
-    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
   ]
 }`),
 	})
@@ -1332,6 +1334,7 @@ func TestProcessJob_CIPromptFallbackUsesDefaultBranchReviewTypeConfig(t *testing
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
+  "schema_version":1,
   "summary":"Default-branch review instructions loaded.",
   "findings":[]
 }`),
@@ -1387,6 +1390,7 @@ func TestProcessJob_CIPromptFallbackKeepsDefaultRefAfterConfigParseError(t *test
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
+  "schema_version":1,
   "summary":"Global review instructions loaded from the default branch.",
   "findings":[]
 }`),

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1324,30 +1324,32 @@ func TestProcessJob_UsesStoredReviewPromptOverride(t *testing.T) {
 	assert.Equal(t, job.Prompt, updated.Prompt)
 }
 
-func TestProcessJob_CIPromptFallbackUsesBaseReviewTypeConfig(t *testing.T) {
+func TestProcessJob_CIPromptFallbackUsesDefaultBranchReviewTypeConfig(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
-	agentName := "ci-custom-review-config-test"
+	agentName := "ci-custom-review-default-config-test"
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
-  "summary":"Base review instructions loaded.",
+  "summary":"Default-branch review instructions loaded.",
   "findings":[]
 }`),
 	})
 	t.Cleanup(func() { agent.Unregister(agentName) })
 
+	releaseSHA := testutil.GetHeadSHA(t, tc.TmpDir)
 	sha := tc.GitRepo.CommitFiles(map[string]string{
-		".roborev.toml": `[review.types.base-review]
-template = "base-review.md"
+		".roborev.toml": `[review.types.default-review]
+template = "default-review.md"
 `,
-		"base-review.md": "Review the base branch contract.\n",
+		"default-review.md": "Review the default branch contract.\n",
 	}, "add base review type")
 	tc.GitRepo.Run("update-ref", "refs/remotes/origin/main", sha)
+	tc.GitRepo.Run("update-ref", "refs/remotes/origin/release/2.0", releaseSHA)
 	tc.GitRepo.Run(
 		"symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main",
 	)
 	require.NoError(t, os.Remove(filepath.Join(tc.TmpDir, ".roborev.toml")))
-	require.NoError(t, os.Remove(filepath.Join(tc.TmpDir, "base-review.md")))
+	require.NoError(t, os.Remove(filepath.Join(tc.TmpDir, "default-review.md")))
 
 	commit, err := tc.DB.GetOrCreateCommit(
 		tc.Repo.ID, sha, "Author", "Subject", time.Now(),
@@ -1357,9 +1359,9 @@ template = "base-review.md"
 		RepoID:       tc.Repo.ID,
 		CommitID:     commit.ID,
 		GitRef:       sha,
-		CIBaseBranch: "main",
+		CIBaseBranch: "release/2.0",
 		Agent:        agentName,
-		ReviewType:   "base-review",
+		ReviewType:   "default-review",
 		JobType:      storage.JobTypeReview,
 		Source:       storage.JobSourceCI,
 	})
@@ -1373,8 +1375,8 @@ template = "base-review.md"
 	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
 	stored, err := tc.DB.GetReviewByJobID(job.ID)
 	require.NoError(t, err)
-	assert.Contains(t, stored.Prompt, "Review the base branch contract.")
-	assert.Contains(t, stored.Output, "Base review instructions loaded.")
+	assert.Contains(t, stored.Prompt, "Review the default branch contract.")
+	assert.Contains(t, stored.Output, "Default-branch review instructions loaded.")
 }
 
 func TestProcessJob_BuildsDirtyPromptFromPersistedDirtyFiles(t *testing.T) {

--- a/internal/git/checkout_metadata.go
+++ b/internal/git/checkout_metadata.go
@@ -20,10 +20,17 @@ type CheckoutMetadata struct {
 // ReadCheckoutMetadata reads checkout identity with go-git. It supports plain
 // repositories and linked worktrees, including their separate git and common
 // directories.
-func ReadCheckoutMetadata(repoPath string) (CheckoutMetadata, error) {
+func ReadCheckoutMetadata(repoPath string) (metadata CheckoutMetadata, err error) {
 	repo, err := openGoGitRepository(repoPath)
 	if err != nil {
 		return CheckoutMetadata{}, fmt.Errorf("open repository: %w", err)
+	}
+	if closer, ok := repo.Storer.(interface{ Close() error }); ok {
+		defer func() {
+			if closeErr := closer.Close(); closeErr != nil && err == nil {
+				err = fmt.Errorf("close repository: %w", closeErr)
+			}
+		}()
 	}
 	worktree, err := repo.Worktree()
 	if err != nil {

--- a/internal/git/checkout_metadata.go
+++ b/internal/git/checkout_metadata.go
@@ -1,0 +1,91 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CheckoutMetadata describes the repository state needed to identify a
+// checkout without spawning git.
+type CheckoutMetadata struct {
+	WorktreeRoot string
+	GitDir       string
+	CommonDir    string
+	Head         string
+	Branch       string
+}
+
+// ReadCheckoutMetadata reads checkout identity with go-git. It supports plain
+// repositories and linked worktrees, including their separate git and common
+// directories.
+func ReadCheckoutMetadata(repoPath string) (CheckoutMetadata, error) {
+	repo, err := openGoGitRepository(repoPath)
+	if err != nil {
+		return CheckoutMetadata{}, fmt.Errorf("open repository: %w", err)
+	}
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return CheckoutMetadata{}, fmt.Errorf("open worktree: %w", err)
+	}
+	root := filepath.Clean(worktree.Filesystem.Root())
+	gitDir, commonDir, err := checkoutGitDirs(root)
+	if err != nil {
+		return CheckoutMetadata{}, err
+	}
+	head, err := repo.Head()
+	if err != nil {
+		return CheckoutMetadata{}, fmt.Errorf("read HEAD: %w", err)
+	}
+	branch := ""
+	if head.Name().IsBranch() {
+		branch = head.Name().Short()
+	}
+	return CheckoutMetadata{
+		WorktreeRoot: root,
+		GitDir:       gitDir,
+		CommonDir:    commonDir,
+		Head:         head.Hash().String(),
+		Branch:       branch,
+	}, nil
+}
+
+func checkoutGitDirs(worktreeRoot string) (string, string, error) {
+	dotGit := filepath.Join(worktreeRoot, ".git")
+	info, err := os.Stat(dotGit)
+	if err != nil {
+		return "", "", fmt.Errorf("stat git directory: %w", err)
+	}
+	if info.IsDir() {
+		return dotGit, dotGit, nil
+	}
+
+	data, err := os.ReadFile(dotGit)
+	if err != nil {
+		return "", "", fmt.Errorf("read git directory file: %w", err)
+	}
+	gitDirText, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir:")
+	if !ok || strings.TrimSpace(gitDirText) == "" {
+		return "", "", fmt.Errorf("invalid git directory file %s", dotGit)
+	}
+	gitDir := filepath.Clean(strings.TrimSpace(gitDirText))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreeRoot, gitDir)
+	}
+	commonDir := gitDir
+	data, err = os.ReadFile(filepath.Join(gitDir, "commondir"))
+	switch {
+	case err == nil:
+		commonDir = filepath.Clean(strings.TrimSpace(string(data)))
+		if commonDir == "." || commonDir == "" {
+			commonDir = gitDir
+		} else if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(gitDir, commonDir)
+		}
+	case os.IsNotExist(err):
+	default:
+		return "", "", fmt.Errorf("read common git directory: %w", err)
+	}
+	return filepath.Clean(gitDir), filepath.Clean(commonDir), nil
+}

--- a/internal/git/checkout_metadata.go
+++ b/internal/git/checkout_metadata.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 // CheckoutMetadata describes the repository state needed to identify a
@@ -21,17 +24,15 @@ type CheckoutMetadata struct {
 // repositories and linked worktrees, including their separate git and common
 // directories.
 func ReadCheckoutMetadata(repoPath string) (metadata CheckoutMetadata, err error) {
-	repo, err := openGoGitRepository(repoPath)
+	// Open linked worktree and common-dir storage separately. go-git's
+	// EnableDotGitCommonDir path leaves the commondir file locked on Windows.
+	repo, err := gogit.PlainOpenWithOptions(repoPath, &gogit.PlainOpenOptions{
+		DetectDotGit: true,
+	})
 	if err != nil {
 		return CheckoutMetadata{}, fmt.Errorf("open repository: %w", err)
 	}
-	if closer, ok := repo.Storer.(interface{ Close() error }); ok {
-		defer func() {
-			if closeErr := closer.Close(); closeErr != nil && err == nil {
-				err = fmt.Errorf("close repository: %w", closeErr)
-			}
-		}()
-	}
+	defer closeCheckoutRepository(repo, &err)
 	worktree, err := repo.Worktree()
 	if err != nil {
 		return CheckoutMetadata{}, fmt.Errorf("open worktree: %w", err)
@@ -41,13 +42,27 @@ func ReadCheckoutMetadata(repoPath string) (metadata CheckoutMetadata, err error
 	if err != nil {
 		return CheckoutMetadata{}, err
 	}
-	head, err := repo.Head()
+	head, err := repo.Reference(plumbing.HEAD, false)
 	if err != nil {
 		return CheckoutMetadata{}, fmt.Errorf("read HEAD: %w", err)
 	}
 	branch := ""
-	if head.Name().IsBranch() {
-		branch = head.Name().Short()
+	if head.Type() == plumbing.SymbolicReference {
+		if head.Target().IsBranch() {
+			branch = head.Target().Short()
+		}
+		refRepo := repo
+		if gitDir != commonDir {
+			refRepo, err = gogit.PlainOpen(commonDir)
+			if err != nil {
+				return CheckoutMetadata{}, fmt.Errorf("open common repository: %w", err)
+			}
+			defer closeCheckoutRepository(refRepo, &err)
+		}
+		head, err = refRepo.Reference(head.Target(), true)
+		if err != nil {
+			return CheckoutMetadata{}, fmt.Errorf("resolve HEAD: %w", err)
+		}
 	}
 	return CheckoutMetadata{
 		WorktreeRoot: root,
@@ -56,6 +71,16 @@ func ReadCheckoutMetadata(repoPath string) (metadata CheckoutMetadata, err error
 		Head:         head.Hash().String(),
 		Branch:       branch,
 	}, nil
+}
+
+func closeCheckoutRepository(repo *gogit.Repository, readErr *error) {
+	closer, ok := repo.Storer.(interface{ Close() error })
+	if !ok {
+		return
+	}
+	if err := closer.Close(); err != nil && *readErr == nil {
+		*readErr = fmt.Errorf("close repository: %w", err)
+	}
 }
 
 func checkoutGitDirs(worktreeRoot string) (string, string, error) {

--- a/internal/git/checkout_metadata_test.go
+++ b/internal/git/checkout_metadata_test.go
@@ -1,0 +1,46 @@
+package git
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadCheckoutMetadataWithoutGitExecutable(t *testing.T) {
+	assert := assert.New(t)
+	repo := NewTestRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+	wantHead := repo.HeadSHA()
+	wantBranch := strings.TrimSpace(repo.Run("branch", "--show-current"))
+	t.Setenv("PATH", t.TempDir())
+
+	metadata, err := ReadCheckoutMetadata(repo.Dir)
+	require.NoError(t, err)
+
+	assert.Equal(cleanEvalPath(repo.Dir), cleanEvalPath(metadata.WorktreeRoot))
+	assert.Equal(filepath.Join(metadata.WorktreeRoot, ".git"), metadata.GitDir)
+	assert.Equal(metadata.GitDir, metadata.CommonDir)
+	assert.Equal(wantHead, metadata.Head)
+	assert.Equal(wantBranch, metadata.Branch)
+}
+
+func TestReadCheckoutMetadataLinkedWorktreeWithoutGitExecutable(t *testing.T) {
+	assert := assert.New(t)
+	repo := NewTestRepo(t)
+	repo.CommitFile("base.txt", "base", "base")
+	worktree := repo.AddWorktree("feature/metadata")
+	wantHead := strings.TrimSpace(worktree.Run("rev-parse", "HEAD"))
+	t.Setenv("PATH", t.TempDir())
+
+	metadata, err := ReadCheckoutMetadata(worktree.Dir)
+	require.NoError(t, err)
+
+	assert.Equal(cleanEvalPath(worktree.Dir), cleanEvalPath(metadata.WorktreeRoot))
+	assert.Equal(wantHead, metadata.Head)
+	assert.Equal("feature/metadata", metadata.Branch)
+	assert.NotEqual(metadata.GitDir, metadata.CommonDir)
+	assert.Equal(cleanEvalPath(filepath.Join(repo.Dir, ".git")), cleanEvalPath(metadata.CommonDir))
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1308,6 +1308,53 @@ func ReadFile(repoPath, sha, filePath string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
+// RefFile is a blob read from a commit. Symlink is true when the tree entry
+// stores a link target instead of regular file contents.
+type RefFile struct {
+	Data    []byte
+	Symlink bool
+}
+
+// ReadRefFile reads a file and its tree mode at a specific commit.
+func ReadRefFile(repoPath, sha, filePath string) (RefFile, error) {
+	cmd := newGitCmd("ls-tree", "-z", sha, "--", filePath)
+	cmd.Dir = repoPath
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return RefFile{}, fmt.Errorf(
+			"git ls-tree %s:%s: %s", sha, filePath, stderr.String(),
+		)
+	}
+	entry := bytes.TrimSuffix(stdout.Bytes(), []byte{0})
+	metadata, entryPath, ok := bytes.Cut(entry, []byte{'\t'})
+	fields := bytes.Fields(metadata)
+	if !ok || len(fields) != 3 || string(entryPath) != filePath ||
+		string(fields[1]) != "blob" {
+		return RefFile{}, fmt.Errorf(
+			"git path %s:%s is not a file", sha, filePath,
+		)
+	}
+	symlink := string(fields[0]) == "120000"
+
+	cmd = newGitCmd("cat-file", "blob", string(fields[2]))
+	cmd.Dir = repoPath
+	stdout.Reset()
+	stderr.Reset()
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return RefFile{}, fmt.Errorf(
+			"git cat-file %s:%s: %s", sha, filePath, stderr.String(),
+		)
+	}
+	return RefFile{
+		Data:    append([]byte(nil), stdout.Bytes()...),
+		Symlink: symlink,
+	}, nil
+}
+
 // IsMissingPathError reports whether a ReadFile error means the path is
 // absent at that ref rather than a git failure. git show emits these two
 // messages for a missing path:

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -23,11 +23,6 @@ these severity values: critical, high, medium, or low. Do not omit a real
 finding because of the configured severity threshold; Roborev applies that
 threshold after receiving the structured result.`
 
-// customReviewContextReserve guarantees that custom rubrics cannot consume the
-// entire prompt and leave no room for commit/range metadata plus the reviewed
-// diff or its snapshot reference.
-const customReviewContextReserve = 16 * 1024
-
 type customReviewTemplateData struct {
 	ReviewType string
 	Includes   map[string]string
@@ -52,19 +47,9 @@ func (b *Builder) resolveSystemPrompt(
 			"custom review type %q is not configured", reviewType,
 		)
 	}
-	customLimit := limit - customReviewContextReserve
-	if customLimit <= 0 {
-		return "", true, fmt.Errorf(
-			"custom review prompt limit is %d bytes; at least %d bytes must be reserved for review context",
-			limit, customReviewContextReserve,
-		)
-	}
-
-	remaining := customLimit
+	remaining := limit
 	read := func(filePath string) (string, error) {
-		data, readErr := b.readCustomReviewFile(
-			filePath, resolved.RepoDefined, remaining,
-		)
+		data, readErr := b.readCustomReviewFile(filePath, remaining)
 		if readErr != nil {
 			return "", readErr
 		}
@@ -75,8 +60,7 @@ func (b *Builder) resolveSystemPrompt(
 	templateText, err := read(resolved.Spec.Template)
 	if err != nil {
 		return "", true, fmt.Errorf(
-			"review type %q template after reserving %d bytes for review context: %w",
-			reviewType, customReviewContextReserve, err,
+			"review type %q template: %w", reviewType, err,
 		)
 	}
 	includes := make(map[string]string, len(resolved.Spec.Includes))
@@ -84,8 +68,8 @@ func (b *Builder) resolveSystemPrompt(
 		contents, includeErr := read(filePath)
 		if includeErr != nil {
 			return "", true, fmt.Errorf(
-				"review type %q include %q after reserving %d bytes for review context: %w",
-				reviewType, name, customReviewContextReserve, includeErr,
+				"review type %q include %q: %w",
+				reviewType, name, includeErr,
 			)
 		}
 		includes[name] = contents
@@ -110,11 +94,10 @@ func (b *Builder) resolveSystemPrompt(
 	}
 	result := strings.TrimSpace(rendered.String()) +
 		customReviewOutputInstruction
-	if len(result)+1 > customLimit {
+	if len(result)+1 > limit {
 		return "", true, fmt.Errorf(
-			"review type %q rendered prompt is %d bytes but only %d bytes are available after reserving %d bytes for review context",
-			reviewType, len(result)+1, customLimit,
-			customReviewContextReserve,
+			"review type %q rendered prompt is %d bytes but prompt limit is %d bytes",
+			reviewType, len(result)+1, limit,
 		)
 	}
 	return result, true, nil
@@ -132,49 +115,12 @@ func (b *Builder) resolveRepoConfig() (*config.RepoConfig, error) {
 
 func (b *Builder) readCustomReviewFile(
 	filePath string,
-	repoDefined bool,
 	limit int,
 ) ([]byte, error) {
 	filePath = strings.TrimSpace(filePath)
 	if limit <= 0 {
 		return nil, fmt.Errorf("custom review files exceed prompt limit")
 	}
-	if repoDefined {
-		if filepath.IsAbs(filePath) || filePath == "~" ||
-			strings.HasPrefix(filePath, "~/") ||
-			strings.HasPrefix(filePath, `~\`) {
-			return nil, fmt.Errorf(
-				"repository-defined path %q must be relative to the repository root",
-				filePath,
-			)
-		}
-		clean := path.Clean(filepath.ToSlash(filePath))
-		if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
-			return nil, fmt.Errorf(
-				"repository-defined path %q escapes the repository root",
-				filePath,
-			)
-		}
-		if b.repoCfgRef != "" {
-			data, err := git.ReadFile(b.repoPath, b.repoCfgRef, clean)
-			if err != nil {
-				return nil, err
-			}
-			return enforceCustomFileLimit(data, limit)
-		}
-		root, err := os.OpenRoot(b.repoPath)
-		if err != nil {
-			return nil, err
-		}
-		defer root.Close()
-		file, err := root.Open(filepath.FromSlash(clean))
-		if err != nil {
-			return nil, err
-		}
-		defer file.Close()
-		return readCustomFile(file, limit)
-	}
-
 	resolvedPath := filePath
 	if filePath == "~" || strings.HasPrefix(filePath, "~/") ||
 		strings.HasPrefix(filePath, `~\`) {
@@ -185,17 +131,14 @@ func (b *Builder) readCustomReviewFile(
 		resolvedPath = filepath.Join(home, strings.TrimLeft(filePath[1:], `/\`))
 	} else if !filepath.IsAbs(filePath) && b.repoCfgRef != "" {
 		clean := path.Clean(filepath.ToSlash(filePath))
-		if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
-			return nil, fmt.Errorf(
-				"global repository-relative path %q escapes the repository root",
-				filePath,
-			)
+		if clean != "." && clean != ".." && !strings.HasPrefix(clean, "../") {
+			data, err := git.ReadFile(b.repoPath, b.repoCfgRef, clean)
+			if err != nil {
+				return nil, err
+			}
+			return enforceCustomFileLimit(data, limit)
 		}
-		data, err := git.ReadFile(b.repoPath, b.repoCfgRef, clean)
-		if err != nil {
-			return nil, err
-		}
-		return enforceCustomFileLimit(data, limit)
+		resolvedPath = filepath.Join(b.repoPath, filePath)
 	} else if !filepath.IsAbs(filePath) {
 		resolvedPath = filepath.Join(b.repoPath, filePath)
 	}

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -23,6 +23,11 @@ these severity values: critical, high, medium, or low. Do not omit a real
 finding because of the configured severity threshold; Roborev applies that
 threshold after receiving the structured result.`
 
+// customReviewContextReserve guarantees that custom rubrics cannot consume the
+// entire prompt and leave no room for commit/range metadata plus the reviewed
+// diff or its snapshot reference.
+const customReviewContextReserve = 16 * 1024
+
 type customReviewTemplateData struct {
 	ReviewType string
 	Includes   map[string]string
@@ -43,10 +48,19 @@ func (b *Builder) resolveSystemPrompt(
 		reviewType, repoCfg, b.globalCfg,
 	)
 	if !ok {
-		return GetSystemPrompt(agentName, promptType), false, nil
+		return "", true, fmt.Errorf(
+			"custom review type %q is not configured", reviewType,
+		)
+	}
+	customLimit := limit - customReviewContextReserve
+	if customLimit <= 0 {
+		return "", true, fmt.Errorf(
+			"custom review prompt limit is %d bytes; at least %d bytes must be reserved for review context",
+			limit, customReviewContextReserve,
+		)
 	}
 
-	remaining := limit
+	remaining := customLimit
 	read := func(filePath string) (string, error) {
 		data, readErr := b.readCustomReviewFile(
 			filePath, resolved.RepoDefined, remaining,
@@ -61,7 +75,8 @@ func (b *Builder) resolveSystemPrompt(
 	templateText, err := read(resolved.Spec.Template)
 	if err != nil {
 		return "", true, fmt.Errorf(
-			"review type %q template: %w", reviewType, err,
+			"review type %q template after reserving %d bytes for review context: %w",
+			reviewType, customReviewContextReserve, err,
 		)
 	}
 	includes := make(map[string]string, len(resolved.Spec.Includes))
@@ -69,8 +84,8 @@ func (b *Builder) resolveSystemPrompt(
 		contents, includeErr := read(filePath)
 		if includeErr != nil {
 			return "", true, fmt.Errorf(
-				"review type %q include %q: %w",
-				reviewType, name, includeErr,
+				"review type %q include %q after reserving %d bytes for review context: %w",
+				reviewType, name, customReviewContextReserve, includeErr,
 			)
 		}
 		includes[name] = contents
@@ -95,10 +110,11 @@ func (b *Builder) resolveSystemPrompt(
 	}
 	result := strings.TrimSpace(rendered.String()) +
 		customReviewOutputInstruction
-	if len(result)+1 > limit {
+	if len(result)+1 > customLimit {
 		return "", true, fmt.Errorf(
-			"review type %q rendered prompt is %d bytes but prompt limit is %d bytes",
-			reviewType, len(result)+1, limit,
+			"review type %q rendered prompt is %d bytes but only %d bytes are available after reserving %d bytes for review context",
+			reviewType, len(result)+1, customLimit,
+			customReviewContextReserve,
 		)
 	}
 	return result, true, nil
@@ -167,6 +183,19 @@ func (b *Builder) readCustomReviewFile(
 			return nil, err
 		}
 		resolvedPath = filepath.Join(home, strings.TrimLeft(filePath[1:], `/\`))
+	} else if !filepath.IsAbs(filePath) && b.repoCfgRef != "" {
+		clean := path.Clean(filepath.ToSlash(filePath))
+		if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+			return nil, fmt.Errorf(
+				"global repository-relative path %q escapes the repository root",
+				filePath,
+			)
+		}
+		data, err := git.ReadFile(b.repoPath, b.repoCfgRef, clean)
+		if err != nil {
+			return nil, err
+		}
+		return enforceCustomFileLimit(data, limit)
 	} else if !filepath.IsAbs(filePath) {
 		resolvedPath = filepath.Join(b.repoPath, filePath)
 	}

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -132,17 +132,54 @@ func (b *Builder) readCustomReviewFile(
 	} else if !filepath.IsAbs(filePath) && b.repoCfgRef != "" {
 		clean := path.Clean(filepath.ToSlash(filePath))
 		if clean != "." && clean != ".." && !strings.HasPrefix(clean, "../") {
-			data, err := git.ReadFile(b.repoPath, b.repoCfgRef, clean)
-			if err != nil {
-				return nil, err
-			}
-			return enforceCustomFileLimit(data, limit)
+			return b.readCustomReviewRefFile(clean, limit)
 		}
 		resolvedPath = filepath.Join(b.repoPath, filePath)
 	} else if !filepath.IsAbs(filePath) {
 		resolvedPath = filepath.Join(b.repoPath, filePath)
 	}
-	file, err := os.Open(resolvedPath)
+	return readCustomReviewFilesystemFile(resolvedPath, limit)
+}
+
+func (b *Builder) readCustomReviewRefFile(
+	filePath string,
+	limit int,
+) ([]byte, error) {
+	seen := make(map[string]struct{})
+	for {
+		if _, ok := seen[filePath]; ok {
+			return nil, fmt.Errorf("custom review file symlink cycle at %q", filePath)
+		}
+		seen[filePath] = struct{}{}
+
+		entry, err := git.ReadRefFile(b.repoPath, b.repoCfgRef, filePath)
+		if err != nil {
+			return nil, err
+		}
+		if !entry.Symlink {
+			return enforceCustomFileLimit(entry.Data, limit)
+		}
+
+		linkTarget := string(entry.Data)
+		if path.IsAbs(filepath.ToSlash(linkTarget)) || filepath.IsAbs(linkTarget) {
+			return readCustomReviewFilesystemFile(linkTarget, limit)
+		}
+		filesystemTarget := filepath.Clean(filepath.Join(
+			b.repoPath,
+			filepath.FromSlash(path.Dir(filePath)),
+			linkTarget,
+		))
+		relativeTarget, relErr := filepath.Rel(b.repoPath, filesystemTarget)
+		if relErr != nil || relativeTarget == ".." ||
+			strings.HasPrefix(relativeTarget, ".."+string(filepath.Separator)) {
+			return readCustomReviewFilesystemFile(filesystemTarget, limit)
+		}
+		filePath = filepath.ToSlash(relativeTarget)
+	}
+}
+
+func readCustomReviewFilesystemFile(filePath string, limit int) ([]byte, error) {
+	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -152,22 +152,48 @@ func (b *Builder) readCustomReviewRefFile(
 		}
 		seen[filePath] = struct{}{}
 
-		entry, err := git.ReadRefFile(b.repoPath, b.repoCfgRef, filePath)
-		if err != nil {
-			return nil, err
-		}
-		if !entry.Symlink {
-			return enforceCustomFileLimit(entry.Data, limit)
+		parts := strings.Split(filePath, "/")
+		var entry git.RefFile
+		var linkPath string
+		var remaining string
+		for i := range parts {
+			candidate := path.Join(parts[:i+1]...)
+			candidateEntry, err := git.ReadRefFile(
+				b.repoPath, b.repoCfgRef, candidate,
+			)
+			if err != nil {
+				if i == len(parts)-1 {
+					return nil, err
+				}
+				continue
+			}
+			if !candidateEntry.Symlink {
+				if i != len(parts)-1 {
+					return nil, fmt.Errorf(
+						"git path %s:%s is not a directory",
+						b.repoCfgRef, candidate,
+					)
+				}
+				return enforceCustomFileLimit(candidateEntry.Data, limit)
+			}
+			entry = candidateEntry
+			linkPath = candidate
+			remaining = path.Join(parts[i+1:]...)
+			break
 		}
 
 		linkTarget := string(entry.Data)
 		if path.IsAbs(filepath.ToSlash(linkTarget)) || filepath.IsAbs(linkTarget) {
-			return readCustomReviewFilesystemFile(linkTarget, limit)
+			return readCustomReviewFilesystemFile(
+				filepath.Join(linkTarget, filepath.FromSlash(remaining)),
+				limit,
+			)
 		}
 		filesystemTarget := filepath.Clean(filepath.Join(
 			b.repoPath,
-			filepath.FromSlash(path.Dir(filePath)),
+			filepath.FromSlash(path.Dir(linkPath)),
 			linkTarget,
+			filepath.FromSlash(remaining),
 		))
 		relativeTarget, relErr := filepath.Rel(b.repoPath, filesystemTarget)
 		if relErr != nil || relativeTarget == ".." ||

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -121,7 +121,7 @@ func (b *Builder) resolveSystemPrompt(
 }
 
 func (b *Builder) resolveRepoConfig() (*config.RepoConfig, error) {
-	if b.repoCfg != nil {
+	if b.repoCfgSet {
 		return b.repoCfg, nil
 	}
 	if b.repoCfgRef != "" {

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -1,0 +1,197 @@
+package prompt
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/git"
+)
+
+const customReviewOutputInstruction = `
+
+Roborev will constrain the final response with a JSON Schema. Return a concise
+summary and every actionable finding. Each finding must include its severity,
+problem, and recommended fix; include a location when one is known. Use only
+these severity values: critical, high, medium, or low. Do not omit a real
+finding because of the configured severity threshold; Roborev applies that
+threshold after receiving the structured result.`
+
+type customReviewTemplateData struct {
+	ReviewType string
+	Includes   map[string]string
+}
+
+func (b *Builder) resolveSystemPrompt(
+	agentName, reviewType, promptType string,
+	limit int,
+) (string, bool, error) {
+	if config.IsBuiltInReviewType(reviewType) {
+		return GetSystemPrompt(agentName, promptType), false, nil
+	}
+	repoCfg, err := b.resolveRepoConfig()
+	if err != nil {
+		return "", false, err
+	}
+	resolved, ok := config.ResolveCustomReviewTypeFromConfig(
+		reviewType, repoCfg, b.globalCfg,
+	)
+	if !ok {
+		return GetSystemPrompt(agentName, promptType), false, nil
+	}
+
+	remaining := limit
+	read := func(filePath string) (string, error) {
+		data, readErr := b.readCustomReviewFile(
+			filePath, resolved.RepoDefined, remaining,
+		)
+		if readErr != nil {
+			return "", readErr
+		}
+		remaining -= len(data)
+		return string(data), nil
+	}
+
+	templateText, err := read(resolved.Spec.Template)
+	if err != nil {
+		return "", true, fmt.Errorf(
+			"review type %q template: %w", reviewType, err,
+		)
+	}
+	includes := make(map[string]string, len(resolved.Spec.Includes))
+	for name, filePath := range resolved.Spec.Includes {
+		contents, includeErr := read(filePath)
+		if includeErr != nil {
+			return "", true, fmt.Errorf(
+				"review type %q include %q: %w",
+				reviewType, name, includeErr,
+			)
+		}
+		includes[name] = contents
+	}
+
+	tmpl, err := template.New(reviewType).
+		Option("missingkey=error").
+		Parse(templateText)
+	if err != nil {
+		return "", true, fmt.Errorf(
+			"review type %q parse template: %w", reviewType, err,
+		)
+	}
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, customReviewTemplateData{
+		ReviewType: reviewType,
+		Includes:   includes,
+	}); err != nil {
+		return "", true, fmt.Errorf(
+			"review type %q render template: %w", reviewType, err,
+		)
+	}
+	result := strings.TrimSpace(rendered.String()) +
+		customReviewOutputInstruction
+	if len(result)+1 > limit {
+		return "", true, fmt.Errorf(
+			"review type %q rendered prompt is %d bytes but prompt limit is %d bytes",
+			reviewType, len(result)+1, limit,
+		)
+	}
+	return result, true, nil
+}
+
+func (b *Builder) resolveRepoConfig() (*config.RepoConfig, error) {
+	if b.repoCfg != nil {
+		return b.repoCfg, nil
+	}
+	if b.repoCfgRef != "" {
+		return config.LoadRepoConfigFromRef(b.repoPath, b.repoCfgRef)
+	}
+	return config.LoadRepoConfig(b.repoPath)
+}
+
+func (b *Builder) readCustomReviewFile(
+	filePath string,
+	repoDefined bool,
+	limit int,
+) ([]byte, error) {
+	filePath = strings.TrimSpace(filePath)
+	if limit <= 0 {
+		return nil, fmt.Errorf("custom review files exceed prompt limit")
+	}
+	if repoDefined {
+		if filepath.IsAbs(filePath) || filePath == "~" ||
+			strings.HasPrefix(filePath, "~/") ||
+			strings.HasPrefix(filePath, `~\`) {
+			return nil, fmt.Errorf(
+				"repository-defined path %q must be relative to the repository root",
+				filePath,
+			)
+		}
+		clean := path.Clean(filepath.ToSlash(filePath))
+		if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+			return nil, fmt.Errorf(
+				"repository-defined path %q escapes the repository root",
+				filePath,
+			)
+		}
+		if b.repoCfgRef != "" {
+			data, err := git.ReadFile(b.repoPath, b.repoCfgRef, clean)
+			if err != nil {
+				return nil, err
+			}
+			return enforceCustomFileLimit(data, limit)
+		}
+		root, err := os.OpenRoot(b.repoPath)
+		if err != nil {
+			return nil, err
+		}
+		defer root.Close()
+		file, err := root.Open(filepath.FromSlash(clean))
+		if err != nil {
+			return nil, err
+		}
+		defer file.Close()
+		return readCustomFile(file, limit)
+	}
+
+	resolvedPath := filePath
+	if filePath == "~" || strings.HasPrefix(filePath, "~/") ||
+		strings.HasPrefix(filePath, `~\`) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		resolvedPath = filepath.Join(home, strings.TrimLeft(filePath[1:], `/\`))
+	} else if !filepath.IsAbs(filePath) {
+		resolvedPath = filepath.Join(b.repoPath, filePath)
+	}
+	file, err := os.Open(resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return readCustomFile(file, limit)
+}
+
+func readCustomFile(r io.Reader, limit int) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, int64(limit)+1))
+	if err != nil {
+		return nil, err
+	}
+	return enforceCustomFileLimit(data, limit)
+}
+
+func enforceCustomFileLimit(data []byte, limit int) ([]byte, error) {
+	if len(data) > limit {
+		return nil, fmt.Errorf(
+			"file is %d bytes but only %d bytes remain in the prompt limit",
+			len(data), limit,
+		)
+	}
+	return data, nil
+}

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -3,6 +3,7 @@ package prompt
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -103,6 +104,36 @@ func TestCustomReviewReadsGlobalRelativeFilesFromConfiguredRef(t *testing.T) {
 	assert.True(t, custom)
 	assert.Contains(t, got, "Trusted global rubric.")
 	assert.NotContains(t, got, "Untrusted working-tree rubric.")
+}
+
+func TestCustomReviewReadsExternalSymlinkFromConfiguredRef(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows")
+	}
+	repo := newTestRepo(t)
+	externalPath := filepath.Join(t.TempDir(), "review.tmpl")
+	require.NoError(t, os.WriteFile(externalPath, []byte("External rubric."), 0o644))
+	linkPath := filepath.Join(repo.dir, "review.tmpl")
+	linkTarget, err := filepath.Rel(filepath.Dir(linkPath), externalPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(linkTarget, linkPath))
+	repo.git("add", "review.tmpl")
+	repo.git("commit", "-m", "add external rubric link")
+	baseRef := repo.git("rev-parse", "HEAD")
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: "review.tmpl"},
+		},
+	}}
+
+	got, custom, err := NewBuilder(nil).
+		ForRepo(repo.dir, 0).
+		WithRepoConfig(repoCfg, baseRef).
+		resolveSystemPrompt("codex", "custom", "custom", MaxPromptSize)
+	require.NoError(t, err)
+	assert.True(t, custom)
+	assert.Contains(t, got, "External rubric.")
+	assert.NotContains(t, got, linkTarget)
 }
 
 func TestCustomReviewUsesExplicitNilRepoConfig(t *testing.T) {

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -1,0 +1,80 @@
+package prompt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
+)
+
+func TestCustomReviewTemplateRendersNamedIncludes(t *testing.T) {
+	repoPath := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, "review.tmpl"),
+		[]byte("Review type: {{ .ReviewType }}\n{{ index .Includes \"rubric\" }}"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, "rubric.md"),
+		[]byte("Find dangerous abstractions."), 0o644,
+	))
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"thermonuclear": {
+				Template: "review.tmpl",
+				Includes: map[string]string{"rubric": "rubric.md"},
+			},
+		},
+	}}
+
+	got, err := NewBuilder(nil).
+		ForRepo(repoPath, 0).
+		WithRepoConfig(repoCfg, "").
+		BuildDirty("diff --git a/a.go b/a.go", 0, "codex", "thermonuclear", "high")
+	require.NoError(t, err)
+	assert.Contains(t, got, "Review type: thermonuclear")
+	assert.Contains(t, got, "Find dangerous abstractions.")
+	assert.Contains(t, got, "Roborev will constrain the final response with a JSON Schema")
+	assert.NotContains(t, got, "SEVERITY_THRESHOLD_MET")
+}
+
+func TestCustomReviewRejectsAbsoluteRepoPath(t *testing.T) {
+	repoPath := t.TempDir()
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: filepath.Join(repoPath, "review.tmpl")},
+		},
+	}}
+
+	_, err := NewBuilder(nil).
+		ForRepo(repoPath, 0).
+		WithRepoConfig(repoCfg, "").
+		BuildDirty("diff", 0, "codex", "custom", "")
+	require.ErrorContains(t, err, "must be relative to the repository root")
+}
+
+func TestCustomReviewReadsRepoFilesFromConfiguredRef(t *testing.T) {
+	repo := newTestRepo(t)
+	baseRef := repo.fastCommitFile(
+		"review.tmpl", "Trusted base rubric.", "add review rubric",
+	)
+	repo.writeFile("review.tmpl", "Untrusted working-tree rubric.")
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: "review.tmpl"},
+		},
+	}}
+
+	got, custom, err := NewBuilder(nil).
+		ForRepo(repo.dir, 0).
+		WithRepoConfig(repoCfg, baseRef).
+		resolveSystemPrompt("codex", "custom", "custom", MaxPromptSize)
+	require.NoError(t, err)
+	assert.True(t, custom)
+	assert.Contains(t, got, "Trusted base rubric.")
+	assert.NotContains(t, got, "Untrusted working-tree rubric.")
+}

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -102,6 +102,27 @@ func TestCustomReviewReadsGlobalRelativeFilesFromConfiguredRef(t *testing.T) {
 	assert.NotContains(t, got, "Untrusted working-tree rubric.")
 }
 
+func TestCustomReviewUsesExplicitNilRepoConfig(t *testing.T) {
+	repo := newTestRepo(t)
+	baseRef := repo.fastCommitFiles(map[string]string{
+		".roborev.toml": "invalid = [",
+		"review.tmpl":   "Trusted global rubric.",
+	}, "add global rubric")
+	globalCfg := &config.Config{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: "review.tmpl"},
+		},
+	}}
+
+	got, custom, err := NewBuilderWithConfig(nil, globalCfg).
+		ForRepo(repo.dir, 0).
+		WithRepoConfig(nil, baseRef).
+		resolveSystemPrompt("codex", "custom", "custom", MaxPromptSize)
+	require.NoError(t, err)
+	assert.True(t, custom)
+	assert.Contains(t, got, "Trusted global rubric.")
+}
+
 func TestCustomReviewMissingDefinitionFails(t *testing.T) {
 	_, _, err := NewBuilder(nil).
 		ForRepo(t.TempDir(), 0).

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -3,6 +3,7 @@ package prompt
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,4 +78,55 @@ func TestCustomReviewReadsRepoFilesFromConfiguredRef(t *testing.T) {
 	assert.True(t, custom)
 	assert.Contains(t, got, "Trusted base rubric.")
 	assert.NotContains(t, got, "Untrusted working-tree rubric.")
+}
+
+func TestCustomReviewReadsGlobalRelativeFilesFromConfiguredRef(t *testing.T) {
+	repo := newTestRepo(t)
+	baseRef := repo.fastCommitFile(
+		"review.tmpl", "Trusted global rubric.", "add global rubric",
+	)
+	repo.writeFile("review.tmpl", "Untrusted working-tree rubric.")
+	globalCfg := &config.Config{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: "review.tmpl"},
+		},
+	}}
+
+	got, custom, err := NewBuilderWithConfig(nil, globalCfg).
+		ForRepo(repo.dir, 0).
+		WithRepoConfig(nil, baseRef).
+		resolveSystemPrompt("codex", "custom", "custom", MaxPromptSize)
+	require.NoError(t, err)
+	assert.True(t, custom)
+	assert.Contains(t, got, "Trusted global rubric.")
+	assert.NotContains(t, got, "Untrusted working-tree rubric.")
+}
+
+func TestCustomReviewMissingDefinitionFails(t *testing.T) {
+	_, _, err := NewBuilder(nil).
+		ForRepo(t.TempDir(), 0).
+		WithRepoConfig(&config.RepoConfig{}, "").
+		resolveSystemPrompt("codex", "removed-type", "removed-type", MaxPromptSize)
+	require.ErrorContains(t, err, `custom review type "removed-type" is not configured`)
+}
+
+func TestCustomReviewReservesPromptSpaceForReviewContext(t *testing.T) {
+	repoPath := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, "review.tmpl"),
+		[]byte(strings.Repeat("x", 1024)), 0o644,
+	))
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: "review.tmpl"},
+		},
+	}}
+
+	_, _, err := NewBuilder(nil).
+		ForRepo(repoPath, 0).
+		WithRepoConfig(repoCfg, "").
+		resolveSystemPrompt(
+			"codex", "custom", "custom", customReviewContextReserve+512,
+		)
+	require.ErrorContains(t, err, "review context")
 }

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -136,6 +136,34 @@ func TestCustomReviewReadsExternalSymlinkFromConfiguredRef(t *testing.T) {
 	assert.NotContains(t, got, linkTarget)
 }
 
+func TestCustomReviewReadsThroughDirectorySymlinkFromConfiguredRef(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not reliably available on Windows")
+	}
+	repo := newTestRepo(t)
+	require.NoError(t, os.Mkdir(filepath.Join(repo.dir, "shared"), 0o755))
+	repo.writeFile("shared/review.tmpl", "Trusted directory-link rubric.")
+	require.NoError(t, os.Symlink("shared", filepath.Join(repo.dir, "reviews")))
+	repo.git("add", "shared/review.tmpl", "reviews")
+	repo.git("commit", "-m", "add linked review directory")
+	baseRef := repo.git("rev-parse", "HEAD")
+	repo.writeFile("shared/review.tmpl", "Working-tree directory-link rubric.")
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: "reviews/review.tmpl"},
+		},
+	}}
+
+	got, custom, err := NewBuilder(nil).
+		ForRepo(repo.dir, 0).
+		WithRepoConfig(repoCfg, baseRef).
+		resolveSystemPrompt("codex", "custom", "custom", MaxPromptSize)
+	require.NoError(t, err)
+	assert.True(t, custom)
+	assert.Contains(t, got, "Trusted directory-link rubric.")
+	assert.NotContains(t, got, "Working-tree directory-link rubric.")
+}
+
 func TestCustomReviewUsesExplicitNilRepoConfig(t *testing.T) {
 	repo := newTestRepo(t)
 	baseRef := repo.fastCommitFiles(map[string]string{

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -43,19 +43,22 @@ func TestCustomReviewTemplateRendersNamedIncludes(t *testing.T) {
 	assert.NotContains(t, got, "SEVERITY_THRESHOLD_MET")
 }
 
-func TestCustomReviewRejectsAbsoluteRepoPath(t *testing.T) {
+func TestCustomReviewReadsAbsoluteRepoConfiguredPath(t *testing.T) {
 	repoPath := t.TempDir()
+	templatePath := filepath.Join(t.TempDir(), "review.tmpl")
+	require.NoError(t, os.WriteFile(templatePath, []byte("External rubric."), 0o644))
 	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
 		Types: map[string]config.ReviewTypeSpec{
-			"custom": {Template: filepath.Join(repoPath, "review.tmpl")},
+			"custom": {Template: templatePath},
 		},
 	}}
 
-	_, err := NewBuilder(nil).
+	got, err := NewBuilder(nil).
 		ForRepo(repoPath, 0).
 		WithRepoConfig(repoCfg, "").
 		BuildDirty("diff", 0, "codex", "custom", "")
-	require.ErrorContains(t, err, "must be relative to the repository root")
+	require.NoError(t, err)
+	assert.Contains(t, got, "External rubric.")
 }
 
 func TestCustomReviewReadsRepoFilesFromConfiguredRef(t *testing.T) {
@@ -131,7 +134,7 @@ func TestCustomReviewMissingDefinitionFails(t *testing.T) {
 	require.ErrorContains(t, err, `custom review type "removed-type" is not configured`)
 }
 
-func TestCustomReviewReservesPromptSpaceForReviewContext(t *testing.T) {
+func TestCustomReviewFilesUsePromptLimit(t *testing.T) {
 	repoPath := t.TempDir()
 	require.NoError(t, os.WriteFile(
 		filepath.Join(repoPath, "review.tmpl"),
@@ -147,7 +150,7 @@ func TestCustomReviewReservesPromptSpaceForReviewContext(t *testing.T) {
 		ForRepo(repoPath, 0).
 		WithRepoConfig(repoCfg, "").
 		resolveSystemPrompt(
-			"codex", "custom", "custom", customReviewContextReserve+512,
+			"codex", "custom", "custom", 512,
 		)
-	require.ErrorContains(t, err, "review context")
+	require.ErrorContains(t, err, "prompt limit")
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -90,6 +90,8 @@ type HistoricalReviewContext struct {
 type Builder struct {
 	db         *storage.DB
 	globalCfg  *config.Config // optional global config for exclude patterns
+	repoCfg    *config.RepoConfig
+	repoCfgRef string
 	ctx        context.Context
 	repoPath   string
 	repoID     int64
@@ -148,6 +150,20 @@ func (b *Builder) ForRepo(repoPath string, repoID int64) *Builder {
 func (b *Builder) WithKataClient(client kata.Client) *Builder {
 	next := *b
 	next.kataClient = client
+	return &next
+}
+
+// WithRepoConfig supplies an already-loaded repository config. When ref is
+// non-empty, repo-defined custom template files are read from that Git ref
+// instead of the working tree. CI uses this to keep prompt configuration on
+// the trusted base branch.
+func (b *Builder) WithRepoConfig(
+	repoCfg *config.RepoConfig,
+	ref string,
+) *Builder {
+	next := *b
+	next.repoCfg = repoCfg
+	next.repoCfgRef = strings.TrimSpace(ref)
 	return &next
 }
 
@@ -547,7 +563,10 @@ func (b *Builder) BuildDirty(diff string, contextCount int, agentName, reviewTyp
 // dirty file names for dependency metadata summaries. The diff itself may have
 // review exclusions applied.
 func (b *Builder) BuildDirtyWithFiles(diff string, changedFiles []string, contextCount int, agentName, reviewType, minSeverity string) (string, error) {
-	ctx := b.newPromptBuildContext(agentName, reviewType, minSeverity, "dirty", optionalSectionsView{})
+	ctx, err := b.newPromptBuildContext(agentName, reviewType, minSeverity, "dirty", optionalSectionsView{})
+	if err != nil {
+		return "", err
+	}
 	ctx.optional.DependencyMetadata = buildDependencyMetadataSection(changedFiles)
 
 	ctx.optional.ProjectGuidelines = buildProjectGuidelinesSectionView(
@@ -766,7 +785,7 @@ type promptBuildContext struct {
 	promptCap      int
 }
 
-func (b *Builder) newPromptBuildContext(agentName, reviewType, minSeverity, defaultPromptType string, optional optionalSectionsView) promptBuildContext {
+func (b *Builder) newPromptBuildContext(agentName, reviewType, minSeverity, defaultPromptType string, optional optionalSectionsView) (promptBuildContext, error) {
 	promptType := defaultPromptType
 	if !config.IsDefaultReviewType(reviewType) {
 		promptType = reviewType
@@ -775,15 +794,29 @@ func (b *Builder) newPromptBuildContext(agentName, reviewType, minSeverity, defa
 		promptType = "design-review"
 	}
 	promptCap := b.resolveMaxPromptSize()
-	requiredPrefix := GetSystemPrompt(agentName, promptType) + "\n"
-	if inst := config.SeverityInstruction(minSeverity); inst != "" {
-		requiredPrefix += inst + "\n"
+	systemPrompt, custom, err := b.resolveSystemPrompt(
+		agentName, reviewType, promptType, promptCap,
+	)
+	if err != nil {
+		return promptBuildContext{}, err
+	}
+	requiredPrefix := systemPrompt + "\n"
+	if !custom {
+		if inst := config.SeverityInstruction(minSeverity); inst != "" {
+			requiredPrefix += inst + "\n"
+		}
+	}
+	if custom && len(requiredPrefix) > promptCap {
+		return promptBuildContext{}, fmt.Errorf(
+			"custom review prompt is %d bytes but prompt limit is %d bytes",
+			len(requiredPrefix), promptCap,
+		)
 	}
 	return promptBuildContext{
 		requiredPrefix: hardCapPrompt(requiredPrefix, promptCap),
 		optional:       optional,
 		promptCap:      promptCap,
-	}
+	}, nil
 }
 
 func defaultOptionalSections(ctx context.Context, repoPath string, globalCfg *config.Config, additionalContext string) optionalSectionsView {
@@ -1097,7 +1130,10 @@ func selectRichestRangePromptView(limit int, view TemplateContext, variants []di
 
 // buildSinglePrompt constructs a prompt for a single commit
 func (b *Builder) buildSinglePrompt(sha string, contextCount int, agentName, reviewType string, opts buildOpts) (string, error) {
-	ctx := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "review", defaultOptionalSections(b.context(), b.repoPath, b.globalCfg, opts.additionalContext))
+	ctx, err := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "review", defaultOptionalSections(b.context(), b.repoPath, b.globalCfg, opts.additionalContext))
+	if err != nil {
+		return "", err
+	}
 
 	// Get previous reviews if requested
 	if contextCount > 0 && b.db != nil {
@@ -1221,7 +1257,10 @@ func (b *Builder) buildSinglePrompt(sha string, contextCount int, agentName, rev
 
 // buildRangePrompt constructs a prompt for a commit range
 func (b *Builder) buildRangePrompt(rangeRef string, contextCount int, agentName, reviewType string, opts buildOpts) (string, error) {
-	ctx := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "range", defaultOptionalSections(b.context(), b.repoPath, b.globalCfg, opts.additionalContext))
+	ctx, err := b.newPromptBuildContext(agentName, reviewType, opts.minSeverity, "range", defaultOptionalSections(b.context(), b.repoPath, b.globalCfg, opts.additionalContext))
+	if err != nil {
+		return "", err
+	}
 
 	// Get previous reviews from before the range start
 	if contextCount > 0 && b.db != nil {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -91,6 +91,7 @@ type Builder struct {
 	db         *storage.DB
 	globalCfg  *config.Config // optional global config for exclude patterns
 	repoCfg    *config.RepoConfig
+	repoCfgSet bool
 	repoCfgRef string
 	ctx        context.Context
 	repoPath   string
@@ -163,6 +164,7 @@ func (b *Builder) WithRepoConfig(
 ) *Builder {
 	next := *b
 	next.repoCfg = repoCfg
+	next.repoCfgSet = true
 	next.repoCfgRef = strings.TrimSpace(ref)
 	return &next
 }

--- a/internal/prompt/prompt_body_templates.go
+++ b/internal/prompt/prompt_body_templates.go
@@ -545,7 +545,7 @@ func inRangeReviewViews(contexts []HistoricalReviewContext) []InRangeReviewTempl
 			continue
 		}
 		verdictLabel := "unknown"
-		switch storage.ParseVerdict(ctx.Review.Output) {
+		switch ctx.Review.Verdict() {
 		case "P":
 			verdictLabel = "passed"
 		case "F":

--- a/internal/prompt/prompt_body_templates_test.go
+++ b/internal/prompt/prompt_body_templates_test.go
@@ -349,6 +349,20 @@ func TestHistoricalReviewContextPreviousReviewViewsPreserveChronologicalOrder(t 
 	assert.Equal(t, "aaaaaaa", views[1].Commit)
 }
 
+func TestInRangeReviewViewsUsesStoredVerdict(t *testing.T) {
+	failed := 0
+	views := inRangeReviewViews([]HistoricalReviewContext{{
+		SHA: "aaaaaaa",
+		Review: &storage.Review{
+			Output:      "No issues found in the summary.",
+			VerdictBool: &failed,
+		},
+	}})
+
+	require.Len(t, views, 1)
+	assert.Equal(t, "failed", views[0].Verdict)
+}
+
 func TestRenderPreviousReviewsFromContexts(t *testing.T) {
 	body, err := renderPreviousReviewsFromContexts([]HistoricalReviewContext{
 		{

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -241,7 +241,10 @@ func runSingle(
 			if decodeErr != nil {
 				err = decodeErr
 			} else {
-				output = structured.Filter(cfg.MinSeverity).Markdown()
+				filtered := structured.Filter(cfg.MinSeverity)
+				passed := filtered.Passed()
+				result.Verdict = &passed
+				output = filtered.Markdown()
 			}
 		}
 	} else {

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -26,6 +26,9 @@ type BatchConfig struct {
 	// matching the CI poller's behavior. When nil, agents are
 	// used as-is (backward compatible).
 	GlobalConfig *config.Config
+	// RepoConfig is the trusted repository configuration used to resolve
+	// custom review templates. When nil, the working tree config is loaded.
+	RepoConfig *config.RepoConfig
 	// AgentRegistry is an optional registry for dependency injection in testing.
 	// If nil, the global agent registry is used.
 	AgentRegistry map[string]agent.Agent
@@ -167,7 +170,10 @@ func runSingle(
 	// settings nor commit-message refs have a trusted source (unlike the
 	// daemon poller, which gates on PR author trust and default-branch
 	// config).
-	builder := prompt.NewBuilderWithConfig(nil, cfg.GlobalConfig).WithContext(ctx).ForRepo(cfg.RepoPath, 0)
+	builder := prompt.NewBuilderWithConfig(nil, cfg.GlobalConfig).
+		WithContext(ctx).
+		ForRepo(cfg.RepoPath, 0).
+		WithRepoConfig(cfg.RepoConfig, "")
 
 	// Normalize review type for prompt building
 	promptReviewType := reviewType
@@ -197,8 +203,35 @@ func runSingle(
 		"ci review: running agent=%s type=%s ref=%s",
 		resolvedAgent.Name(), reviewType, cfg.GitRef)
 
-	output, err := resolvedAgent.Review(
-		ctx, cfg.RepoPath, cfg.GitRef, reviewPrompt, nil)
+	var output string
+	if !config.IsBuiltInReviewType(reviewType) {
+		structuredAgent, ok := resolvedAgent.(agent.StructuredReviewAgent)
+		if !ok {
+			result.Status = ResultFailed
+			result.Error = fmt.Sprintf(
+				"agent %q does not support schema-constrained reviews",
+				resolvedAgent.Name(),
+			)
+			return result
+		}
+		raw, reviewErr := structuredAgent.ReviewWithSchema(
+			ctx, cfg.RepoPath, cfg.GitRef, reviewPrompt,
+			CustomReviewSchema, nil,
+		)
+		err = reviewErr
+		if err == nil {
+			structured, decodeErr := DecodeStructuredReview(raw)
+			if decodeErr != nil {
+				err = decodeErr
+			} else {
+				output = structured.Filter(cfg.MinSeverity).Markdown()
+			}
+		}
+	} else {
+		output, err = resolvedAgent.Review(
+			ctx, cfg.RepoPath, cfg.GitRef, reviewPrompt, nil,
+		)
+	}
 	if err != nil {
 		result.Status = ResultFailed
 		result.Error = formatBatchAgentError(resolvedAgent.Name(), err)

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -134,11 +134,11 @@ func runSingle(
 			err = fmt.Errorf("no agents available (mock registry)")
 		}
 	} else if autoDetectAgent {
-		resolvedAgent, err = agent.GetAvailableWithConfig(
-			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)
+		resolvedAgent, err = agent.GetAvailableWithConfigFromConfig(
+			cfg.RepoConfig, resolvedName, cfg.GlobalConfig, backupAgent)
 	} else {
-		resolvedAgent, err = agent.GetPreferredOrBackupWithConfig(
-			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)
+		resolvedAgent, err = agent.GetPreferredOrBackupWithConfigFromConfig(
+			cfg.RepoConfig, resolvedName, cfg.GlobalConfig, backupAgent)
 	}
 
 	if err == nil && hasConfig {

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -93,17 +93,13 @@ func runSingle(
 	// Map review type to workflow name for config
 	// resolution (same mapping as CI poller).
 	workflow := config.WorkflowForReviewType(reviewType)
-	reasoning := cfg.Reasoning
-	var err error
-	if cfg.GlobalConfig != nil || cfg.RepoConfig != nil {
-		reasoning, err = config.ResolveCIReviewReasoningForType(
-			cfg.Reasoning, cfg.RepoConfig, cfg.GlobalConfig, reviewType,
-		)
-		if err != nil {
-			result.Status = ResultFailed
-			result.Error = fmt.Sprintf("resolve reasoning: %v", err)
-			return result
-		}
+	reasoning, err := config.ResolveCIReviewReasoningForType(
+		cfg.Reasoning, cfg.RepoConfig, cfg.GlobalConfig, reviewType,
+	)
+	if err != nil {
+		result.Status = ResultFailed
+		result.Error = fmt.Sprintf("resolve reasoning: %v", err)
+		return result
 	}
 
 	// Workflow-aware agent/model resolution when config
@@ -241,10 +237,9 @@ func runSingle(
 			if decodeErr != nil {
 				err = decodeErr
 			} else {
-				filtered := structured.Filter(cfg.MinSeverity)
-				passed := filtered.Passed()
-				result.Verdict = &passed
-				output = filtered.Markdown()
+				result.Structured = &structured
+				result = result.FilterStructured(cfg.MinSeverity)
+				output = result.Output
 			}
 		}
 	} else {

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -14,21 +14,26 @@ import (
 
 // BatchConfig holds parameters for a parallel review batch.
 type BatchConfig struct {
-	RepoPath     string
-	GitRef       string   // "BASE..HEAD" range
-	Agents       []string // agent names (resolved per-job)
-	ReviewTypes  []string // resolved review types
+	RepoPath    string
+	GitRef      string   // "BASE..HEAD" range
+	Agents      []string // agent names (resolved per-job)
+	ReviewTypes []string // resolved review types
+	// Reasoning is an explicit CLI reasoning override. Repository CI
+	// reasoning and per-type defaults are resolved separately for each job.
 	Reasoning    string
 	ContextCount int
-	// GlobalConfig enables workflow-aware agent/model resolution.
-	// When set, each job resolves its agent and model through
+	// GlobalConfig supplies trusted operator settings. When it or RepoConfig
+	// is set, each job resolves its agent and model through
 	// config.ResolveAgentForWorkflow / ResolveModelForWorkflow,
-	// matching the CI poller's behavior. When nil, agents are
-	// used as-is (backward compatible).
+	// matching the CI poller's behavior. Without either config, agents are
+	// used as-is.
 	GlobalConfig *config.Config
 	// RepoConfig is the trusted repository configuration used to resolve
 	// custom review templates. When nil, the working tree config is loaded.
 	RepoConfig *config.RepoConfig
+	// RepoConfigRef is the trusted git ref used to read repository-relative
+	// custom templates and includes.
+	RepoConfigRef string
 	// AgentRegistry is an optional registry for dependency injection in testing.
 	// If nil, the global agent registry is used.
 	AgentRegistry map[string]agent.Agent
@@ -88,6 +93,18 @@ func runSingle(
 	// Map review type to workflow name for config
 	// resolution (same mapping as CI poller).
 	workflow := config.WorkflowForReviewType(reviewType)
+	reasoning := cfg.Reasoning
+	var err error
+	if cfg.GlobalConfig != nil || cfg.RepoConfig != nil {
+		reasoning, err = config.ResolveCIReviewReasoningForType(
+			cfg.Reasoning, cfg.RepoConfig, cfg.GlobalConfig, reviewType,
+		)
+		if err != nil {
+			result.Status = ResultFailed
+			result.Error = fmt.Sprintf("resolve reasoning: %v", err)
+			return result
+		}
+	}
 
 	// Workflow-aware agent/model resolution when config
 	// is available; otherwise use the agent name as-is.
@@ -95,10 +112,10 @@ func runSingle(
 	var model string
 	var backupAgent string
 	var resolution agent.WorkflowConfig
-	var err error
-	if cfg.GlobalConfig != nil {
-		resolution, err = agent.ResolveWorkflowConfig(
-			agentName, cfg.RepoPath, cfg.GlobalConfig, workflow, cfg.Reasoning,
+	hasConfig := cfg.GlobalConfig != nil || cfg.RepoConfig != nil
+	if hasConfig {
+		resolution, err = agent.ResolveWorkflowConfigFromConfig(
+			agentName, cfg.RepoConfig, cfg.GlobalConfig, workflow, reasoning,
 		)
 		if err != nil {
 			result.Status = ResultFailed
@@ -108,8 +125,8 @@ func runSingle(
 		resolvedName = resolution.PreferredAgent
 		backupAgent = resolution.BackupAgent
 	}
-	strictWorkflowAgent := cfg.GlobalConfig != nil && (config.HasWorkflowAgentOverrideFromConfig(
-		resolution.RepoConfig, cfg.GlobalConfig, workflow, cfg.Reasoning,
+	strictWorkflowAgent := hasConfig && (config.HasWorkflowAgentOverrideFromConfig(
+		resolution.RepoConfig, cfg.GlobalConfig, workflow, reasoning,
 	) || strings.TrimSpace(backupAgent) != "")
 	autoDetectAgent := strings.TrimSpace(agentName) == "" && cfg.AgentRegistry == nil && !strictWorkflowAgent
 
@@ -128,7 +145,7 @@ func runSingle(
 			cfg.RepoPath, resolvedName, cfg.GlobalConfig, backupAgent)
 	}
 
-	if err == nil && cfg.GlobalConfig != nil {
+	if err == nil && hasConfig {
 		model = resolution.ModelForSelectedAgent(
 			resolvedAgent.Name(), "",
 		)
@@ -148,9 +165,9 @@ func runSingle(
 	}
 
 	// Apply reasoning level
-	if cfg.Reasoning != "" {
+	if reasoning != "" {
 		resolvedAgent = resolvedAgent.WithReasoning(
-			agent.ParseReasoningLevel(cfg.Reasoning))
+			agent.ParseReasoningLevel(reasoning))
 	}
 	resolvedAgent = agent.WithCodexSkillsDisabled(
 		resolvedAgent,
@@ -173,7 +190,7 @@ func runSingle(
 	builder := prompt.NewBuilderWithConfig(nil, cfg.GlobalConfig).
 		WithContext(ctx).
 		ForRepo(cfg.RepoPath, 0).
-		WithRepoConfig(cfg.RepoConfig, "")
+		WithRepoConfig(cfg.RepoConfig, cfg.RepoConfigRef)
 
 	// Normalize review type for prompt building
 	promptReviewType := reviewType

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -229,6 +229,8 @@ func runSingle(
 	result.Status = ResultDone
 	result.Output = agentReview.Output
 	result.Structured = agentReview.Structured
+	result.StructuredOutput = agentReview.StructuredOutput
+	result.StructuredMinSeverity = agentReview.StructuredMinSeverity
 	result.Verdict = agentReview.Verdict
 	return result
 }

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -216,37 +216,10 @@ func runSingle(
 		"ci review: running agent=%s type=%s ref=%s",
 		resolvedAgent.Name(), reviewType, cfg.GitRef)
 
-	var output string
-	if !config.IsBuiltInReviewType(reviewType) {
-		structuredAgent, ok := resolvedAgent.(agent.StructuredReviewAgent)
-		if !ok {
-			result.Status = ResultFailed
-			result.Error = fmt.Sprintf(
-				"agent %q does not support schema-constrained reviews",
-				resolvedAgent.Name(),
-			)
-			return result
-		}
-		raw, reviewErr := structuredAgent.ReviewWithSchema(
-			ctx, cfg.RepoPath, cfg.GitRef, reviewPrompt,
-			CustomReviewSchema, nil,
-		)
-		err = reviewErr
-		if err == nil {
-			structured, decodeErr := DecodeStructuredReview(raw)
-			if decodeErr != nil {
-				err = decodeErr
-			} else {
-				result.Structured = &structured
-				result = result.FilterStructured(cfg.MinSeverity)
-				output = result.Output
-			}
-		}
-	} else {
-		output, err = resolvedAgent.Review(
-			ctx, cfg.RepoPath, cfg.GitRef, reviewPrompt, nil,
-		)
-	}
+	agentReview, err := RunAgentReview(
+		ctx, resolvedAgent, cfg.RepoPath, cfg.GitRef, reviewPrompt,
+		reviewType, cfg.MinSeverity, nil,
+	)
 	if err != nil {
 		result.Status = ResultFailed
 		result.Error = formatBatchAgentError(resolvedAgent.Name(), err)
@@ -254,7 +227,9 @@ func runSingle(
 	}
 
 	result.Status = ResultDone
-	result.Output = output
+	result.Output = agentReview.Output
+	result.Structured = agentReview.Structured
+	result.Verdict = agentReview.Verdict
 	return result
 }
 

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -154,6 +154,12 @@ func runSingle(
 			resolvedName, err)
 		return result
 	}
+	result.Agent = resolvedAgent.Name()
+	if err := agent.ValidateStructuredReviewSelection(reviewType, resolvedAgent); err != nil {
+		result.Status = ResultFailed
+		result.Error = fmt.Sprintf("resolve agent %q: %v", resolvedName, err)
+		return result
+	}
 
 	// Apply model override
 	if model != "" {

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -293,6 +293,38 @@ func TestRunBatch_WorkflowAwareResolution(t *testing.T) {
 	assert.Equal("security-agent", secResult.Agent, "security type resolved to %q, want %q", secResult.Agent, "security-agent")
 }
 
+func TestRunBatchUsesPassedRepoConfigForCustomAgent(t *testing.T) {
+	repoPath := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repoPath, ".roborev.toml"),
+		[]byte("[review.types.custom]\ntemplate = \"head.tmpl\"\nagent = \"head-agent\"\n"),
+		0o644,
+	))
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {
+				Template: "base.tmpl",
+				Agent:    "base-agent",
+			},
+		},
+	}}
+	cfg := BatchConfig{
+		RepoPath:    repoPath,
+		GitRef:      "abc..def",
+		Agents:      []string{""},
+		ReviewTypes: []string{"custom"},
+		RepoConfig:  repoCfg,
+		AgentRegistry: map[string]agent.Agent{
+			"base-agent": &mockAgent{name: "base-agent"},
+			"head-agent": &mockAgent{name: "head-agent"},
+		},
+	}
+
+	results := RunBatch(context.Background(), cfg)
+	require.Len(t, results, 1)
+	assert.Equal(t, "base-agent", results[0].Agent)
+}
+
 func TestRunBatch_BlankCIAgentAutoDetectsAvailableAgent(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -356,6 +356,23 @@ func TestRunBatchUsesPassedRepoConfigForCustomAgent(t *testing.T) {
 	assert.Equal(t, "base-agent", results[0].Agent)
 }
 
+func TestRunBatchUsesPassedRepoConfigForNamedACPExecution(t *testing.T) {
+	cfg := BatchConfig{
+		RepoPath:    t.TempDir(),
+		GitRef:      "abc..def",
+		Agents:      []string{"acp.trusted"},
+		ReviewTypes: []string{"default"},
+		RepoConfig: &config.RepoConfig{ACP: config.ACPAgentConfigs{
+			"trusted": {Command: "go"},
+		}},
+	}
+
+	results := RunBatch(context.Background(), cfg)
+	require.Len(t, results, 1)
+	assert.Equal(t, ResultFailed, results[0].Status)
+	assert.Contains(t, results[0].Error, "build prompt")
+}
+
 func TestRunBatchPreservesStructuredVerdict(t *testing.T) {
 	repo := testutil.NewTestRepoWithCommit(t)
 	require.NoError(t, os.WriteFile(

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -390,7 +390,8 @@ func TestRunBatchPreservesStructuredVerdict(t *testing.T) {
 	structuredAgent := &structuredBatchAgent{
 		name: "structured-batch",
 		result: json.RawMessage(`{
-  "summary":"High: no actionable findings.",
+	  "schema_version":1,
+	  "summary":"High: no actionable findings.",
   "findings":[
     {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
   ]

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -393,6 +393,7 @@ func TestRunBatchPreservesStructuredVerdict(t *testing.T) {
 	require.Len(t, results, 1)
 	require.Equal(t, ResultDone, results[0].Status, results[0].Error)
 	require.NotNil(t, results[0].Verdict)
+	require.NotNil(t, results[0].Structured)
 	assert.True(t, results[0].Passed())
 	assert.Contains(t, results[0].Output, "High: no actionable findings.")
 }

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -56,6 +57,36 @@ func (m *mockAgent) WithModel(model string) agent.Agent {
 
 func (m *mockAgent) CommandLine() string {
 	return m.name
+}
+
+type structuredBatchAgent struct {
+	mockAgent
+	result json.RawMessage
+}
+
+func (a *structuredBatchAgent) WithReasoning(
+	_ agent.ReasoningLevel,
+) agent.Agent {
+	return a
+}
+
+func (a *structuredBatchAgent) WithAgentic(_ bool) agent.Agent {
+	return a
+}
+
+func (a *structuredBatchAgent) WithModel(model string) agent.Agent {
+	clone := *a
+	clone.model = model
+	return &clone
+}
+
+func (a *structuredBatchAgent) ReviewWithSchema(
+	_ context.Context,
+	_, _, _ string,
+	_ json.RawMessage,
+	_ io.Writer,
+) (json.RawMessage, error) {
+	return a.result, a.err
 }
 
 // getResultByType is a helper to find a ReviewResult by its ReviewType
@@ -323,6 +354,47 @@ func TestRunBatchUsesPassedRepoConfigForCustomAgent(t *testing.T) {
 	results := RunBatch(context.Background(), cfg)
 	require.Len(t, results, 1)
 	assert.Equal(t, "base-agent", results[0].Agent)
+}
+
+func TestRunBatchPreservesStructuredVerdict(t *testing.T) {
+	repo := testutil.NewTestRepoWithCommit(t)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo.Root, "custom.tmpl"),
+		[]byte("Review the change."), 0o644,
+	))
+	repo.RunGit("add", "custom.tmpl")
+	repo.RunGit("commit", "-m", "add custom review")
+
+	repoCfg := &config.RepoConfig{Review: config.ReviewConfig{
+		Types: map[string]config.ReviewTypeSpec{
+			"custom": {Template: "custom.tmpl"},
+		},
+	}}
+	structuredAgent := &structuredBatchAgent{
+		name: "structured-batch",
+		result: json.RawMessage(`{
+  "summary":"High: no actionable findings.",
+  "findings":[
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
+  ]
+}`),
+	}
+
+	results := RunBatch(context.Background(), BatchConfig{
+		RepoPath:      repo.Root,
+		GitRef:        repo.RevParse("HEAD"),
+		Agents:        []string{structuredAgent.name},
+		ReviewTypes:   []string{"custom"},
+		RepoConfig:    repoCfg,
+		MinSeverity:   "high",
+		AgentRegistry: map[string]agent.Agent{structuredAgent.name: structuredAgent},
+	})
+
+	require.Len(t, results, 1)
+	require.Equal(t, ResultDone, results[0].Status, results[0].Error)
+	require.NotNil(t, results[0].Verdict)
+	assert.True(t, results[0].Passed())
+	assert.Contains(t, results[0].Output, "High: no actionable findings.")
 }
 
 func TestRunBatch_BlankCIAgentAutoDetectsAvailableAgent(t *testing.T) {

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -3,6 +3,7 @@
 package review
 
 import (
+	"encoding/json"
 	"slices"
 	"strings"
 	"unicode/utf8"
@@ -26,6 +27,13 @@ type ReviewResult struct {
 	// applied without reparsing or asking a synthesis agent to infer findings
 	// from rendered Markdown.
 	Structured *StructuredReview
+	// StructuredOutput is the unfiltered JSON returned by the agent. Queued
+	// reviews persist it so a later panel threshold can use the same findings.
+	StructuredOutput json.RawMessage
+	// StructuredMinSeverity is the threshold already applied to Output and
+	// Verdict. Later consumers combine it with their own threshold instead of
+	// accidentally restoring findings that were already excluded.
+	StructuredMinSeverity string
 
 	// Skipped/SkipReason are populated for skipped (auto-design) rows so
 	// synthesis can render them as a distinct short section instead of
@@ -54,8 +62,12 @@ func (r ReviewResult) FilterStructured(minSeverity string) ReviewResult {
 	if r.Structured == nil {
 		return r
 	}
-	filtered := r.Structured.Filter(minSeverity)
+	effectiveMinSeverity := stricterMinSeverity(
+		r.StructuredMinSeverity, minSeverity,
+	)
+	filtered := r.Structured.Filter(effectiveMinSeverity)
 	r.Structured = &filtered
+	r.StructuredMinSeverity = effectiveMinSeverity
 	r.Verdict = storage.VerdictFromPassed(filtered.Passed())
 	r.Output = filtered.Markdown()
 	return r

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -22,6 +22,10 @@ type ReviewResult struct {
 	// returned structured output. Prose reviews leave it nil and use the
 	// existing deterministic Markdown parser.
 	Verdict *bool
+	// Structured retains schema output so later severity thresholds can be
+	// applied without reparsing or asking a synthesis agent to infer findings
+	// from rendered Markdown.
+	Structured *StructuredReview
 
 	// Skipped/SkipReason are populated for skipped (auto-design) rows so
 	// synthesis can render them as a distinct short section instead of
@@ -42,6 +46,19 @@ func (r ReviewResult) Passed() bool {
 		return *r.Verdict
 	}
 	return storage.ParseVerdict(r.Output) == "P"
+}
+
+// FilterStructured applies minSeverity to schema-backed output and updates the
+// rendered text and verdict together. Prose review results are unchanged.
+func (r ReviewResult) FilterStructured(minSeverity string) ReviewResult {
+	if r.Structured == nil {
+		return r
+	}
+	filtered := r.Structured.Filter(minSeverity)
+	r.Structured = &filtered
+	r.Verdict = new(filtered.Passed())
+	r.Output = filtered.Markdown()
+	return r
 }
 
 // Result status values for ReviewResult.Status.

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 	"unicode/utf8"
+
+	"go.kenn.io/roborev/internal/storage"
 )
 
 // ReviewResult holds the outcome of a single review in a batch.
@@ -16,6 +18,10 @@ type ReviewResult struct {
 	Output     string
 	Status     string // ResultDone, ResultFailed, or ResultSkipped
 	Error      string
+	// Verdict is the canonical pass/fail result when the review provider
+	// returned structured output. Prose reviews leave it nil and use the
+	// existing deterministic Markdown parser.
+	Verdict *bool
 
 	// Skipped/SkipReason are populated for skipped (auto-design) rows so
 	// synthesis can render them as a distinct short section instead of
@@ -27,6 +33,15 @@ type ReviewResult struct {
 	// otherwise successful panel fail. It is set from the resolved member config
 	// stored with the job, not from live config.
 	AllowFailure bool
+}
+
+// Passed returns the canonical review verdict when one is available, falling
+// back to Markdown parsing for prose reviews.
+func (r ReviewResult) Passed() bool {
+	if r.Verdict != nil {
+		return *r.Verdict
+	}
+	return storage.ParseVerdict(r.Output) == "P"
 }
 
 // Result status values for ReviewResult.Status.

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -18,10 +18,10 @@ type ReviewResult struct {
 	Output     string
 	Status     string // ResultDone, ResultFailed, or ResultSkipped
 	Error      string
-	// Verdict is the canonical pass/fail result when the review provider
-	// returned structured output. Prose reviews leave it nil and use the
-	// existing deterministic Markdown parser.
-	Verdict *bool
+	// Verdict is the canonical pass/fail result. The runner derives prose
+	// verdicts once and takes custom-review verdicts from structured output.
+	// The empty value is reserved for historical or manually assembled results.
+	Verdict storage.Verdict
 	// Structured retains schema output so later severity thresholds can be
 	// applied without reparsing or asking a synthesis agent to infer findings
 	// from rendered Markdown.
@@ -42,10 +42,10 @@ type ReviewResult struct {
 // Passed returns the canonical review verdict when one is available, falling
 // back to Markdown parsing for prose reviews.
 func (r ReviewResult) Passed() bool {
-	if r.Verdict != nil {
-		return *r.Verdict
+	if r.Verdict != storage.VerdictUnknown {
+		return r.Verdict.Passed()
 	}
-	return storage.ParseVerdict(r.Output) == "P"
+	return storage.ParseVerdict(r.Output) == storage.VerdictPass
 }
 
 // FilterStructured applies minSeverity to schema-backed output and updates the
@@ -56,7 +56,7 @@ func (r ReviewResult) FilterStructured(minSeverity string) ReviewResult {
 	}
 	filtered := r.Structured.Filter(minSeverity)
 	r.Structured = &filtered
-	r.Verdict = new(filtered.Passed())
+	r.Verdict = storage.VerdictFromPassed(filtered.Passed())
 	r.Output = filtered.Markdown()
 	return r
 }

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -9,15 +10,6 @@ import (
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )
-
-// AgentReview is the canonical result of one agent review. Output and Verdict
-// are resolved together so callers do not reinterpret rendered review text.
-// Structured is populated for schema-constrained custom reviews.
-type AgentReview struct {
-	Output     string
-	Verdict    storage.Verdict
-	Structured *StructuredReview
-}
 
 // RunAgentReview owns the built-in versus custom review execution contract.
 // Built-in reviews derive their verdict once from prose. Custom reviews derive
@@ -27,13 +19,13 @@ func RunAgentReview(
 	a agent.Agent,
 	repoPath, gitRef, reviewPrompt, reviewType, minSeverity string,
 	out io.Writer,
-) (AgentReview, error) {
+) (ReviewResult, error) {
 	if config.IsBuiltInReviewType(reviewType) {
 		output, err := a.Review(ctx, repoPath, gitRef, reviewPrompt, out)
 		if err != nil {
-			return AgentReview{}, err
+			return ReviewResult{}, err
 		}
-		result := AgentReview{Output: output}
+		result := ReviewResult{Output: output}
 		if output != "" {
 			result.Verdict = storage.ParseVerdict(output)
 		}
@@ -42,7 +34,7 @@ func RunAgentReview(
 
 	structuredAgent, ok := a.(agent.StructuredReviewAgent)
 	if !ok {
-		return AgentReview{}, fmt.Errorf(
+		return ReviewResult{}, fmt.Errorf(
 			"agent %q does not support schema-constrained reviews", a.Name(),
 		)
 	}
@@ -50,20 +42,22 @@ func RunAgentReview(
 		ctx, repoPath, gitRef, reviewPrompt, CustomReviewSchema, out,
 	)
 	if err != nil {
-		return AgentReview{}, err
+		return ReviewResult{}, err
 	}
 	structured, err := DecodeStructuredReview(raw)
 	if err != nil {
-		return AgentReview{}, err
+		return ReviewResult{}, err
 	}
-	structured = structured.Filter(minSeverity)
-	output := structured.Markdown()
+	filtered := structured.Filter(minSeverity)
+	output := filtered.Markdown()
 	if out != nil {
 		_, _ = fmt.Fprintln(out, output)
 	}
-	return AgentReview{
-		Output:     output,
-		Verdict:    storage.VerdictFromPassed(structured.Passed()),
-		Structured: &structured,
+	return ReviewResult{
+		Output:                output,
+		Verdict:               storage.VerdictFromPassed(filtered.Passed()),
+		Structured:            &structured,
+		StructuredOutput:      append(json.RawMessage(nil), raw...),
+		StructuredMinSeverity: minSeverity,
 	}, nil
 }

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -1,0 +1,69 @@
+package review
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
+)
+
+// AgentReview is the canonical result of one agent review. Output and Verdict
+// are resolved together so callers do not reinterpret rendered review text.
+// Structured is populated for schema-constrained custom reviews.
+type AgentReview struct {
+	Output     string
+	Verdict    storage.Verdict
+	Structured *StructuredReview
+}
+
+// RunAgentReview owns the built-in versus custom review execution contract.
+// Built-in reviews derive their verdict once from prose. Custom reviews derive
+// it from schema output, then carry that verdict beside the rendered Markdown.
+func RunAgentReview(
+	ctx context.Context,
+	a agent.Agent,
+	repoPath, gitRef, reviewPrompt, reviewType, minSeverity string,
+	out io.Writer,
+) (AgentReview, error) {
+	if config.IsBuiltInReviewType(reviewType) {
+		output, err := a.Review(ctx, repoPath, gitRef, reviewPrompt, out)
+		if err != nil {
+			return AgentReview{}, err
+		}
+		result := AgentReview{Output: output}
+		if output != "" {
+			result.Verdict = storage.ParseVerdict(output)
+		}
+		return result, nil
+	}
+
+	structuredAgent, ok := a.(agent.StructuredReviewAgent)
+	if !ok {
+		return AgentReview{}, fmt.Errorf(
+			"agent %q does not support schema-constrained reviews", a.Name(),
+		)
+	}
+	raw, err := structuredAgent.ReviewWithSchema(
+		ctx, repoPath, gitRef, reviewPrompt, CustomReviewSchema, out,
+	)
+	if err != nil {
+		return AgentReview{}, err
+	}
+	structured, err := DecodeStructuredReview(raw)
+	if err != nil {
+		return AgentReview{}, err
+	}
+	structured = structured.Filter(minSeverity)
+	output := structured.Markdown()
+	if out != nil {
+		_, _ = fmt.Fprintln(out, output)
+	}
+	return AgentReview{
+		Output:     output,
+		Verdict:    storage.VerdictFromPassed(structured.Passed()),
+		Structured: &structured,
+	}, nil
+}

--- a/internal/review/runner_test.go
+++ b/internal/review/runner_test.go
@@ -16,7 +16,8 @@ func TestRunAgentReviewKeepsCustomVerdictWithRenderedOutput(t *testing.T) {
 	a := &structuredBatchAgent{
 		name: "structured",
 		result: json.RawMessage(`{
-  "summary": "High: no actionable findings remain.",
+	  "schema_version": 1,
+	  "summary": "High: no actionable findings remain.",
   "findings": [
     {"severity":"low","problem":"Vague name.","fix":"Rename it.","location":null}
   ]

--- a/internal/review/runner_test.go
+++ b/internal/review/runner_test.go
@@ -1,0 +1,51 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestRunAgentReviewKeepsCustomVerdictWithRenderedOutput(t *testing.T) {
+	a := &structuredBatchAgent{
+		name: "structured",
+		result: json.RawMessage(`{
+  "summary": "High: no actionable findings remain.",
+  "findings": [
+    {"severity":"low","problem":"Vague name.","fix":"Rename it.","location":null}
+  ]
+}`),
+	}
+	var streamed strings.Builder
+
+	got, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"custom", "medium", &streamed,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got.Structured)
+	assert.Empty(t, got.Structured.Findings)
+	assert.Equal(t, storage.VerdictPass, got.Verdict)
+	assert.Equal(t, got.Output+"\n", streamed.String())
+	assert.Equal(t, storage.VerdictFail, storage.ParseVerdict(got.Output),
+		"rendered prose must not replace the structured verdict")
+}
+
+func TestRunAgentReviewDerivesBuiltInVerdict(t *testing.T) {
+	a := &mockAgent{name: "prose", output: "No issues found."}
+
+	got, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "", nil,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, got.Structured)
+	assert.Equal(t, "No issues found.", got.Output)
+	assert.Equal(t, storage.VerdictPass, got.Verdict)
+}

--- a/internal/review/runner_test.go
+++ b/internal/review/runner_test.go
@@ -30,7 +30,11 @@ func TestRunAgentReviewKeepsCustomVerdictWithRenderedOutput(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, got.Structured)
-	assert.Empty(t, got.Structured.Findings)
+	require.Len(t, got.Structured.Findings, 1)
+	assert.Equal(t, "low", got.Structured.Findings[0].Severity)
+	assert.JSONEq(t, string(a.result), string(got.StructuredOutput))
+	assert.Equal(t, "medium", got.StructuredMinSeverity)
+	assert.NotContains(t, got.Output, "Vague name")
 	assert.Equal(t, storage.VerdictPass, got.Verdict)
 	assert.Equal(t, got.Output+"\n", streamed.String())
 	assert.Equal(t, storage.VerdictFail, storage.ParseVerdict(got.Output),

--- a/internal/review/structured.go
+++ b/internal/review/structured.go
@@ -1,121 +1,20 @@
 package review
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
-	"io"
 	"strings"
+
+	"go.kenn.io/roborev/internal/structuredreview"
 )
 
-var CustomReviewSchema = json.RawMessage(`{
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["summary", "findings"],
-  "properties": {
-    "summary": {"type": "string", "minLength": 1},
-    "findings": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["severity", "problem", "fix", "location"],
-        "properties": {
-          "severity": {
-            "type": "string",
-            "enum": ["critical", "high", "medium", "low"]
-          },
-          "problem": {"type": "string", "minLength": 1},
-          "fix": {"type": "string", "minLength": 1},
-          "location": {"type": ["string", "null"]}
-        }
-      }
-    }
-  }
-}`)
+var CustomReviewSchema = structuredreview.Schema
 
-type StructuredReview struct {
-	Summary  string              `json:"summary"`
-	Findings []StructuredFinding `json:"findings"`
-}
+type StructuredReview = structuredreview.Document
 
-type StructuredFinding struct {
-	Severity string `json:"severity"`
-	Problem  string `json:"problem"`
-	Fix      string `json:"fix"`
-	Location string `json:"location,omitempty"`
-}
+type StructuredFinding = structuredreview.Finding
 
 func DecodeStructuredReview(raw json.RawMessage) (StructuredReview, error) {
-	dec := json.NewDecoder(bytes.NewReader(raw))
-	dec.DisallowUnknownFields()
-	var result StructuredReview
-	if err := dec.Decode(&result); err != nil {
-		return StructuredReview{}, fmt.Errorf("decode structured review: %w", err)
-	}
-	if err := ensureStructuredReviewEOF(dec); err != nil {
-		return StructuredReview{}, err
-	}
-	result.Summary = strings.TrimSpace(result.Summary)
-	if result.Summary == "" {
-		return StructuredReview{}, fmt.Errorf("structured review summary is required")
-	}
-	if result.Findings == nil {
-		return StructuredReview{}, fmt.Errorf("structured review findings is required")
-	}
-	for i := range result.Findings {
-		finding := &result.Findings[i]
-		finding.Severity = strings.ToLower(strings.TrimSpace(finding.Severity))
-		finding.Problem = strings.TrimSpace(finding.Problem)
-		finding.Fix = strings.TrimSpace(finding.Fix)
-		finding.Location = strings.TrimSpace(finding.Location)
-		if severityRank(finding.Severity) == 0 {
-			return StructuredReview{}, fmt.Errorf(
-				"structured review finding %d has invalid severity %q",
-				i+1, finding.Severity,
-			)
-		}
-		if finding.Problem == "" {
-			return StructuredReview{}, fmt.Errorf(
-				"structured review finding %d has no problem", i+1,
-			)
-		}
-		if finding.Fix == "" {
-			return StructuredReview{}, fmt.Errorf(
-				"structured review finding %d has no fix", i+1,
-			)
-		}
-	}
-	return result, nil
-}
-
-func ensureStructuredReviewEOF(dec *json.Decoder) error {
-	var extra any
-	err := dec.Decode(&extra)
-	if err == io.EOF {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("decode trailing structured review data: %w", err)
-	}
-	return fmt.Errorf("structured review contains trailing JSON")
-}
-
-func (r StructuredReview) Filter(minSeverity string) StructuredReview {
-	threshold := severityRank(strings.ToLower(strings.TrimSpace(minSeverity)))
-	if threshold == 0 {
-		threshold = severityRank("low")
-	}
-	filtered := StructuredReview{
-		Summary:  r.Summary,
-		Findings: make([]StructuredFinding, 0, len(r.Findings)),
-	}
-	for _, finding := range r.Findings {
-		if severityRank(finding.Severity) >= threshold {
-			filtered.Findings = append(filtered.Findings, finding)
-		}
-	}
-	return filtered
+	return structuredreview.Decode(raw)
 }
 
 func stricterMinSeverity(first, second string) string {
@@ -125,30 +24,6 @@ func stricterMinSeverity(first, second string) string {
 		return first
 	}
 	return second
-}
-
-func (r StructuredReview) Passed() bool {
-	return len(r.Findings) == 0
-}
-
-func (r StructuredReview) Markdown() string {
-	var out strings.Builder
-	out.WriteString("## Summary\n\n")
-	out.WriteString(strings.TrimSpace(r.Summary))
-	if len(r.Findings) == 0 {
-		out.WriteString("\n\nNo findings at or above the configured severity threshold.\n")
-		return out.String()
-	}
-	out.WriteString("\n\n## Findings\n")
-	for i, finding := range r.Findings {
-		fmt.Fprintf(&out, "\n### %d. %s\n\n", i+1, titleSeverity(finding.Severity))
-		if finding.Location != "" {
-			fmt.Fprintf(&out, "**Location:** %s\n\n", finding.Location)
-		}
-		fmt.Fprintf(&out, "**Problem:** %s\n\n", finding.Problem)
-		fmt.Fprintf(&out, "**Fix:** %s\n", finding.Fix)
-	}
-	return out.String()
 }
 
 func severityRank(severity string) int {
@@ -164,11 +39,4 @@ func severityRank(severity string) int {
 	default:
 		return 0
 	}
-}
-
-func titleSeverity(severity string) string {
-	if severity == "" {
-		return "Finding"
-	}
-	return strings.ToUpper(severity[:1]) + severity[1:]
 }

--- a/internal/review/structured.go
+++ b/internal/review/structured.go
@@ -118,6 +118,15 @@ func (r StructuredReview) Filter(minSeverity string) StructuredReview {
 	return filtered
 }
 
+func stricterMinSeverity(first, second string) string {
+	first = strings.ToLower(strings.TrimSpace(first))
+	second = strings.ToLower(strings.TrimSpace(second))
+	if severityRank(first) >= severityRank(second) {
+		return first
+	}
+	return second
+}
+
 func (r StructuredReview) Passed() bool {
 	return len(r.Findings) == 0
 }

--- a/internal/review/structured.go
+++ b/internal/review/structured.go
@@ -1,0 +1,165 @@
+package review
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+var CustomReviewSchema = json.RawMessage(`{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["summary", "findings"],
+  "properties": {
+    "summary": {"type": "string", "minLength": 1},
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "problem", "fix", "location"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low"]
+          },
+          "problem": {"type": "string", "minLength": 1},
+          "fix": {"type": "string", "minLength": 1},
+          "location": {"type": ["string", "null"]}
+        }
+      }
+    }
+  }
+}`)
+
+type StructuredReview struct {
+	Summary  string              `json:"summary"`
+	Findings []StructuredFinding `json:"findings"`
+}
+
+type StructuredFinding struct {
+	Severity string `json:"severity"`
+	Problem  string `json:"problem"`
+	Fix      string `json:"fix"`
+	Location string `json:"location,omitempty"`
+}
+
+func DecodeStructuredReview(raw json.RawMessage) (StructuredReview, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var result StructuredReview
+	if err := dec.Decode(&result); err != nil {
+		return StructuredReview{}, fmt.Errorf("decode structured review: %w", err)
+	}
+	if err := ensureStructuredReviewEOF(dec); err != nil {
+		return StructuredReview{}, err
+	}
+	result.Summary = strings.TrimSpace(result.Summary)
+	if result.Summary == "" {
+		return StructuredReview{}, fmt.Errorf("structured review summary is required")
+	}
+	if result.Findings == nil {
+		return StructuredReview{}, fmt.Errorf("structured review findings is required")
+	}
+	for i := range result.Findings {
+		finding := &result.Findings[i]
+		finding.Severity = strings.ToLower(strings.TrimSpace(finding.Severity))
+		finding.Problem = strings.TrimSpace(finding.Problem)
+		finding.Fix = strings.TrimSpace(finding.Fix)
+		finding.Location = strings.TrimSpace(finding.Location)
+		if severityRank(finding.Severity) == 0 {
+			return StructuredReview{}, fmt.Errorf(
+				"structured review finding %d has invalid severity %q",
+				i+1, finding.Severity,
+			)
+		}
+		if finding.Problem == "" {
+			return StructuredReview{}, fmt.Errorf(
+				"structured review finding %d has no problem", i+1,
+			)
+		}
+		if finding.Fix == "" {
+			return StructuredReview{}, fmt.Errorf(
+				"structured review finding %d has no fix", i+1,
+			)
+		}
+	}
+	return result, nil
+}
+
+func ensureStructuredReviewEOF(dec *json.Decoder) error {
+	var extra any
+	err := dec.Decode(&extra)
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("decode trailing structured review data: %w", err)
+	}
+	return fmt.Errorf("structured review contains trailing JSON")
+}
+
+func (r StructuredReview) Filter(minSeverity string) StructuredReview {
+	threshold := severityRank(strings.ToLower(strings.TrimSpace(minSeverity)))
+	if threshold == 0 {
+		threshold = severityRank("low")
+	}
+	filtered := StructuredReview{
+		Summary:  r.Summary,
+		Findings: make([]StructuredFinding, 0, len(r.Findings)),
+	}
+	for _, finding := range r.Findings {
+		if severityRank(finding.Severity) >= threshold {
+			filtered.Findings = append(filtered.Findings, finding)
+		}
+	}
+	return filtered
+}
+
+func (r StructuredReview) Passed() bool {
+	return len(r.Findings) == 0
+}
+
+func (r StructuredReview) Markdown() string {
+	var out strings.Builder
+	out.WriteString("## Summary\n\n")
+	out.WriteString(strings.TrimSpace(r.Summary))
+	if len(r.Findings) == 0 {
+		out.WriteString("\n\nNo findings at or above the configured severity threshold.\n")
+		return out.String()
+	}
+	out.WriteString("\n\n## Findings\n")
+	for i, finding := range r.Findings {
+		fmt.Fprintf(&out, "\n### %d. %s\n\n", i+1, titleSeverity(finding.Severity))
+		if finding.Location != "" {
+			fmt.Fprintf(&out, "**Location:** %s\n\n", finding.Location)
+		}
+		fmt.Fprintf(&out, "**Problem:** %s\n\n", finding.Problem)
+		fmt.Fprintf(&out, "**Fix:** %s\n", finding.Fix)
+	}
+	return out.String()
+}
+
+func severityRank(severity string) int {
+	switch severity {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func titleSeverity(severity string) string {
+	if severity == "" {
+		return "Finding"
+	}
+	return strings.ToUpper(severity[:1]) + severity[1:]
+}

--- a/internal/review/structured_test.go
+++ b/internal/review/structured_test.go
@@ -10,10 +10,11 @@ import (
 
 func TestStructuredReviewFiltersAndRenders(t *testing.T) {
 	raw := json.RawMessage(`{
+  "schema_version": 1,
   "summary": "Two maintainability risks found.",
   "findings": [
     {"severity":"high","problem":"State can diverge.","fix":"Use one owner.","location":"state.go:20"},
-    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
   ]
 }`)
 
@@ -30,7 +31,7 @@ func TestStructuredReviewFiltersAndRenders(t *testing.T) {
 
 func TestStructuredReviewPassesAfterSeverityFiltering(t *testing.T) {
 	decoded, err := DecodeStructuredReview(json.RawMessage(
-		`{"summary":"Minor issue.","findings":[{"severity":"low","problem":"Vague name.","fix":"Rename it.","location":null}]}`,
+		`{"schema_version":1,"summary":"Minor issue.","findings":[{"severity":"low","problem":"Vague name.","fix":"Rename it.","location":null}]}`,
 	))
 	require.NoError(t, err)
 	filtered := decoded.Filter("high")
@@ -40,9 +41,16 @@ func TestStructuredReviewPassesAfterSeverityFiltering(t *testing.T) {
 
 func TestStructuredReviewRejectsUnknownFields(t *testing.T) {
 	_, err := DecodeStructuredReview(json.RawMessage(
-		`{"summary":"Done.","findings":[],"verdict":"pass"}`,
+		`{"schema_version":1,"summary":"Done.","findings":[],"verdict":"pass"}`,
 	))
 	require.ErrorContains(t, err, "unknown field")
+}
+
+func TestStructuredReviewRequiresCurrentSchemaVersion(t *testing.T) {
+	_, err := DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":2,"summary":"Done.","findings":[]}`,
+	))
+	require.ErrorContains(t, err, "unsupported structured review schema_version 2")
 }
 
 func TestStricterMinSeverity(t *testing.T) {

--- a/internal/review/structured_test.go
+++ b/internal/review/structured_test.go
@@ -44,3 +44,8 @@ func TestStructuredReviewRejectsUnknownFields(t *testing.T) {
 	))
 	require.ErrorContains(t, err, "unknown field")
 }
+
+func TestStricterMinSeverity(t *testing.T) {
+	assert.Equal(t, "high", stricterMinSeverity("low", "high"))
+	assert.Equal(t, "high", stricterMinSeverity("high", "low"))
+}

--- a/internal/review/structured_test.go
+++ b/internal/review/structured_test.go
@@ -1,0 +1,46 @@
+package review
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructuredReviewFiltersAndRenders(t *testing.T) {
+	raw := json.RawMessage(`{
+  "summary": "Two maintainability risks found.",
+  "findings": [
+    {"severity":"high","problem":"State can diverge.","fix":"Use one owner.","location":"state.go:20"},
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+  ]
+}`)
+
+	decoded, err := DecodeStructuredReview(raw)
+	require.NoError(t, err)
+	filtered := decoded.Filter("medium")
+	require.Len(t, filtered.Findings, 1)
+	assert.False(t, filtered.Passed())
+	markdown := filtered.Markdown()
+	assert.Contains(t, markdown, "### 1. High")
+	assert.Contains(t, markdown, "**Location:** state.go:20")
+	assert.NotContains(t, markdown, "Name is vague")
+}
+
+func TestStructuredReviewPassesAfterSeverityFiltering(t *testing.T) {
+	decoded, err := DecodeStructuredReview(json.RawMessage(
+		`{"summary":"Minor issue.","findings":[{"severity":"low","problem":"Vague name.","fix":"Rename it.","location":null}]}`,
+	))
+	require.NoError(t, err)
+	filtered := decoded.Filter("high")
+	assert.True(t, filtered.Passed())
+	assert.Contains(t, filtered.Markdown(), "No findings at or above")
+}
+
+func TestStructuredReviewRejectsUnknownFields(t *testing.T) {
+	_, err := DecodeStructuredReview(json.RawMessage(
+		`{"summary":"Done.","findings":[],"verdict":"pass"}`,
+	))
+	require.ErrorContains(t, err, "unknown field")
+}

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -11,7 +11,6 @@ import (
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
-	"go.kenn.io/roborev/internal/storage"
 )
 
 // ErrAllFailed is returned by Synthesize when every review job
@@ -109,9 +108,13 @@ func formatSingleResult(
 	r ReviewResult,
 	headSHA string,
 ) string {
+	passed := r.Passed()
+	if r.Verdict == nil &&
+		(r.Output == "" || r.Output == "No issues found.") {
+		passed = true
+	}
 	var header string
-	if r.Output == "" || r.Output == "No issues found." ||
-		storage.ParseVerdict(r.Output) == "P" {
+	if passed {
 		header = fmt.Sprintf(
 			"## roborev: Review Passed (`%s`)\n\n",
 			gitrepo.ShortSHA(headSHA))

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -11,6 +11,7 @@ import (
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
 )
 
 // ErrAllFailed is returned by Synthesize when every review job
@@ -114,7 +115,7 @@ func formatSingleResult(
 	headSHA string,
 ) string {
 	passed := r.Passed()
-	if r.Verdict == nil &&
+	if r.Verdict == storage.VerdictUnknown &&
 		(r.Output == "" || r.Output == "No issues found.") {
 		passed = true
 	}

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -58,6 +58,10 @@ func Synthesize(
 	results []ReviewResult,
 	opts SynthesizeOpts,
 ) (string, error) {
+	for i := range results {
+		results[i] = results[i].FilterStructured(opts.MinSeverity)
+	}
+
 	successCount := 0
 	for _, r := range results {
 		if IsSubstantiveOutput(r) {
@@ -87,7 +91,8 @@ func Synthesize(
 	// filtering is needed (synthesis applies the filter).
 	// "low" means no filtering, so treat same as empty.
 	if len(results) == 1 && successCount == 1 &&
-		(opts.MinSeverity == "" || opts.MinSeverity == "low") {
+		(opts.MinSeverity == "" || opts.MinSeverity == "low" ||
+			results[0].Structured != nil) {
 		return formatSingleResult(
 			results[0], opts.HeadSHA), nil
 	}

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
 )
 
 func assertContains(t *testing.T, s, substr string) {
@@ -142,7 +143,7 @@ func TestSynthesize_Formatting(t *testing.T) {
 					ReviewType: "custom",
 					Status:     "done",
 					Output:     "High: no actionable findings.",
-					Verdict:    new(true),
+					Verdict:    storage.VerdictPass,
 				},
 			},
 			expectedErr: nil,
@@ -159,7 +160,7 @@ func TestSynthesize_Formatting(t *testing.T) {
 					ReviewType: "custom",
 					Status:     "done",
 					Output:     "No issues found.",
-					Verdict:    new(false),
+					Verdict:    storage.VerdictFail,
 				},
 			},
 			expectedErr: nil,

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -423,7 +423,8 @@ func TestSynthesize_UsesSynthesisEntrypoint(t *testing.T) {
 
 func TestSynthesizeFiltersStructuredResultWithoutReparsingSummary(t *testing.T) {
 	structured := StructuredReview{
-		Summary: "High: no actionable findings.",
+		SchemaVersion: storage.StructuredReviewSchemaVersion,
+		Summary:       "High: no actionable findings.",
 		Findings: []StructuredFinding{{
 			Severity: "low",
 			Problem:  "Name is vague.",

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -420,6 +420,33 @@ func TestSynthesize_UsesSynthesisEntrypoint(t *testing.T) {
 	assert.NotContains(t, synth.synthPrompt, "Review the code changes in commit")
 }
 
+func TestSynthesizeFiltersStructuredResultWithoutReparsingSummary(t *testing.T) {
+	structured := StructuredReview{
+		Summary: "High: no actionable findings.",
+		Findings: []StructuredFinding{{
+			Severity: "low",
+			Problem:  "Name is vague.",
+			Fix:      "Rename it.",
+		}},
+	}
+	result := ReviewResult{
+		Agent:      "codex",
+		ReviewType: "custom",
+		Status:     ResultDone,
+		Structured: &structured,
+	}.FilterStructured("low")
+
+	comment, err := Synthesize(context.Background(), []ReviewResult{result}, SynthesizeOpts{
+		MinSeverity: "high",
+		HeadSHA:     "abc123",
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, comment, "Review Passed")
+	assert.Contains(t, comment, "No findings at or above")
+	assert.NotContains(t, comment, "Name is vague")
+}
+
 func TestSynthesize_EmptyAgentAutoSelectsAvailableAgent(t *testing.T) {
 	t.Setenv("PATH", "")
 

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -135,6 +135,40 @@ func TestSynthesize_Formatting(t *testing.T) {
 			},
 		},
 		{
+			name: "SingleStructuredSuccess",
+			results: []ReviewResult{
+				{
+					Agent:      "codex",
+					ReviewType: "custom",
+					Status:     "done",
+					Output:     "High: no actionable findings.",
+					Verdict:    new(true),
+				},
+			},
+			expectedErr: nil,
+			expectedTexts: []string{
+				"Review Passed",
+				"High: no actionable findings.",
+			},
+		},
+		{
+			name: "SingleStructuredFailure",
+			results: []ReviewResult{
+				{
+					Agent:      "codex",
+					ReviewType: "custom",
+					Status:     "done",
+					Output:     "No issues found.",
+					Verdict:    new(false),
+				},
+			},
+			expectedErr: nil,
+			expectedTexts: []string{
+				"Review Complete",
+				"No issues found.",
+			},
+		},
+		{
 			name: "SingleSeverityThresholdMet",
 			results: []ReviewResult{
 				{

--- a/internal/storage/ci.go
+++ b/internal/storage/ci.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"time"
 )
 
@@ -25,19 +26,21 @@ func (db *DB) RecordCIReview(githubRepo string, prNumber int, headSHA string, jo
 
 // BatchReviewResult holds the output of a single review job within a panel run.
 type BatchReviewResult struct {
-	JobID                 int64  `json:"job_id"`
-	Agent                 string `json:"agent"`
-	ReviewType            string `json:"review_type"`
-	PanelMemberName       string `json:"panel_member_name,omitempty"`
-	Output                string `json:"output"`
-	VerdictBool           *int   `json:"verdict_bool,omitempty"`
-	Status                string `json:"status"` // "done", "failed", "skipped", etc.
-	Error                 string `json:"error"`
-	SkipReason            string `json:"skip_reason,omitempty"`
-	PanelMemberConfigJSON string `json:"panel_member_config_json,omitempty"`
-	StartedAt             string `json:"started_at,omitempty"`
-	FinishedAt            string `json:"finished_at,omitempty"`
-	TokenUsage            string `json:"token_usage,omitempty"`
+	JobID                 int64           `json:"job_id"`
+	Agent                 string          `json:"agent"`
+	ReviewType            string          `json:"review_type"`
+	PanelMemberName       string          `json:"panel_member_name,omitempty"`
+	Output                string          `json:"output"`
+	VerdictBool           *int            `json:"verdict_bool,omitempty"`
+	StructuredOutput      json.RawMessage `json:"structured_output,omitempty"`
+	MinSeverity           string          `json:"min_severity,omitempty"`
+	Status                string          `json:"status"` // "done", "failed", "skipped", etc.
+	Error                 string          `json:"error"`
+	SkipReason            string          `json:"skip_reason,omitempty"`
+	PanelMemberConfigJSON string          `json:"panel_member_config_json,omitempty"`
+	StartedAt             string          `json:"started_at,omitempty"`
+	FinishedAt            string          `json:"finished_at,omitempty"`
+	TokenUsage            string          `json:"token_usage,omitempty"`
 }
 
 // CancelJobWithError cancels a queued or running job and sets an error

--- a/internal/storage/ci.go
+++ b/internal/storage/ci.go
@@ -30,6 +30,7 @@ type BatchReviewResult struct {
 	ReviewType            string `json:"review_type"`
 	PanelMemberName       string `json:"panel_member_name,omitempty"`
 	Output                string `json:"output"`
+	VerdictBool           *int   `json:"verdict_bool,omitempty"`
 	Status                string `json:"status"` // "done", "failed", "skipped", etc.
 	Error                 string `json:"error"`
 	SkipReason            string `json:"skip_reason,omitempty"`

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -864,6 +864,18 @@ func (db *DB) migrate() error {
 		}
 	}
 
+	// Migration: preserve schema-constrained review output for later severity
+	// filtering by panel synthesis.
+	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('reviews') WHERE name = 'structured_output'`).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("check structured_output column: %w", err)
+	}
+	if count == 0 {
+		if _, err = db.Exec(`ALTER TABLE reviews ADD COLUMN structured_output TEXT`); err != nil {
+			return fmt.Errorf("add structured_output column: %w", err)
+		}
+	}
+
 	// Migration: add provider column to review_jobs if missing
 	err = db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('review_jobs') WHERE name = 'provider'`).Scan(&count)
 	if err != nil {

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -61,19 +61,26 @@ func TestJobLifecycle(t *testing.T) {
 	assert.Equal(t, JobStatusDone, updatedJob.Status)
 }
 
-func TestCompleteJobWithVerdictUsesExplicitVerdict(t *testing.T) {
+func TestCompleteJobResultStoresCanonicalReview(t *testing.T) {
 	env := setupJobEnv(t, "/tmp/structured-verdict", "structured123")
 	claimed := claimJob(t, env.db, "worker-1")
 	require.NotNil(t, claimed)
 
-	require.NoError(t, env.db.CompleteJobWithVerdict(
-		env.job.ID, "codex", "prompt", "No issues found.", VerdictFail,
+	structured := []byte(`{"summary":"Misleading summary.","findings":[]}`)
+	require.NoError(t, env.db.CompleteJobResult(
+		env.job.ID, "codex", "prompt", ReviewCompletion{
+			Output:           "No issues found.",
+			Verdict:          VerdictFail,
+			StructuredOutput: structured,
+		},
 	))
 	var verdict sql.NullInt64
+	var storedStructured string
 	require.NoError(t, env.db.QueryRow(
-		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, env.job.ID,
-	).Scan(&verdict))
+		`SELECT verdict_bool, structured_output FROM reviews WHERE job_id = ?`, env.job.ID,
+	).Scan(&verdict, &storedStructured))
 	assert.Equal(t, sql.NullInt64{Int64: 0, Valid: true}, verdict)
+	assert.JSONEq(t, string(structured), storedStructured)
 }
 
 func TestClaimJobOrdersMixedEnqueueTimestampFormats(t *testing.T) {

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -66,7 +67,7 @@ func TestCompleteJobResultStoresCanonicalReview(t *testing.T) {
 	claimed := claimJob(t, env.db, "worker-1")
 	require.NotNil(t, claimed)
 
-	structured := []byte(`{"summary":"Misleading summary.","findings":[]}`)
+	structured := []byte(`{"schema_version":1,"summary":"Misleading summary.","findings":[]}`)
 	require.NoError(t, env.db.CompleteJobResult(
 		env.job.ID, "codex", "prompt", ReviewCompletion{
 			Output:           "No issues found.",
@@ -81,6 +82,38 @@ func TestCompleteJobResultStoresCanonicalReview(t *testing.T) {
 	).Scan(&verdict, &storedStructured))
 	assert.Equal(t, sql.NullInt64{Int64: 0, Valid: true}, verdict)
 	assert.JSONEq(t, string(structured), storedStructured)
+}
+
+func TestCompleteJobResultRejectsInvalidStructuredOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{name: "malformed JSON", raw: json.RawMessage(`{"schema_version":1`)},
+		{name: "missing version", raw: json.RawMessage(`{"summary":"Done.","findings":[]}`)},
+		{name: "unsupported version", raw: json.RawMessage(`{"schema_version":2,"summary":"Done.","findings":[]}`)},
+		{name: "missing findings", raw: json.RawMessage(`{"schema_version":1,"summary":"Done."}`)},
+		{name: "missing required location", raw: json.RawMessage(`{"schema_version":1,"summary":"Done.","findings":[{"severity":"low","problem":"Problem.","fix":"Fix."}]}`)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := setupJobEnv(t, "/tmp/invalid-structured-output", "structured-invalid")
+			claimed := claimJob(t, env.db, "worker-1")
+			require.NotNil(t, claimed)
+
+			err := env.db.CompleteJobResult(
+				env.job.ID, "codex", "prompt", ReviewCompletion{
+					Output:           "No issues found.",
+					StructuredOutput: tt.raw,
+				},
+			)
+			require.ErrorContains(t, err, "validate structured review output")
+
+			updatedJob, err := env.db.GetJobByID(env.job.ID)
+			require.NoError(t, err)
+			assert.Equal(t, JobStatusRunning, updatedJob.Status)
+		})
+	}
 }
 
 func TestClaimJobOrdersMixedEnqueueTimestampFormats(t *testing.T) {

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -67,7 +67,7 @@ func TestCompleteJobWithVerdictUsesExplicitVerdict(t *testing.T) {
 	require.NotNil(t, claimed)
 
 	require.NoError(t, env.db.CompleteJobWithVerdict(
-		env.job.ID, "codex", "prompt", "No issues found.", false,
+		env.job.ID, "codex", "prompt", "No issues found.", VerdictFail,
 	))
 	var verdict sql.NullInt64
 	require.NoError(t, env.db.QueryRow(

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -61,6 +61,21 @@ func TestJobLifecycle(t *testing.T) {
 	assert.Equal(t, JobStatusDone, updatedJob.Status)
 }
 
+func TestCompleteJobWithVerdictUsesExplicitVerdict(t *testing.T) {
+	env := setupJobEnv(t, "/tmp/structured-verdict", "structured123")
+	claimed := claimJob(t, env.db, "worker-1")
+	require.NotNil(t, claimed)
+
+	require.NoError(t, env.db.CompleteJobWithVerdict(
+		env.job.ID, "codex", "prompt", "No issues found.", false,
+	))
+	var verdict sql.NullInt64
+	require.NoError(t, env.db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, env.job.ID,
+	).Scan(&verdict))
+	assert.Equal(t, sql.NullInt64{Int64: 0, Valid: true}, verdict)
+}
+
 func TestClaimJobOrdersMixedEnqueueTimestampFormats(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/db_migration_test.go
+++ b/internal/storage/db_migration_test.go
@@ -496,37 +496,21 @@ func TestMigrationNormalizesWindowsRepoRootPathConflicts(t *testing.T) {
 	assert.Equal(t, targetCommitID, responseCommitID)
 }
 
-func TestMigrationAddsVerdictBoolColumn(t *testing.T) {
+func TestMigrationAddsCanonicalReviewColumns(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()
 
-	// Verify verdict_bool column exists
 	var count int
-	err := db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('reviews') WHERE name = 'verdict_bool'`).Scan(&count)
-	if err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "Failed to check verdict_bool column: %v", err)
-	}
-	if count != 1 {
-		require.Condition(t, func() bool {
-			return false
-		}, "verdict_bool column not found in reviews table")
-	}
+	require.NoError(t, db.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('reviews')
+		WHERE name IN ('verdict_bool', 'structured_output')
+	`).Scan(&count))
+	assert.Equal(t, 2, count)
 
 	// Verify the index exists
 	var indexCount int
-	err = db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_reviews_verdict_bool'`).Scan(&indexCount)
-	if err != nil {
-		require.Condition(t, func() bool {
-			return false
-		}, "Failed to check verdict_bool index: %v", err)
-	}
-	if indexCount != 1 {
-		require.Condition(t, func() bool {
-			return false
-		}, "idx_reviews_verdict_bool index not found")
-	}
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_reviews_verdict_bool'`).Scan(&indexCount))
+	assert.Equal(t, 1, indexCount)
 }
 
 func TestMigrationAddsSessionIDColumn(t *testing.T) {

--- a/internal/storage/hydration.go
+++ b/internal/storage/hydration.go
@@ -189,6 +189,45 @@ type reviewScanFields struct {
 	StructuredOutput sql.NullString
 }
 
+const reviewSelectColumns = `
+	rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at,
+	rv.closed, rv.uuid, rv.verdict_bool, rv.structured_output`
+
+func reviewScanDestinations(
+	review *Review,
+	fields *reviewScanFields,
+) []any {
+	return []any{
+		&review.ID,
+		&review.JobID,
+		&review.Agent,
+		&review.Prompt,
+		&review.Output,
+		&fields.CreatedAt,
+		&fields.Closed,
+		&fields.UUID,
+		&fields.VerdictBool,
+		&fields.StructuredOutput,
+	}
+}
+
+func scanReviewFields(
+	scanner sqlScanner,
+) (Review, reviewScanFields, error) {
+	var review Review
+	var fields reviewScanFields
+	if err := scanner.Scan(reviewScanDestinations(&review, &fields)...); err != nil {
+		return Review{}, reviewScanFields{}, err
+	}
+	applyReviewScan(&review, fields)
+	return review, fields, nil
+}
+
+func scanReview(scanner sqlScanner) (Review, error) {
+	review, _, err := scanReviewFields(scanner)
+	return review, err
+}
+
 func applyReviewScan(review *Review, fields reviewScanFields) {
 	review.CreatedAt = parseSQLiteTime(fields.CreatedAt)
 	review.Closed = fields.Closed != 0

--- a/internal/storage/hydration.go
+++ b/internal/storage/hydration.go
@@ -179,10 +179,11 @@ func applyReviewJobScan(job *ReviewJob, fields reviewJobScanFields) {
 }
 
 type reviewScanFields struct {
-	CreatedAt   string
-	Closed      int
-	UUID        sql.NullString
-	VerdictBool sql.NullInt64
+	CreatedAt        string
+	Closed           int
+	UUID             sql.NullString
+	VerdictBool      sql.NullInt64
+	StructuredOutput sql.NullString
 }
 
 func applyReviewScan(review *Review, fields reviewScanFields) {
@@ -190,6 +191,9 @@ func applyReviewScan(review *Review, fields reviewScanFields) {
 	review.Closed = fields.Closed != 0
 	if fields.UUID.Valid {
 		review.UUID = fields.UUID.String
+	}
+	if fields.StructuredOutput.Valid {
+		review.StructuredOutput = []byte(fields.StructuredOutput.String)
 	}
 	applyReviewVerdict(review, fields.VerdictBool)
 }

--- a/internal/storage/hydration.go
+++ b/internal/storage/hydration.go
@@ -1,6 +1,9 @@
 package storage
 
-import "database/sql"
+import (
+	"database/sql"
+	"encoding/json"
+)
 
 type sqlScanner interface {
 	Scan(dest ...any) error
@@ -193,7 +196,10 @@ func applyReviewScan(review *Review, fields reviewScanFields) {
 		review.UUID = fields.UUID.String
 	}
 	if fields.StructuredOutput.Valid {
-		review.StructuredOutput = []byte(fields.StructuredOutput.String)
+		_ = json.Unmarshal(
+			[]byte(fields.StructuredOutput.String),
+			&review.StructuredOutput,
+		)
 	}
 	applyReviewVerdict(review, fields.VerdictBool)
 }

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -2688,7 +2688,7 @@ func (db *DB) GetPanelMemberReviews(panelRunUUID string) ([]BatchReviewResult, e
 		return nil, nil
 	}
 	rows, err := db.Query(`
-		SELECT j.id, j.agent, j.review_type, COALESCE(j.panel_member_name, ''), COALESCE(rv.output, ''), j.status, COALESCE(j.error, ''), COALESCE(j.skip_reason, ''),
+		SELECT j.id, j.agent, j.review_type, COALESCE(j.panel_member_name, ''), COALESCE(rv.output, ''), rv.verdict_bool, j.status, COALESCE(j.error, ''), COALESCE(j.skip_reason, ''),
 		       COALESCE(j.panel_member_config_json, ''),
 		       COALESCE(j.started_at, ''), COALESCE(j.finished_at, ''), COALESCE(j.token_usage, '')
 		FROM review_jobs j
@@ -2703,7 +2703,7 @@ func (db *DB) GetPanelMemberReviews(panelRunUUID string) ([]BatchReviewResult, e
 	var results []BatchReviewResult
 	for rows.Next() {
 		var r BatchReviewResult
-		if err := rows.Scan(&r.JobID, &r.Agent, &r.ReviewType, &r.PanelMemberName, &r.Output, &r.Status, &r.Error, &r.SkipReason, &r.PanelMemberConfigJSON, &r.StartedAt, &r.FinishedAt, &r.TokenUsage); err != nil {
+		if err := rows.Scan(&r.JobID, &r.Agent, &r.ReviewType, &r.PanelMemberName, &r.Output, &r.VerdictBool, &r.Status, &r.Error, &r.SkipReason, &r.PanelMemberConfigJSON, &r.StartedAt, &r.FinishedAt, &r.TokenUsage); err != nil {
 			return nil, fmt.Errorf("scan panel member review: %w", err)
 		}
 		results = append(results, r)

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1126,6 +1126,25 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 // Only updates if job is still in 'running' state (respects cancellation).
 // If the job has an output_prefix, it will be prepended to the output.
 func (db *DB) CompleteJob(jobID int64, agent, prompt, output string) error {
+	return db.completeJob(jobID, agent, prompt, output, nil)
+}
+
+// CompleteJobWithVerdict marks a job done and stores an explicit verdict.
+// Schema-constrained custom reviews use this instead of reparsing their
+// canonical Markdown output.
+func (db *DB) CompleteJobWithVerdict(
+	jobID int64,
+	agent, prompt, output string,
+	passed bool,
+) error {
+	return db.completeJob(jobID, agent, prompt, output, &passed)
+}
+
+func (db *DB) completeJob(
+	jobID int64,
+	agent, prompt, output string,
+	passed *bool,
+) error {
 	// Get machine ID and generate UUIDs before starting transaction
 	// to avoid potential lock conflicts with GetMachineID's writes
 	now := time.Now().Format(time.RFC3339)
@@ -1184,7 +1203,13 @@ func (db *DB) CompleteJob(jobID int64, agent, prompt, output string) error {
 
 	// Insert review with sync columns
 	var verdictBoolVal any
-	if finalOutput != "" {
+	if passed != nil {
+		if *passed {
+			verdictBoolVal = 1
+		} else {
+			verdictBoolVal = 0
+		}
+	} else if finalOutput != "" {
 		verdictBoolVal = verdictToBool(ParseVerdict(finalOutput))
 	}
 	_, err = conn.ExecContext(ctx, `INSERT INTO reviews (job_id, agent, prompt, output, verdict_bool, uuid, updated_by_machine_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1126,24 +1126,23 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 // Only updates if job is still in 'running' state (respects cancellation).
 // If the job has an output_prefix, it will be prepended to the output.
 func (db *DB) CompleteJob(jobID int64, agent, prompt, output string) error {
-	return db.completeJob(jobID, agent, prompt, output, nil)
+	return db.completeJob(jobID, agent, prompt, output, VerdictUnknown)
 }
 
-// CompleteJobWithVerdict marks a job done and stores an explicit verdict.
-// Schema-constrained custom reviews use this instead of reparsing their
-// canonical Markdown output.
+// CompleteJobWithVerdict marks a job done and stores the verdict produced by
+// the review runner instead of deriving it again from rendered output.
 func (db *DB) CompleteJobWithVerdict(
 	jobID int64,
 	agent, prompt, output string,
-	passed bool,
+	verdict Verdict,
 ) error {
-	return db.completeJob(jobID, agent, prompt, output, &passed)
+	return db.completeJob(jobID, agent, prompt, output, verdict)
 }
 
 func (db *DB) completeJob(
 	jobID int64,
 	agent, prompt, output string,
-	passed *bool,
+	verdict Verdict,
 ) error {
 	// Get machine ID and generate UUIDs before starting transaction
 	// to avoid potential lock conflicts with GetMachineID's writes
@@ -1203,12 +1202,8 @@ func (db *DB) completeJob(
 
 	// Insert review with sync columns
 	var verdictBoolVal any
-	if passed != nil {
-		if *passed {
-			verdictBoolVal = 1
-		} else {
-			verdictBoolVal = 0
-		}
+	if verdict != VerdictUnknown {
+		verdictBoolVal = verdictToBool(verdict)
 	} else if finalOutput != "" {
 		verdictBoolVal = verdictToBool(ParseVerdict(finalOutput))
 	}

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"go.kenn.io/roborev/internal/structuredreview"
 )
 
 // preciseTimestampLayout is a fixed-width timestamp layout used for the
@@ -1152,6 +1154,9 @@ func (db *DB) completeJob(
 	agent, prompt string,
 	completion ReviewCompletion,
 ) error {
+	if err := validateStructuredOutputForWrite(completion.StructuredOutput); err != nil {
+		return err
+	}
 	// Get machine ID and generate UUIDs before starting transaction
 	// to avoid potential lock conflicts with GetMachineID's writes
 	now := time.Now().Format(time.RFC3339)
@@ -1232,6 +1237,16 @@ func (db *DB) completeJob(
 		return err
 	}
 	committed = true
+	return nil
+}
+
+func validateStructuredOutputForWrite(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	if _, err := structuredreview.Decode(raw); err != nil {
+		return fmt.Errorf("validate structured review output: %w", err)
+	}
 	return nil
 }
 

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1126,23 +1126,30 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 // Only updates if job is still in 'running' state (respects cancellation).
 // If the job has an output_prefix, it will be prepended to the output.
 func (db *DB) CompleteJob(jobID int64, agent, prompt, output string) error {
-	return db.completeJob(jobID, agent, prompt, output, VerdictUnknown)
+	return db.completeJob(jobID, agent, prompt, ReviewCompletion{Output: output})
 }
 
-// CompleteJobWithVerdict marks a job done and stores the verdict produced by
-// the review runner instead of deriving it again from rendered output.
-func (db *DB) CompleteJobWithVerdict(
+// ReviewCompletion is the canonical result persisted for one completed review.
+type ReviewCompletion struct {
+	Output           string
+	Verdict          Verdict
+	StructuredOutput json.RawMessage
+}
+
+// CompleteJobResult marks a job done and stores the result produced by the
+// review runner without reinterpreting its rendered output.
+func (db *DB) CompleteJobResult(
 	jobID int64,
-	agent, prompt, output string,
-	verdict Verdict,
+	agent, prompt string,
+	result ReviewCompletion,
 ) error {
-	return db.completeJob(jobID, agent, prompt, output, verdict)
+	return db.completeJob(jobID, agent, prompt, result)
 }
 
 func (db *DB) completeJob(
 	jobID int64,
-	agent, prompt, output string,
-	verdict Verdict,
+	agent, prompt string,
+	completion ReviewCompletion,
 ) error {
 	// Get machine ID and generate UUIDs before starting transaction
 	// to avoid potential lock conflicts with GetMachineID's writes
@@ -1179,9 +1186,9 @@ func (db *DB) completeJob(
 	}
 
 	// Prepend output_prefix if present
-	finalOutput := output
+	finalOutput := completion.Output
 	if outputPrefix.Valid && outputPrefix.String != "" {
-		finalOutput = outputPrefix.String + output
+		finalOutput = outputPrefix.String + completion.Output
 	}
 
 	// Update job status only if still running (not canceled)
@@ -1202,13 +1209,14 @@ func (db *DB) completeJob(
 
 	// Insert review with sync columns
 	var verdictBoolVal any
-	if verdict != VerdictUnknown {
-		verdictBoolVal = verdictToBool(verdict)
+	if completion.Verdict != VerdictUnknown {
+		verdictBoolVal = verdictToBool(completion.Verdict)
 	} else if finalOutput != "" {
 		verdictBoolVal = verdictToBool(ParseVerdict(finalOutput))
 	}
-	_, err = conn.ExecContext(ctx, `INSERT INTO reviews (job_id, agent, prompt, output, verdict_bool, uuid, updated_by_machine_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		jobID, agent, prompt, finalOutput, verdictBoolVal, reviewUUID, machineID, now)
+	_, err = conn.ExecContext(ctx, `INSERT INTO reviews (job_id, agent, prompt, output, verdict_bool, structured_output, uuid, updated_by_machine_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		jobID, agent, prompt, finalOutput, verdictBoolVal,
+		nullString(string(completion.StructuredOutput)), reviewUUID, machineID, now)
 	if err != nil {
 		return err
 	}
@@ -2683,7 +2691,7 @@ func (db *DB) GetPanelMemberReviews(panelRunUUID string) ([]BatchReviewResult, e
 		return nil, nil
 	}
 	rows, err := db.Query(`
-		SELECT j.id, j.agent, j.review_type, COALESCE(j.panel_member_name, ''), COALESCE(rv.output, ''), rv.verdict_bool, j.status, COALESCE(j.error, ''), COALESCE(j.skip_reason, ''),
+		SELECT j.id, j.agent, j.review_type, COALESCE(j.panel_member_name, ''), COALESCE(rv.output, ''), rv.verdict_bool, rv.structured_output, COALESCE(j.min_severity, ''), j.status, COALESCE(j.error, ''), COALESCE(j.skip_reason, ''),
 		       COALESCE(j.panel_member_config_json, ''),
 		       COALESCE(j.started_at, ''), COALESCE(j.finished_at, ''), COALESCE(j.token_usage, '')
 		FROM review_jobs j
@@ -2698,8 +2706,12 @@ func (db *DB) GetPanelMemberReviews(panelRunUUID string) ([]BatchReviewResult, e
 	var results []BatchReviewResult
 	for rows.Next() {
 		var r BatchReviewResult
-		if err := rows.Scan(&r.JobID, &r.Agent, &r.ReviewType, &r.PanelMemberName, &r.Output, &r.VerdictBool, &r.Status, &r.Error, &r.SkipReason, &r.PanelMemberConfigJSON, &r.StartedAt, &r.FinishedAt, &r.TokenUsage); err != nil {
+		var structuredOutput sql.NullString
+		if err := rows.Scan(&r.JobID, &r.Agent, &r.ReviewType, &r.PanelMemberName, &r.Output, &r.VerdictBool, &structuredOutput, &r.MinSeverity, &r.Status, &r.Error, &r.SkipReason, &r.PanelMemberConfigJSON, &r.StartedAt, &r.FinishedAt, &r.TokenUsage); err != nil {
 			return nil, fmt.Errorf("scan panel member review: %w", err)
+		}
+		if structuredOutput.Valid {
+			r.StructuredOutput = json.RawMessage(structuredOutput.String)
 		}
 		results = append(results, r)
 	}

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1134,6 +1134,7 @@ type ReviewCompletion struct {
 	Output           string
 	Verdict          Verdict
 	StructuredOutput json.RawMessage
+	MinSeverity      string
 }
 
 // CompleteJobResult marks a job done and stores the result produced by the
@@ -1192,7 +1193,12 @@ func (db *DB) completeJob(
 	}
 
 	// Update job status only if still running (not canceled)
-	result, err := conn.ExecContext(ctx, `UPDATE review_jobs SET status = 'done', finished_at = ?, updated_at = ? WHERE id = ? AND status = 'running'`, now, now, jobID)
+	result, err := conn.ExecContext(ctx, `
+		UPDATE review_jobs
+		SET status = 'done', finished_at = ?, updated_at = ?,
+		    min_severity = COALESCE(NULLIF(?, ''), min_severity)
+		WHERE id = ? AND status = 'running'
+	`, now, now, normalizeMinSeverityForWrite(completion.MinSeverity), jobID)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -1,10 +1,10 @@
 package storage
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
 	gitrepo "go.kenn.io/kit/git/repo"
 )
 
@@ -284,6 +284,18 @@ type JobWithReview struct {
 	Review *Review   `json:"review,omitempty"`
 }
 
+// StructuredOutput is the schema-constrained JSON object returned by a custom
+// review. Its schema keeps arbitrary nested values available to generated API
+// clients instead of reducing them to empty structs.
+type StructuredOutput map[string]any
+
+func (StructuredOutput) Schema(huma.Registry) *huma.Schema {
+	return &huma.Schema{
+		Type:                 huma.TypeObject,
+		AdditionalProperties: true,
+	}
+}
+
 type Review struct {
 	ID        int64     `json:"id"`
 	JobID     int64     `json:"job_id"`
@@ -300,8 +312,8 @@ type Review struct {
 	SyncedAt           *time.Time `json:"synced_at,omitempty"`             // Last sync time
 
 	// Stored verdict: 1=pass, 0=fail, NULL=legacy (not yet backfilled)
-	VerdictBool      *int            `json:"verdict_bool,omitempty"`
-	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
+	VerdictBool      *int             `json:"verdict_bool,omitempty"`
+	StructuredOutput StructuredOutput `json:"structured_output,omitempty"`
 
 	// Joined fields
 	Job *ReviewJob `json:"job,omitempty"`

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -299,7 +300,8 @@ type Review struct {
 	SyncedAt           *time.Time `json:"synced_at,omitempty"`             // Last sync time
 
 	// Stored verdict: 1=pass, 0=fail, NULL=legacy (not yet backfilled)
-	VerdictBool *int `json:"verdict_bool,omitempty"`
+	VerdictBool      *int            `json:"verdict_bool,omitempty"`
+	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
 
 	// Joined fields
 	Job *ReviewJob `json:"job,omitempty"`

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	gitrepo "go.kenn.io/kit/git/repo"
+
+	"go.kenn.io/roborev/internal/structuredreview"
 )
 
 type Repo struct {
@@ -288,6 +290,10 @@ type JobWithReview struct {
 // review. Its schema keeps arbitrary nested values available to generated API
 // clients instead of reducing them to empty structs.
 type StructuredOutput map[string]any
+
+// StructuredReviewSchemaVersion is the version stored in schema-constrained
+// review documents. Writers reject documents with any other version.
+const StructuredReviewSchemaVersion = structuredreview.SchemaVersion
 
 func (StructuredOutput) Schema(huma.Registry) *huma.Schema {
 	return &huma.Schema{

--- a/internal/storage/panels_test.go
+++ b/internal/storage/panels_test.go
@@ -670,8 +670,11 @@ func TestGetPanelMemberReviews(t *testing.T) {
 	m0 := byIndex[0]
 	_, err = db.Exec(`UPDATE review_jobs SET status='running', worker_id='w1' WHERE id=?`, m0.ID)
 	require.NoError(t, err)
-	require.NoError(t, db.CompleteJobWithVerdict(
-		m0.ID, "test", "prompt", "High: no actionable findings.", VerdictPass,
+	require.NoError(t, db.CompleteJobResult(
+		m0.ID, "test", "prompt", ReviewCompletion{
+			Output:  "High: no actionable findings.",
+			Verdict: VerdictPass,
+		},
 	))
 
 	got, err := db.GetPanelMemberReviews("run-1")

--- a/internal/storage/panels_test.go
+++ b/internal/storage/panels_test.go
@@ -671,7 +671,7 @@ func TestGetPanelMemberReviews(t *testing.T) {
 	_, err = db.Exec(`UPDATE review_jobs SET status='running', worker_id='w1' WHERE id=?`, m0.ID)
 	require.NoError(t, err)
 	require.NoError(t, db.CompleteJobWithVerdict(
-		m0.ID, "test", "prompt", "High: no actionable findings.", true,
+		m0.ID, "test", "prompt", "High: no actionable findings.", VerdictPass,
 	))
 
 	got, err := db.GetPanelMemberReviews("run-1")

--- a/internal/storage/panels_test.go
+++ b/internal/storage/panels_test.go
@@ -670,7 +670,9 @@ func TestGetPanelMemberReviews(t *testing.T) {
 	m0 := byIndex[0]
 	_, err = db.Exec(`UPDATE review_jobs SET status='running', worker_id='w1' WHERE id=?`, m0.ID)
 	require.NoError(t, err)
-	require.NoError(t, db.CompleteJob(m0.ID, "test", "prompt", "No issues found."))
+	require.NoError(t, db.CompleteJobWithVerdict(
+		m0.ID, "test", "prompt", "High: no actionable findings.", true,
+	))
 
 	got, err := db.GetPanelMemberReviews("run-1")
 	require.NoError(t, err)
@@ -686,7 +688,9 @@ func TestGetPanelMemberReviews(t *testing.T) {
 
 	// The completed member surfaces its review output and done status.
 	assert.Equal("done", got[0].Status)
-	assert.Equal("No issues found.", got[0].Output)
+	assert.Equal("High: no actionable findings.", got[0].Output)
+	require.NotNil(t, got[0].VerdictBool)
+	assert.Equal(1, *got[0].VerdictBool)
 	// A member without a review has an empty output but its own status.
 	assert.Empty(got[1].Output)
 

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -444,6 +445,9 @@ func (p *PgPool) EnsureSchema(ctx context.Context) error {
 			if _, err = p.pool.Exec(ctx, `ALTER TABLE reviews ADD COLUMN IF NOT EXISTS verdict_bool BOOLEAN`); err != nil {
 				return fmt.Errorf("v20 migration (add review verdict): %w", err)
 			}
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE reviews ADD COLUMN IF NOT EXISTS structured_output JSONB`); err != nil {
+				return fmt.Errorf("v20 migration (add structured review output): %w", err)
+			}
 		}
 		// Update version
 		_, err = p.pool.Exec(ctx, `INSERT INTO schema_version (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`, pgSchemaVersion)
@@ -797,15 +801,16 @@ func (p *PgPool) UpsertReview(ctx context.Context, r SyncableReview) error {
 	_, err := p.pool.Exec(ctx, `
 		INSERT INTO reviews (
 			uuid, job_uuid, agent, prompt, output, closed,
-			verdict_bool, updated_by_machine_id, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, clock_timestamp())
+			verdict_bool, structured_output, updated_by_machine_id, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			closed = EXCLUDED.closed,
 			verdict_bool = COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool),
+			structured_output = COALESCE(EXCLUDED.structured_output, reviews.structured_output),
 			updated_by_machine_id = EXCLUDED.updated_by_machine_id,
 			updated_at = clock_timestamp()
 	`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
-		r.VerdictBool, r.UpdatedByMachineID, r.CreatedAt)
+		r.VerdictBool, nullJSON(r.StructuredOutput), r.UpdatedByMachineID, r.CreatedAt)
 	return err
 }
 
@@ -1110,6 +1115,7 @@ type PulledReview struct {
 	Output             string
 	Closed             bool
 	VerdictBool        *bool
+	StructuredOutput   json.RawMessage
 	UpdatedByMachineID string
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
@@ -1137,7 +1143,7 @@ func (p *PgPool) PullReviews(ctx context.Context, excludeMachineID string, known
 	rows, err := p.pool.Query(ctx, `
 		SELECT
 			r.uuid, r.job_uuid, r.agent, r.prompt, r.output, r.closed,
-			r.verdict_bool, r.updated_by_machine_id, r.created_at, r.updated_at, r.id
+			r.verdict_bool, r.structured_output, r.updated_by_machine_id, r.created_at, r.updated_at, r.id
 		FROM reviews r
 		WHERE (r.updated_by_machine_id IS NULL OR r.updated_by_machine_id != $1)
 		AND r.job_uuid = ANY($2)
@@ -1156,16 +1162,18 @@ func (p *PgPool) PullReviews(ctx context.Context, excludeMachineID string, known
 
 	for rows.Next() {
 		var r PulledReview
+		var structuredOutput []byte
 
 		err := rows.Scan(
 			&r.UUID, &r.JobUUID, &r.Agent, &r.Prompt, &r.Output, &r.Closed,
-			&r.VerdictBool, &r.UpdatedByMachineID, &r.CreatedAt, &r.UpdatedAt, &lastID,
+			&r.VerdictBool, &structuredOutput, &r.UpdatedByMachineID, &r.CreatedAt, &r.UpdatedAt, &lastID,
 		)
 		if err != nil {
 			return nil, cursor, fmt.Errorf("scan review: %w", err)
 		}
 
 		lastUpdatedAt = r.UpdatedAt
+		r.StructuredOutput = append(json.RawMessage(nil), structuredOutput...)
 		reviews = append(reviews, r)
 	}
 
@@ -1258,6 +1266,13 @@ func nullString(s string) any {
 	return s
 }
 
+func nullJSON(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}
+
 func sanitizePostgresText(s string) string {
 	return strings.ReplaceAll(strings.ToValidUTF8(s, "\uFFFD"), "\x00", "\uFFFD")
 }
@@ -1291,15 +1306,16 @@ func (p *PgPool) BatchUpsertReviews(ctx context.Context, reviews []SyncableRevie
 		batch.Queue(`
 			INSERT INTO reviews (
 				uuid, job_uuid, agent, prompt, output, closed,
-				verdict_bool, updated_by_machine_id, created_at, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, clock_timestamp())
+				verdict_bool, structured_output, updated_by_machine_id, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, clock_timestamp())
 			ON CONFLICT (uuid) DO UPDATE SET
 				closed = EXCLUDED.closed,
 				verdict_bool = COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool),
+				structured_output = COALESCE(EXCLUDED.structured_output, reviews.structured_output),
 				updated_by_machine_id = EXCLUDED.updated_by_machine_id,
 				updated_at = clock_timestamp()
 		`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
-			r.VerdictBool, r.UpdatedByMachineID, r.CreatedAt)
+			r.VerdictBool, nullJSON(r.StructuredOutput), r.UpdatedByMachineID, r.CreatedAt)
 	}
 
 	br := p.pool.SendBatch(ctx, batch)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -15,12 +15,12 @@ import (
 )
 
 // PostgreSQL schema version - increment when schema changes
-const pgSchemaVersion = 19
+const pgSchemaVersion = 20
 
 // pgSchemaName is the PostgreSQL schema used to isolate roborev tables
 const pgSchemaName = "roborev"
 
-//go:embed schemas/postgres_v19.sql
+//go:embed schemas/postgres_v20.sql
 var pgSchemaSQL string
 
 // pgSchemaStatements returns the individual DDL statements for schema creation.
@@ -440,6 +440,11 @@ func (p *PgPool) EnsureSchema(ctx context.Context) error {
 				}
 			}
 		}
+		if currentVersion < 20 {
+			if _, err = p.pool.Exec(ctx, `ALTER TABLE reviews ADD COLUMN IF NOT EXISTS verdict_bool BOOLEAN`); err != nil {
+				return fmt.Errorf("v20 migration (add review verdict): %w", err)
+			}
+		}
 		// Update version
 		_, err = p.pool.Exec(ctx, `INSERT INTO schema_version (version) VALUES ($1) ON CONFLICT (version) DO NOTHING`, pgSchemaVersion)
 		if err != nil {
@@ -792,14 +797,15 @@ func (p *PgPool) UpsertReview(ctx context.Context, r SyncableReview) error {
 	_, err := p.pool.Exec(ctx, `
 		INSERT INTO reviews (
 			uuid, job_uuid, agent, prompt, output, closed,
-			updated_by_machine_id, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, clock_timestamp())
+			verdict_bool, updated_by_machine_id, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			closed = EXCLUDED.closed,
+			verdict_bool = COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool),
 			updated_by_machine_id = EXCLUDED.updated_by_machine_id,
 			updated_at = clock_timestamp()
 	`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
-		r.UpdatedByMachineID, r.CreatedAt)
+		r.VerdictBool, r.UpdatedByMachineID, r.CreatedAt)
 	return err
 }
 
@@ -1103,6 +1109,7 @@ type PulledReview struct {
 	Prompt             string
 	Output             string
 	Closed             bool
+	VerdictBool        *bool
 	UpdatedByMachineID string
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
@@ -1130,7 +1137,7 @@ func (p *PgPool) PullReviews(ctx context.Context, excludeMachineID string, known
 	rows, err := p.pool.Query(ctx, `
 		SELECT
 			r.uuid, r.job_uuid, r.agent, r.prompt, r.output, r.closed,
-			r.updated_by_machine_id, r.created_at, r.updated_at, r.id
+			r.verdict_bool, r.updated_by_machine_id, r.created_at, r.updated_at, r.id
 		FROM reviews r
 		WHERE (r.updated_by_machine_id IS NULL OR r.updated_by_machine_id != $1)
 		AND r.job_uuid = ANY($2)
@@ -1152,7 +1159,7 @@ func (p *PgPool) PullReviews(ctx context.Context, excludeMachineID string, known
 
 		err := rows.Scan(
 			&r.UUID, &r.JobUUID, &r.Agent, &r.Prompt, &r.Output, &r.Closed,
-			&r.UpdatedByMachineID, &r.CreatedAt, &r.UpdatedAt, &lastID,
+			&r.VerdictBool, &r.UpdatedByMachineID, &r.CreatedAt, &r.UpdatedAt, &lastID,
 		)
 		if err != nil {
 			return nil, cursor, fmt.Errorf("scan review: %w", err)
@@ -1284,14 +1291,15 @@ func (p *PgPool) BatchUpsertReviews(ctx context.Context, reviews []SyncableRevie
 		batch.Queue(`
 			INSERT INTO reviews (
 				uuid, job_uuid, agent, prompt, output, closed,
-				updated_by_machine_id, created_at, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, clock_timestamp())
+				verdict_bool, updated_by_machine_id, created_at, updated_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, clock_timestamp())
 			ON CONFLICT (uuid) DO UPDATE SET
 				closed = EXCLUDED.closed,
+				verdict_bool = COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool),
 				updated_by_machine_id = EXCLUDED.updated_by_machine_id,
 				updated_at = clock_timestamp()
 		`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
-			r.UpdatedByMachineID, r.CreatedAt)
+			r.VerdictBool, r.UpdatedByMachineID, r.CreatedAt)
 	}
 
 	br := p.pool.SendBatch(ctx, batch)

--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -919,6 +919,15 @@ func TestIntegration_Multiplayer(t *testing.T) {
 
 	jobA, reviewA := createCompletedReview(t, dbA, nodeA.Repo.ID, "aaaa1111", "Alice", "Feature A", "prompt A", "Review from Machine A")
 	jobB, reviewB := createCompletedReview(t, dbB, nodeB.Repo.ID, "bbbb2222", "Bob", "Feature B", "prompt B", "Review from Machine B")
+	_, err := dbB.Exec(
+		`UPDATE reviews
+		 SET verdict_bool = 0, structured_output = ?, synced_at = NULL,
+		     updated_at = datetime('now')
+		 WHERE id = ?`,
+		`{"summary":"Canonical remote result.","findings":[]}`,
+		reviewB.ID,
+	)
+	require.NoError(t, err)
 
 	// Sync to push, then sync again to pull each other's data
 	if _, err := workerA.SyncNow(); err != nil {
@@ -1012,6 +1021,9 @@ func TestIntegration_Multiplayer(t *testing.T) {
 			return false
 		}, "Machine A: pulled review UUID mismatch: got %s, want %s", reviewBinA.UUID, reviewB.UUID)
 	}
+	require.NotNil(t, reviewBinA.VerdictBool)
+	assert.Equal(t, 0, *reviewBinA.VerdictBool)
+	assert.Equal(t, "Canonical remote result.", reviewBinA.StructuredOutput["summary"])
 
 	reviewAinB, err := dbB.GetReviewByCommitSHA("aaaa1111")
 	if err != nil {

--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -924,7 +924,7 @@ func TestIntegration_Multiplayer(t *testing.T) {
 		 SET verdict_bool = 0, structured_output = ?, synced_at = NULL,
 		     updated_at = datetime('now')
 		 WHERE id = ?`,
-		`{"summary":"Canonical remote result.","findings":[]}`,
+		`{"schema_version":1,"summary":"Canonical remote result.","findings":[]}`,
 		reviewB.ID,
 	)
 	require.NoError(t, err)

--- a/internal/storage/postgres_migration_test.go
+++ b/internal/storage/postgres_migration_test.go
@@ -84,23 +84,21 @@ func openTestPgPoolRawAtVersion(t *testing.T, version int) *PgPool {
 	return pool
 }
 
-func TestPostgresMigration_ReviewVerdict(t *testing.T) {
+func TestPostgresMigration_CanonicalReview(t *testing.T) {
 	openTestPgPoolRawAtVersion(t, 18)
 	ctx := t.Context()
 
 	pg := openTestPgPool(t)
 	defer pg.Close()
 
-	var exists bool
+	var count int
 	require.NoError(t, pgxPool(pg).QueryRow(ctx, `
-		SELECT EXISTS (
-			SELECT 1 FROM information_schema.columns
-			WHERE table_schema = 'roborev'
-			  AND table_name = 'reviews'
-			  AND column_name = 'verdict_bool'
-		)
-	`).Scan(&exists))
-	assert.True(t, exists)
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = 'roborev'
+		  AND table_name = 'reviews'
+		  AND column_name IN ('verdict_bool', 'structured_output')
+	`).Scan(&count))
+	assert.Equal(t, 2, count)
 }
 
 func TestPostgresMigration_ResponseSource(t *testing.T) {

--- a/internal/storage/postgres_migration_test.go
+++ b/internal/storage/postgres_migration_test.go
@@ -26,6 +26,9 @@ var postgresV14Schema string
 //go:embed schemas/postgres_v17.sql
 var postgresV17Schema string
 
+//go:embed schemas/postgres_v18.sql
+var postgresV18Schema string
+
 // openTestPgPoolRawAtVersion bootstraps a fresh Postgres test pool at the
 // given older schema version by running only the corresponding embedded
 // schema file and seeding schema_version. It deliberately does NOT call
@@ -49,6 +52,7 @@ func openTestPgPoolRawAtVersion(t *testing.T, version int) *PgPool {
 		13: postgresV13Schema,
 		14: postgresV14Schema,
 		17: postgresV17Schema,
+		18: postgresV18Schema,
 	}
 	schemaSQL, ok := schemas[version]
 	require.Truef(t, ok, "openTestPgPoolRawAtVersion: no embedded schema for version %d", version)
@@ -78,6 +82,25 @@ func openTestPgPoolRawAtVersion(t *testing.T, version int) *PgPool {
 	require.NoError(t, err, "seed schema_version")
 
 	return pool
+}
+
+func TestPostgresMigration_ReviewVerdict(t *testing.T) {
+	openTestPgPoolRawAtVersion(t, 18)
+	ctx := t.Context()
+
+	pg := openTestPgPool(t)
+	defer pg.Close()
+
+	var exists bool
+	require.NoError(t, pgxPool(pg).QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = 'roborev'
+			  AND table_name = 'reviews'
+			  AND column_name = 'verdict_bool'
+		)
+	`).Scan(&exists))
+	assert.True(t, exists)
 }
 
 func TestPostgresMigration_ResponseSource(t *testing.T) {

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -1128,6 +1128,7 @@ func TestIntegration_BatchUpsertReviews(t *testing.T) {
 			Output:             "test output 1",
 			Closed:             false,
 			VerdictBool:        new(true),
+			StructuredOutput:   []byte(`{"summary":"Clean.","findings":[]}`),
 			UpdatedByMachineID: defaultTestMachineID,
 			CreatedAt:          time.Now(),
 		},
@@ -1149,10 +1150,12 @@ func TestIntegration_BatchUpsertReviews(t *testing.T) {
 	assert.Equal(t, 2, countSuccesses(success))
 
 	var verdict bool
+	var structuredOutput []byte
 	require.NoError(t, pool.pool.QueryRow(ctx,
-		`SELECT verdict_bool FROM reviews WHERE uuid = $1`, reviews[0].UUID,
-	).Scan(&verdict))
+		`SELECT verdict_bool, structured_output FROM reviews WHERE uuid = $1`, reviews[0].UUID,
+	).Scan(&verdict, &structuredOutput))
 	assert.True(t, verdict)
+	assert.JSONEq(t, string(reviews[0].StructuredOutput), string(structuredOutput))
 
 	t.Run("empty batch is no-op", func(t *testing.T) {
 		success, err := pool.BatchUpsertReviews(ctx, []SyncableReview{})

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -1127,6 +1127,7 @@ func TestIntegration_BatchUpsertReviews(t *testing.T) {
 			Prompt:             "test prompt 1",
 			Output:             "test output 1",
 			Closed:             false,
+			VerdictBool:        new(true),
 			UpdatedByMachineID: defaultTestMachineID,
 			CreatedAt:          time.Now(),
 		},
@@ -1146,6 +1147,12 @@ func TestIntegration_BatchUpsertReviews(t *testing.T) {
 	require.NoError(t, err, "BatchUpsertReviews failed: %v")
 
 	assert.Equal(t, 2, countSuccesses(success))
+
+	var verdict bool
+	require.NoError(t, pool.pool.QueryRow(ctx,
+		`SELECT verdict_bool FROM reviews WHERE uuid = $1`, reviews[0].UUID,
+	).Scan(&verdict))
+	assert.True(t, verdict)
 
 	t.Run("empty batch is no-op", func(t *testing.T) {
 		success, err := pool.BatchUpsertReviews(ctx, []SyncableReview{})

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -1128,7 +1128,7 @@ func TestIntegration_BatchUpsertReviews(t *testing.T) {
 			Output:             "test output 1",
 			Closed:             false,
 			VerdictBool:        new(true),
-			StructuredOutput:   []byte(`{"summary":"Clean.","findings":[]}`),
+			StructuredOutput:   []byte(`{"schema_version":1,"summary":"Clean.","findings":[]}`),
 			UpdatedByMachineID: defaultTestMachineID,
 			CreatedAt:          time.Now(),
 		},

--- a/internal/storage/repos.go
+++ b/internal/storage/repos.go
@@ -550,7 +550,7 @@ func (db *DB) GetRepoStats(repoID int64) (*RepoStats, error) {
 
 		applyJobVerdict(&job, verdictBool, output, output != "")
 		if job.Verdict != nil {
-			if *job.Verdict == verdictPass {
+			if *job.Verdict == string(VerdictPass) {
 				stats.PassedReviews++
 			} else {
 				stats.FailedReviews++

--- a/internal/storage/reviews.go
+++ b/internal/storage/reviews.go
@@ -16,7 +16,7 @@ func (db *DB) GetReviewByJobID(jobID int64) (*Review, error) {
 	var job ReviewJob
 	var jobFields reviewJobScanFields
 	err := db.QueryRow(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.uuid, rv.verdict_bool,
+		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.uuid, rv.verdict_bool, rv.structured_output,
 		       j.id, COALESCE(j.uuid, ''), j.repo_id, j.commit_id, j.git_ref, j.branch, j.ci_base_branch, j.session_id, j.resume_source_job_uuid, j.agent, j.reasoning, j.status, j.enqueued_at,
 		       j.started_at, j.finished_at, j.worker_id, j.error, j.model, j.provider, j.requested_model, j.requested_provider, j.job_type, j.review_type, j.patch_id,
 		       rp.root_path, rp.name, c.subject, j.token_usage, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
@@ -26,7 +26,7 @@ func (db *DB) GetReviewByJobID(jobID int64) (*Review, error) {
 		JOIN repos rp ON rp.id = j.repo_id
 		LEFT JOIN commits c ON c.id = j.commit_id
 		WHERE rv.job_id = ?
-	`, jobID).Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &reviewFields.CreatedAt, &reviewFields.Closed, &reviewFields.UUID, &reviewFields.VerdictBool,
+	`, jobID).Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &reviewFields.CreatedAt, &reviewFields.Closed, &reviewFields.UUID, &reviewFields.VerdictBool, &reviewFields.StructuredOutput,
 		&job.ID, &job.UUID, &job.RepoID, &jobFields.CommitID, &job.GitRef, &jobFields.Branch, &jobFields.CIBaseBranch, &jobFields.SessionID, &jobFields.ResumeSourceUUID, &job.Agent, &job.Reasoning, &job.Status, &jobFields.EnqueuedAt,
 		&jobFields.StartedAt, &jobFields.FinishedAt, &jobFields.WorkerID, &jobFields.Error, &jobFields.Model, &jobFields.Provider, &jobFields.RequestedModel, &jobFields.RequestedProvider, &jobFields.JobType, &jobFields.ReviewType, &jobFields.PatchID,
 		&job.RepoPath, &job.RepoName, &jobFields.CommitSubject, &jobFields.TokenUsage, &jobFields.MinSeverity, &jobFields.BackupAgent, &jobFields.BackupModel,
@@ -78,7 +78,7 @@ func (db *DB) GetReviewByCommitSHA(sha string) (*Review, error) {
 // GetAllReviewsForGitRef returns all reviews for a git ref (commit SHA or range) for re-review context
 func (db *DB) GetAllReviewsForGitRef(gitRef string) ([]Review, error) {
 	rows, err := db.Query(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed
+		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.structured_output
 		FROM reviews rv
 		JOIN review_jobs j ON j.id = rv.job_id
 		WHERE j.git_ref = ?
@@ -94,7 +94,7 @@ func (db *DB) GetAllReviewsForGitRef(gitRef string) ([]Review, error) {
 	for rows.Next() {
 		var r Review
 		var fields reviewScanFields
-		if err := rows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed); err != nil {
+		if err := rows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.StructuredOutput); err != nil {
 			return nil, err
 		}
 		applyReviewScan(&r, fields)
@@ -107,7 +107,7 @@ func (db *DB) GetAllReviewsForGitRef(gitRef string) ([]Review, error) {
 // GetRecentReviewsForRepo returns the N most recent reviews for a repo
 func (db *DB) GetRecentReviewsForRepo(repoID int64, limit int) ([]Review, error) {
 	rows, err := db.Query(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed
+		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.structured_output
 		FROM reviews rv
 		JOIN review_jobs j ON j.id = rv.job_id
 		WHERE j.repo_id = ?
@@ -123,7 +123,7 @@ func (db *DB) GetRecentReviewsForRepo(repoID int64, limit int) ([]Review, error)
 	for rows.Next() {
 		var r Review
 		var fields reviewScanFields
-		if err := rows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed); err != nil {
+		if err := rows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.StructuredOutput); err != nil {
 			return nil, err
 		}
 		applyReviewScan(&r, fields)
@@ -480,7 +480,7 @@ func (db *DB) GetJobsWithReviewsByIDs(jobIDs []int64) (map[int64]JobWithReview, 
 
 	// Fetch reviews for these jobs
 	reviewQuery := fmt.Sprintf(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.verdict_bool
+		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.verdict_bool, rv.structured_output
 		FROM reviews rv
 		WHERE rv.job_id IN (%s)
 	`, inClause)
@@ -494,7 +494,7 @@ func (db *DB) GetJobsWithReviewsByIDs(jobIDs []int64) (map[int64]JobWithReview, 
 	for reviewRows.Next() {
 		var r Review
 		var fields reviewScanFields
-		if err := reviewRows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.VerdictBool); err != nil {
+		if err := reviewRows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.VerdictBool, &fields.StructuredOutput); err != nil {
 			return nil, fmt.Errorf("scan review: %w", err)
 		}
 		applyReviewScan(&r, fields)
@@ -518,9 +518,9 @@ func (db *DB) GetReviewByID(reviewID int64) (*Review, error) {
 	var fields reviewScanFields
 
 	err := db.QueryRow(`
-		SELECT id, job_id, agent, prompt, output, created_at, closed
+		SELECT id, job_id, agent, prompt, output, created_at, closed, structured_output
 		FROM reviews WHERE id = ?
-	`, reviewID).Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed)
+	`, reviewID).Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.StructuredOutput)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/reviews.go
+++ b/internal/storage/reviews.go
@@ -15,8 +15,15 @@ func (db *DB) GetReviewByJobID(jobID int64) (*Review, error) {
 	var reviewFields reviewScanFields
 	var job ReviewJob
 	var jobFields reviewJobScanFields
+	reviewDestinations := reviewScanDestinations(&r, &reviewFields)
+	jobDestinations := []any{
+		&job.ID, &job.UUID, &job.RepoID, &jobFields.CommitID, &job.GitRef, &jobFields.Branch, &jobFields.CIBaseBranch, &jobFields.SessionID, &jobFields.ResumeSourceUUID, &job.Agent, &job.Reasoning, &job.Status, &jobFields.EnqueuedAt,
+		&jobFields.StartedAt, &jobFields.FinishedAt, &jobFields.WorkerID, &jobFields.Error, &jobFields.Model, &jobFields.Provider, &jobFields.RequestedModel, &jobFields.RequestedProvider, &jobFields.JobType, &jobFields.ReviewType, &jobFields.PatchID,
+		&job.RepoPath, &job.RepoName, &jobFields.CommitSubject, &jobFields.TokenUsage, &jobFields.MinSeverity, &jobFields.BackupAgent, &jobFields.BackupModel,
+		&jobFields.PanelRunUUID, &jobFields.PanelRole, &jobFields.PanelName, &jobFields.PanelMemberName, &jobFields.PanelMemberIndex, &jobFields.PanelMemberConfig, &jobFields.ClaimBlocked,
+	}
 	err := db.QueryRow(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.uuid, rv.verdict_bool, rv.structured_output,
+		SELECT `+reviewSelectColumns+`,
 		       j.id, COALESCE(j.uuid, ''), j.repo_id, j.commit_id, j.git_ref, j.branch, j.ci_base_branch, j.session_id, j.resume_source_job_uuid, j.agent, j.reasoning, j.status, j.enqueued_at,
 		       j.started_at, j.finished_at, j.worker_id, j.error, j.model, j.provider, j.requested_model, j.requested_provider, j.job_type, j.review_type, j.patch_id,
 		       rp.root_path, rp.name, c.subject, j.token_usage, COALESCE(j.min_severity, ''), COALESCE(j.backup_agent, ''), COALESCE(j.backup_model, ''),
@@ -26,11 +33,7 @@ func (db *DB) GetReviewByJobID(jobID int64) (*Review, error) {
 		JOIN repos rp ON rp.id = j.repo_id
 		LEFT JOIN commits c ON c.id = j.commit_id
 		WHERE rv.job_id = ?
-	`, jobID).Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &reviewFields.CreatedAt, &reviewFields.Closed, &reviewFields.UUID, &reviewFields.VerdictBool, &reviewFields.StructuredOutput,
-		&job.ID, &job.UUID, &job.RepoID, &jobFields.CommitID, &job.GitRef, &jobFields.Branch, &jobFields.CIBaseBranch, &jobFields.SessionID, &jobFields.ResumeSourceUUID, &job.Agent, &job.Reasoning, &job.Status, &jobFields.EnqueuedAt,
-		&jobFields.StartedAt, &jobFields.FinishedAt, &jobFields.WorkerID, &jobFields.Error, &jobFields.Model, &jobFields.Provider, &jobFields.RequestedModel, &jobFields.RequestedProvider, &jobFields.JobType, &jobFields.ReviewType, &jobFields.PatchID,
-		&job.RepoPath, &job.RepoName, &jobFields.CommitSubject, &jobFields.TokenUsage, &jobFields.MinSeverity, &jobFields.BackupAgent, &jobFields.BackupModel,
-		&jobFields.PanelRunUUID, &jobFields.PanelRole, &jobFields.PanelName, &jobFields.PanelMemberName, &jobFields.PanelMemberIndex, &jobFields.PanelMemberConfig, &jobFields.ClaimBlocked)
+	`, jobID).Scan(append(reviewDestinations, jobDestinations...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +81,7 @@ func (db *DB) GetReviewByCommitSHA(sha string) (*Review, error) {
 // GetAllReviewsForGitRef returns all reviews for a git ref (commit SHA or range) for re-review context
 func (db *DB) GetAllReviewsForGitRef(gitRef string) ([]Review, error) {
 	rows, err := db.Query(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.structured_output
+		SELECT `+reviewSelectColumns+`
 		FROM reviews rv
 		JOIN review_jobs j ON j.id = rv.job_id
 		WHERE j.git_ref = ?
@@ -92,12 +95,10 @@ func (db *DB) GetAllReviewsForGitRef(gitRef string) ([]Review, error) {
 
 	var reviews []Review
 	for rows.Next() {
-		var r Review
-		var fields reviewScanFields
-		if err := rows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.StructuredOutput); err != nil {
+		r, err := scanReview(rows)
+		if err != nil {
 			return nil, err
 		}
-		applyReviewScan(&r, fields)
 		reviews = append(reviews, r)
 	}
 
@@ -107,7 +108,7 @@ func (db *DB) GetAllReviewsForGitRef(gitRef string) ([]Review, error) {
 // GetRecentReviewsForRepo returns the N most recent reviews for a repo
 func (db *DB) GetRecentReviewsForRepo(repoID int64, limit int) ([]Review, error) {
 	rows, err := db.Query(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.structured_output
+		SELECT `+reviewSelectColumns+`
 		FROM reviews rv
 		JOIN review_jobs j ON j.id = rv.job_id
 		WHERE j.repo_id = ?
@@ -121,12 +122,10 @@ func (db *DB) GetRecentReviewsForRepo(repoID int64, limit int) ([]Review, error)
 
 	var reviews []Review
 	for rows.Next() {
-		var r Review
-		var fields reviewScanFields
-		if err := rows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.StructuredOutput); err != nil {
+		r, err := scanReview(rows)
+		if err != nil {
 			return nil, err
 		}
-		applyReviewScan(&r, fields)
 		reviews = append(reviews, r)
 	}
 
@@ -480,10 +479,10 @@ func (db *DB) GetJobsWithReviewsByIDs(jobIDs []int64) (map[int64]JobWithReview, 
 
 	// Fetch reviews for these jobs
 	reviewQuery := fmt.Sprintf(`
-		SELECT rv.id, rv.job_id, rv.agent, rv.prompt, rv.output, rv.created_at, rv.closed, rv.verdict_bool, rv.structured_output
+		SELECT %s
 		FROM reviews rv
 		WHERE rv.job_id IN (%s)
-	`, inClause)
+	`, reviewSelectColumns, inClause)
 
 	reviewRows, err := db.Query(reviewQuery, args...)
 	if err != nil {
@@ -492,12 +491,10 @@ func (db *DB) GetJobsWithReviewsByIDs(jobIDs []int64) (map[int64]JobWithReview, 
 	defer reviewRows.Close()
 
 	for reviewRows.Next() {
-		var r Review
-		var fields reviewScanFields
-		if err := reviewRows.Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.VerdictBool, &fields.StructuredOutput); err != nil {
+		r, fields, err := scanReviewFields(reviewRows)
+		if err != nil {
 			return nil, fmt.Errorf("scan review: %w", err)
 		}
-		applyReviewScan(&r, fields)
 
 		if entry, ok := result[r.JobID]; ok {
 			entry.Review = &r
@@ -514,18 +511,13 @@ func (db *DB) GetJobsWithReviewsByIDs(jobIDs []int64) (map[int64]JobWithReview, 
 
 // GetReviewByID finds a review by its ID
 func (db *DB) GetReviewByID(reviewID int64) (*Review, error) {
-	var r Review
-	var fields reviewScanFields
-
-	err := db.QueryRow(`
-		SELECT id, job_id, agent, prompt, output, created_at, closed, structured_output
-		FROM reviews WHERE id = ?
-	`, reviewID).Scan(&r.ID, &r.JobID, &r.Agent, &r.Prompt, &r.Output, &fields.CreatedAt, &fields.Closed, &fields.StructuredOutput)
+	r, err := scanReview(db.QueryRow(`
+		SELECT `+reviewSelectColumns+`
+		FROM reviews rv WHERE rv.id = ?
+	`, reviewID))
 	if err != nil {
 		return nil, err
 	}
-	applyReviewScan(&r, fields)
-
 	return &r, nil
 }
 

--- a/internal/storage/reviews_test.go
+++ b/internal/storage/reviews_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -542,6 +543,83 @@ func TestGetReviewByCommitSHAUsesStoredVerdict(t *testing.T) {
 
 	assert.False(t, review.VerdictBool == nil || *review.VerdictBool != 0)
 	assert.False(t, review.Job == nil || review.Job.Verdict == nil || *review.Job.Verdict != "F")
+}
+
+func TestReviewLoadersUseStoredStructuredVerdict(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, "/tmp/structured-verdict-read-test")
+	job, err := db.EnqueueJob(EnqueueOpts{
+		RepoID:      repo.ID,
+		GitRef:      "structured-verdict-ref",
+		Agent:       "test",
+		ReviewType:  "custom-review",
+		MinSeverity: "high",
+	})
+	require.NoError(t, err)
+	claimed, err := db.ClaimJob("test-worker")
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+	require.NoError(t, db.CompleteJobResult(
+		job.ID,
+		"test",
+		"prompt",
+		ReviewCompletion{
+			Output: "## Summary\n\nHigh: no actionable findings.\n\n" +
+				"No findings at or above the configured severity threshold.\n",
+			Verdict: VerdictPass,
+			StructuredOutput: json.RawMessage(`{
+  "summary":"High: no actionable findings.",
+  "findings":[
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+  ]
+}`),
+		},
+	))
+	canonical, err := db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+
+	loaders := []struct {
+		name string
+		load func(*testing.T) *Review
+	}{
+		{
+			name: "by ID",
+			load: func(t *testing.T) *Review {
+				review, err := db.GetReviewByID(canonical.ID)
+				require.NoError(t, err)
+				return review
+			},
+		},
+		{
+			name: "all for ref",
+			load: func(t *testing.T) *Review {
+				reviews, err := db.GetAllReviewsForGitRef(job.GitRef)
+				require.NoError(t, err)
+				require.Len(t, reviews, 1)
+				return &reviews[0]
+			},
+		},
+		{
+			name: "recent for repo",
+			load: func(t *testing.T) *Review {
+				reviews, err := db.GetRecentReviewsForRepo(repo.ID, 1)
+				require.NoError(t, err)
+				require.Len(t, reviews, 1)
+				return &reviews[0]
+			},
+		},
+	}
+	for _, tc := range loaders {
+		t.Run(tc.name, func(t *testing.T) {
+			review := tc.load(t)
+			assert := assert.New(t)
+			assert.Equal(VerdictPass, review.Verdict())
+			assert.NotNil(review.VerdictBool)
+			assert.NotEmpty(review.StructuredOutput)
+		})
+	}
 }
 
 // createCompletedJobWithOptions helper creates a job, claims it, and completes it.

--- a/internal/storage/reviews_test.go
+++ b/internal/storage/reviews_test.go
@@ -570,9 +570,10 @@ func TestReviewLoadersUseStoredStructuredVerdict(t *testing.T) {
 				"No findings at or above the configured severity threshold.\n",
 			Verdict: VerdictPass,
 			StructuredOutput: json.RawMessage(`{
-  "summary":"High: no actionable findings.",
+	  "schema_version":1,
+	  "summary":"High: no actionable findings.",
   "findings":[
-    {"severity":"low","problem":"Name is vague.","fix":"Rename it."}
+    {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
   ]
 }`),
 		},

--- a/internal/storage/schemas/postgres_v20.sql
+++ b/internal/storage/schemas/postgres_v20.sql
@@ -1,0 +1,188 @@
+-- PostgreSQL schema version 20
+-- On top of v19 (review experiments), preserves the canonical stored verdict
+-- when reviews synchronize between machines.
+-- Note: Version is managed by EnsureSchema(), not this file.
+
+CREATE SCHEMA IF NOT EXISTS roborev;
+
+CREATE TABLE IF NOT EXISTS roborev.schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.machines (
+  id SERIAL PRIMARY KEY,
+  machine_id UUID UNIQUE NOT NULL,
+  name TEXT,
+  last_seen_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.repos (
+  id SERIAL PRIMARY KEY,
+  identity TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.commits (
+  id SERIAL PRIMARY KEY,
+  repo_id INTEGER REFERENCES roborev.repos(id),
+  sha TEXT NOT NULL,
+  author TEXT NOT NULL,
+  subject TEXT NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(repo_id, sha)
+);
+
+CREATE TABLE IF NOT EXISTS roborev.review_jobs (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  repo_id INTEGER NOT NULL REFERENCES roborev.repos(id),
+  commit_id INTEGER REFERENCES roborev.commits(id),
+  git_ref TEXT NOT NULL,
+  branch TEXT,
+  session_id TEXT,
+  resume_source_job_uuid TEXT,
+  agent TEXT NOT NULL,
+  model TEXT,
+  provider TEXT,
+  requested_model TEXT,
+  requested_provider TEXT,
+  reasoning TEXT,
+  job_type TEXT NOT NULL DEFAULT 'review',
+  review_type TEXT NOT NULL DEFAULT '',
+  patch_id TEXT,
+  status TEXT NOT NULL CHECK(status IN ('queued', 'running', 'done', 'failed', 'canceled', 'applied', 'rebased', 'skipped')),
+  agentic BOOLEAN DEFAULT FALSE,
+  agent_invoked BOOLEAN NOT NULL DEFAULT FALSE,
+  enqueued_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  started_at TIMESTAMP WITH TIME ZONE,
+  finished_at TIMESTAMP WITH TIME ZONE,
+  retry_not_before TIMESTAMP WITH TIME ZONE,
+  prompt TEXT,
+  diff_content TEXT,
+  dirty_files TEXT,
+  error TEXT,
+  token_usage TEXT,
+  worktree_path TEXT,
+  min_severity TEXT NOT NULL DEFAULT '',
+  backup_agent TEXT NOT NULL DEFAULT '',
+  backup_model TEXT NOT NULL DEFAULT '',
+  skip_reason TEXT,
+  source TEXT,
+  panel_run_uuid TEXT,
+  panel_role TEXT,
+  panel_name TEXT,
+  panel_member_name TEXT,
+  panel_member_index INTEGER,
+  panel_member_config_json TEXT,
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.reviews (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  agent TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  output TEXT NOT NULL,
+  closed BOOLEAN NOT NULL DEFAULT FALSE,
+  verdict_bool BOOLEAN,
+  updated_by_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.responses (
+  id SERIAL PRIMARY KEY,
+  uuid UUID UNIQUE NOT NULL,
+  job_uuid UUID NOT NULL REFERENCES roborev.review_jobs(uuid),
+  responder TEXT NOT NULL,
+  response TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'local',
+  source_machine_id UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  inserted_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE TABLE IF NOT EXISTS roborev.experiment_definitions (
+  experiment_id TEXT PRIMARY KEY,
+  definition_hash TEXT NOT NULL,
+  definition_json TEXT NOT NULL,
+  first_seen_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  source_machine_id UUID NOT NULL,
+  synced_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE TABLE IF NOT EXISTS roborev.experiment_assignments (
+  id BIGSERIAL UNIQUE NOT NULL,
+  review_unit_kind TEXT NOT NULL,
+  review_unit_uuid TEXT NOT NULL,
+  experiment_id TEXT NOT NULL REFERENCES roborev.experiment_definitions(experiment_id),
+  arm TEXT NOT NULL,
+  subject_hash TEXT NOT NULL,
+  effective_config_hash TEXT NOT NULL,
+  effective_config_json TEXT NOT NULL,
+  assigned_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  inserted_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp(),
+  source_machine_id UUID NOT NULL,
+  synced_at TIMESTAMP WITH TIME ZONE,
+  PRIMARY KEY (review_unit_kind, review_unit_uuid, experiment_id)
+);
+
+-- ci_pr_review_attempts holds local CI-poller retry state keyed by
+-- (github_repo, pr_number, head_sha). It is the durable source of truth for
+-- whether a HEAD is being reviewed and, when an AI-provider outage defers it,
+-- when to retry. One row per reviewed HEAD. next_attempt_at is NULL while a
+-- run is in-flight or pending and set once deferred. state is one of
+-- 'pending', 'deferred', or 'done'. This table is created in both the SQLite
+-- and Postgres backends for schema parity per the design, but it is NOT
+-- registered in any sync cursor (not sync-replicated). Avoid inline
+-- semicolons in this comment -- pgSchemaStatements splits the embedded
+-- Postgres schema on semicolons, so a literal one here would fragment the
+-- comment into a bad statement.
+CREATE TABLE IF NOT EXISTS roborev.ci_pr_review_attempts (
+  id BIGSERIAL PRIMARY KEY,
+  github_repo TEXT NOT NULL,
+  pr_number INTEGER NOT NULL,
+  head_sha TEXT NOT NULL,
+  attempt INTEGER NOT NULL DEFAULT 1,
+  first_attempt_at TIMESTAMPTZ NOT NULL,
+  next_attempt_at TIMESTAMPTZ,
+  last_error_class TEXT NOT NULL DEFAULT '',
+  consecutive_genuine_attempts INTEGER NOT NULL DEFAULT 0,
+  last_error_excerpt TEXT NOT NULL DEFAULT '',
+  last_panel_run_uuid TEXT NOT NULL DEFAULT '',
+  state TEXT NOT NULL DEFAULT 'pending',
+  updated_at TIMESTAMPTZ NOT NULL,
+  UNIQUE(github_repo, pr_number, head_sha)
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_jobs_source ON roborev.review_jobs(source_machine_id);
+CREATE INDEX IF NOT EXISTS idx_review_jobs_updated ON roborev.review_jobs(updated_at);
+-- Note: idx_review_jobs_branch, idx_review_jobs_job_type,
+-- idx_review_jobs_patch_id, and idx_review_jobs_panel are created by
+-- migration code, not here (to support upgrades from older versions
+-- where those columns don't exist yet — the embedded schema is replayed
+-- on every startup, including against older databases).
+CREATE INDEX IF NOT EXISTS idx_reviews_job_uuid ON roborev.reviews(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_reviews_updated ON roborev.reviews(updated_at);
+CREATE INDEX IF NOT EXISTS idx_responses_job_uuid ON roborev.responses(job_uuid);
+CREATE INDEX IF NOT EXISTS idx_responses_id ON roborev.responses(id);
+-- idx_responses_inserted is created by EnsureSchema after migrations so
+-- upgrades from older schemas do not try to index a column before it exists.
+-- Partial unique indexes for auto-design dedup are created by EnsureSchema
+-- (fresh-init block + v12 migration step) — placing them here would break
+-- v1->v12 migrations where the source column doesn't yet exist when this
+-- schema is replayed.
+CREATE INDEX IF NOT EXISTS idx_experiment_assignments_subject
+  ON roborev.experiment_assignments(experiment_id, subject_hash);
+CREATE INDEX IF NOT EXISTS idx_experiment_assignments_inserted
+  ON roborev.experiment_assignments(inserted_at, id);
+
+CREATE TABLE IF NOT EXISTS roborev.sync_metadata (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/internal/storage/schemas/postgres_v20.sql
+++ b/internal/storage/schemas/postgres_v20.sql
@@ -1,6 +1,6 @@
 -- PostgreSQL schema version 20
 -- On top of v19 (review experiments), preserves the canonical stored verdict
--- when reviews synchronize between machines.
+-- and schema-constrained output when reviews synchronize between machines.
 -- Note: Version is managed by EnsureSchema(), not this file.
 
 CREATE SCHEMA IF NOT EXISTS roborev;
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS roborev.reviews (
   output TEXT NOT NULL,
   closed BOOLEAN NOT NULL DEFAULT FALSE,
   verdict_bool BOOLEAN,
+  structured_output JSONB,
   updated_by_machine_id UUID NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -629,6 +630,7 @@ type SyncableReview struct {
 	Output             string
 	Closed             bool
 	VerdictBool        *bool
+	StructuredOutput   json.RawMessage
 	UpdatedByMachineID string
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
@@ -641,7 +643,7 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 		SELECT
 			r.id, r.uuid, r.job_id, j.uuid,
 			r.agent, r.prompt, r.output, r.closed,
-			r.verdict_bool, r.updated_by_machine_id, r.created_at, r.updated_at
+			r.verdict_bool, r.structured_output, r.updated_by_machine_id, r.created_at, r.updated_at
 		FROM reviews r
 		JOIN review_jobs j ON r.job_id = j.id
 		WHERE r.updated_by_machine_id = ?
@@ -662,11 +664,12 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 		var r SyncableReview
 		var createdAt, updatedAt string
 		var verdictBool sql.NullBool
+		var structuredOutput sql.NullString
 
 		err := rows.Scan(
 			&r.ID, &r.UUID, &r.JobID, &r.JobUUID,
 			&r.Agent, &r.Prompt, &r.Output, &r.Closed,
-			&verdictBool, &r.UpdatedByMachineID, &createdAt, &updatedAt,
+			&verdictBool, &structuredOutput, &r.UpdatedByMachineID, &createdAt, &updatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan review: %w", err)
@@ -676,6 +679,9 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 		r.UpdatedAt = parseSQLiteTime(updatedAt)
 		if verdictBool.Valid {
 			r.VerdictBool = new(verdictBool.Bool)
+		}
+		if structuredOutput.Valid {
+			r.StructuredOutput = json.RawMessage(structuredOutput.String)
 		}
 		reviews = append(reviews, r)
 	}
@@ -875,17 +881,18 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 	_, err = db.Exec(`
 		INSERT INTO reviews (
 			uuid, job_id, agent, prompt, output, closed,
-			verdict_bool, updated_by_machine_id, created_at, updated_at, synced_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			verdict_bool, structured_output, updated_by_machine_id, created_at, updated_at, synced_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(uuid) DO UPDATE SET
 			closed = excluded.closed,
 			verdict_bool = COALESCE(excluded.verdict_bool, reviews.verdict_bool),
+			structured_output = COALESCE(excluded.structured_output, reviews.structured_output),
 			updated_by_machine_id = excluded.updated_by_machine_id,
 			updated_at = excluded.updated_at,
 			synced_at = ?
 			WHERE `+sqliteNormalizedTimestampExpr("reviews.updated_at")+` < `+sqliteNormalizedTimestampExpr("excluded.updated_at")+`
 	`, r.UUID, jobID, r.Agent, r.Prompt, r.Output, r.Closed,
-		verdictBool,
+		verdictBool, nullStr(string(r.StructuredOutput)),
 		r.UpdatedByMachineID, r.CreatedAt.Format(time.RFC3339), r.UpdatedAt.Format(time.RFC3339), now, now)
 	return err
 }

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -628,6 +628,7 @@ type SyncableReview struct {
 	Prompt             string
 	Output             string
 	Closed             bool
+	VerdictBool        *bool
 	UpdatedByMachineID string
 	CreatedAt          time.Time
 	UpdatedAt          time.Time
@@ -640,7 +641,7 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 		SELECT
 			r.id, r.uuid, r.job_id, j.uuid,
 			r.agent, r.prompt, r.output, r.closed,
-			r.updated_by_machine_id, r.created_at, r.updated_at
+			r.verdict_bool, r.updated_by_machine_id, r.created_at, r.updated_at
 		FROM reviews r
 		JOIN review_jobs j ON r.job_id = j.id
 		WHERE r.updated_by_machine_id = ?
@@ -660,11 +661,12 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 	for rows.Next() {
 		var r SyncableReview
 		var createdAt, updatedAt string
+		var verdictBool sql.NullBool
 
 		err := rows.Scan(
 			&r.ID, &r.UUID, &r.JobID, &r.JobUUID,
 			&r.Agent, &r.Prompt, &r.Output, &r.Closed,
-			&r.UpdatedByMachineID, &createdAt, &updatedAt,
+			&verdictBool, &r.UpdatedByMachineID, &createdAt, &updatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan review: %w", err)
@@ -672,6 +674,9 @@ func (db *DB) GetReviewsToSync(machineID string, limit int) ([]SyncableReview, e
 
 		r.CreatedAt = parseSQLiteTime(createdAt)
 		r.UpdatedAt = parseSQLiteTime(updatedAt)
+		if verdictBool.Valid {
+			r.VerdictBool = new(verdictBool.Bool)
+		}
 		reviews = append(reviews, r)
 	}
 	return reviews, rows.Err()
@@ -859,7 +864,12 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	var verdictBool any
-	if r.Output != "" {
+	if r.VerdictBool != nil {
+		verdictBool = 0
+		if *r.VerdictBool {
+			verdictBool = 1
+		}
+	} else if r.Output != "" {
 		verdictBool = verdictToBool(ParseVerdict(r.Output))
 	}
 	_, err = db.Exec(`
@@ -869,7 +879,7 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(uuid) DO UPDATE SET
 			closed = excluded.closed,
-			verdict_bool = COALESCE(reviews.verdict_bool, excluded.verdict_bool),
+			verdict_bool = COALESCE(excluded.verdict_bool, reviews.verdict_bool),
 			updated_by_machine_id = excluded.updated_by_machine_id,
 			updated_at = excluded.updated_at,
 			synced_at = ?

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -570,6 +570,29 @@ func TestGetReviewsToSync_RequiresJobSynced(t *testing.T) {
 	require.NoError(t, err, "GetReviewsToSync failed: %v")
 
 	assert.Len(t, reviews, 1)
+	require.NotNil(t, reviews[0].VerdictBool)
+	assert.False(t, *reviews[0].VerdictBool)
+}
+
+func TestUpsertPulledReviewUsesStoredVerdict(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createPendingJob("stored-review-verdict")
+
+	require.NoError(t, h.db.UpsertPulledReview(PulledReview{
+		UUID:               GenerateUUID(),
+		JobUUID:            job.UUID,
+		Agent:              "test",
+		Prompt:             "prompt",
+		Output:             "No issues found.",
+		VerdictBool:        new(false),
+		UpdatedByMachineID: GenerateUUID(),
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}))
+
+	review, err := h.db.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, VerdictFail, review.Verdict())
 }
 
 // TestGetCommentsToSync_RequiresJobSynced verifies that responses are only

--- a/internal/storage/syncworker.go
+++ b/internal/storage/syncworker.go
@@ -845,18 +845,7 @@ func (w *SyncWorker) pullChangesWithStats(ctx context.Context, pool *PgPool) (pu
 		}
 
 		for _, r := range reviews {
-			pr := PulledReview{
-				UUID:               r.UUID,
-				JobUUID:            r.JobUUID,
-				Agent:              r.Agent,
-				Prompt:             r.Prompt,
-				Output:             r.Output,
-				Closed:             r.Closed,
-				UpdatedByMachineID: r.UpdatedByMachineID,
-				CreatedAt:          r.CreatedAt,
-				UpdatedAt:          r.UpdatedAt,
-			}
-			if err := w.db.UpsertPulledReview(pr); err != nil {
+			if err := w.db.UpsertPulledReview(r); err != nil {
 				// Don't advance cursor if any upsert fails - we'll retry next sync
 				return stats, fmt.Errorf("pull review %s: %w", r.UUID, err)
 			}

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -7,15 +7,34 @@ import (
 	"go.kenn.io/roborev/internal/config"
 )
 
+// Verdict is the canonical pass/fail result of a completed review. The empty
+// value means no verdict is available, for example when a review produced no
+// output.
+type Verdict string
+
 const (
-	verdictPass = "P"
-	verdictFail = "F"
+	VerdictUnknown Verdict = ""
+	VerdictPass    Verdict = "P"
+	VerdictFail    Verdict = "F"
 )
+
+// VerdictFromPassed converts a structured pass/fail result into a Verdict.
+func VerdictFromPassed(passed bool) Verdict {
+	if passed {
+		return VerdictPass
+	}
+	return VerdictFail
+}
+
+// Passed reports whether the verdict is an explicit pass.
+func (v Verdict) Passed() bool {
+	return v == VerdictPass
+}
 
 // verdictToBool converts a ParseVerdict result ("P"/"F") to an integer
 // for storage in the verdict_bool column (1=pass, 0=fail).
-func verdictToBool(verdict string) int {
-	if verdict == verdictPass {
+func verdictToBool(verdict Verdict) int {
+	if verdict == VerdictPass {
 		return 1
 	}
 	return 0
@@ -23,12 +42,12 @@ func verdictToBool(verdict string) int {
 
 // verdictFromBoolOrParse returns the verdict string from a stored verdict_bool
 // value. If the value is NULL (legacy row), falls back to ParseVerdict(output).
-func verdictFromBoolOrParse(vb sql.NullInt64, output string) string {
+func verdictFromBoolOrParse(vb sql.NullInt64, output string) Verdict {
 	if vb.Valid {
 		if vb.Int64 == 1 {
-			return verdictPass
+			return VerdictPass
 		}
-		return verdictFail
+		return VerdictFail
 	}
 	return ParseVerdict(output)
 }
@@ -42,12 +61,12 @@ func applyReviewVerdict(review *Review, verdictBool sql.NullInt64) {
 
 // Verdict returns the review's stored pass/fail result. Reviews created before
 // verdict_bool was populated retain the existing Markdown fallback.
-func (r Review) Verdict() string {
+func (r Review) Verdict() Verdict {
 	if r.VerdictBool != nil {
 		if *r.VerdictBool == 1 {
-			return verdictPass
+			return VerdictPass
 		}
-		return verdictFail
+		return VerdictFail
 	}
 	return ParseVerdict(r.Output)
 }
@@ -61,7 +80,8 @@ func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, h
 		return
 	}
 	verdict := verdictFromBoolOrParse(verdictBool, output)
-	job.Verdict = &verdict
+	value := string(verdict)
+	job.Verdict = &value
 }
 
 // ParseVerdict extracts P (pass) or F (fail) from review output.
@@ -71,11 +91,11 @@ func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, h
 // that quickly turns into a brittle natural-language parser. If agent output is
 // too chatty or mixes process narration with findings, that should be fixed in
 // the review prompt rather than by adding more verdict heuristics here.
-func ParseVerdict(output string) string {
+func ParseVerdict(output string) Verdict {
 	// First check for severity labels which indicate actual findings
 	// These appear as "- Medium —", "* Low:", "Critical -", etc.
 	if hasSeverityLabel(output) {
-		return verdictFail
+		return VerdictFail
 	}
 
 	// Marker signals pass ONLY when it stands alone. A loose
@@ -83,7 +103,7 @@ func ParseVerdict(output string) string {
 	// labels (e.g. "the auth module leaks tokens") flip to pass
 	// just because the agent echoed the marker in narration.
 	if config.IsMarkerOnlyOutput(output) {
-		return verdictPass
+		return VerdictPass
 	}
 
 	for line := range strings.SplitSeq(output, "\n") {
@@ -92,17 +112,17 @@ func ParseVerdict(output string) string {
 		// before a later "No issues found." summary. Preserve the existing rule
 		// that a later clear pass phrase wins over contradictory narration.
 		if isExplicitVerdictValue(normalized, "pass") {
-			return verdictPass
+			return VerdictPass
 		}
 		if isNoFindingVerdictLine(normalized) {
-			return verdictPass
+			return VerdictPass
 		}
 		if !hasPassPrefix(normalized) {
 			continue
 		}
-		return verdictPass
+		return VerdictPass
 	}
-	return verdictFail
+	return VerdictFail
 }
 
 func normalizeVerdictLine(line string) string {

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -40,6 +40,18 @@ func applyReviewVerdict(review *Review, verdictBool sql.NullInt64) {
 	}
 }
 
+// Verdict returns the review's stored pass/fail result. Reviews created before
+// verdict_bool was populated retain the existing Markdown fallback.
+func (r Review) Verdict() string {
+	if r.VerdictBool != nil {
+		if *r.VerdictBool == 1 {
+			return verdictPass
+		}
+		return verdictFail
+	}
+	return ParseVerdict(r.Output)
+}
+
 // applyJobVerdict derives the job's verdict from the stored verdict_bool,
 // falling back to parsing the review output. hasReview reports whether a
 // non-empty review output exists; callers that skip hydrating the output for

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -29,6 +29,17 @@ func runVerdictTests(t *testing.T, tests []verdictTestCase) {
 	}
 }
 
+func TestReviewVerdictUsesStoredValue(t *testing.T) {
+	assert.Equal(t, VerdictFail, (Review{
+		Output:      "No issues found.",
+		VerdictBool: new(0),
+	}).Verdict())
+	assert.Equal(t, VerdictPass, (Review{
+		Output:      "High: broken behavior",
+		VerdictBool: new(1),
+	}).Verdict())
+}
+
 var verdictTests = []verdictTestCase{
 	// --- SimplePass: basic "no issues found" phrasing ---
 	{

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -6,15 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	VerdictPass = "P"
-	VerdictFail = "F"
-)
-
 type verdictTestCase struct {
 	name   string
 	output string
-	want   string
+	want   Verdict
 }
 
 func runVerdictTests(t *testing.T, tests []verdictTestCase) {

--- a/internal/structuredreview/document.go
+++ b/internal/structuredreview/document.go
@@ -1,0 +1,215 @@
+package structuredreview
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const SchemaVersion = 1
+
+var Schema = json.RawMessage(fmt.Sprintf(`{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "summary", "findings"],
+  "properties": {
+    "schema_version": {"type": "integer", "const": %d},
+    "summary": {"type": "string", "minLength": 1},
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "problem", "fix", "location"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low"]
+          },
+          "problem": {"type": "string", "minLength": 1},
+          "fix": {"type": "string", "minLength": 1},
+          "location": {"type": ["string", "null"]}
+        }
+      }
+    }
+  }
+}`, SchemaVersion))
+
+type Document struct {
+	SchemaVersion int       `json:"schema_version"`
+	Summary       string    `json:"summary"`
+	Findings      []Finding `json:"findings"`
+}
+
+type Finding struct {
+	Severity string `json:"severity"`
+	Problem  string `json:"problem"`
+	Fix      string `json:"fix"`
+	Location string `json:"location,omitempty"`
+}
+
+type documentWire struct {
+	SchemaVersion int           `json:"schema_version"`
+	Summary       string        `json:"summary"`
+	Findings      []findingWire `json:"findings"`
+}
+
+type findingWire struct {
+	Severity string          `json:"severity"`
+	Problem  string          `json:"problem"`
+	Fix      string          `json:"fix"`
+	Location json.RawMessage `json:"location"`
+}
+
+func Decode(raw json.RawMessage) (Document, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var wire documentWire
+	if err := dec.Decode(&wire); err != nil {
+		return Document{}, fmt.Errorf("decode structured review: %w", err)
+	}
+	if err := ensureEOF(dec); err != nil {
+		return Document{}, err
+	}
+	if wire.Findings == nil {
+		return Document{}, fmt.Errorf("structured review findings is required")
+	}
+	result := Document{
+		SchemaVersion: wire.SchemaVersion,
+		Summary:       wire.Summary,
+		Findings:      make([]Finding, len(wire.Findings)),
+	}
+	for i, finding := range wire.Findings {
+		if len(finding.Location) == 0 {
+			return Document{}, fmt.Errorf(
+				"structured review finding %d has no location field", i+1,
+			)
+		}
+		var location string
+		if !bytes.Equal(finding.Location, []byte("null")) {
+			if err := json.Unmarshal(finding.Location, &location); err != nil {
+				return Document{}, fmt.Errorf(
+					"structured review finding %d has invalid location: %w", i+1, err,
+				)
+			}
+		}
+		result.Findings[i] = Finding{
+			Severity: finding.Severity,
+			Problem:  finding.Problem,
+			Fix:      finding.Fix,
+			Location: location,
+		}
+	}
+	if result.SchemaVersion != SchemaVersion {
+		return Document{}, fmt.Errorf(
+			"unsupported structured review schema_version %d",
+			result.SchemaVersion,
+		)
+	}
+	result.Summary = strings.TrimSpace(result.Summary)
+	if result.Summary == "" {
+		return Document{}, fmt.Errorf("structured review summary is required")
+	}
+	for i := range result.Findings {
+		finding := &result.Findings[i]
+		finding.Severity = strings.ToLower(strings.TrimSpace(finding.Severity))
+		finding.Problem = strings.TrimSpace(finding.Problem)
+		finding.Fix = strings.TrimSpace(finding.Fix)
+		finding.Location = strings.TrimSpace(finding.Location)
+		if severityRank(finding.Severity) == 0 {
+			return Document{}, fmt.Errorf(
+				"structured review finding %d has invalid severity %q",
+				i+1, finding.Severity,
+			)
+		}
+		if finding.Problem == "" {
+			return Document{}, fmt.Errorf(
+				"structured review finding %d has no problem", i+1,
+			)
+		}
+		if finding.Fix == "" {
+			return Document{}, fmt.Errorf(
+				"structured review finding %d has no fix", i+1,
+			)
+		}
+	}
+	return result, nil
+}
+
+func ensureEOF(dec *json.Decoder) error {
+	var extra any
+	err := dec.Decode(&extra)
+	if err == io.EOF {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("decode trailing structured review data: %w", err)
+	}
+	return fmt.Errorf("structured review contains trailing JSON")
+}
+
+func (r Document) Filter(minSeverity string) Document {
+	threshold := severityRank(strings.ToLower(strings.TrimSpace(minSeverity)))
+	if threshold == 0 {
+		threshold = severityRank("low")
+	}
+	filtered := Document{
+		SchemaVersion: r.SchemaVersion,
+		Summary:       r.Summary,
+		Findings:      make([]Finding, 0, len(r.Findings)),
+	}
+	for _, finding := range r.Findings {
+		if severityRank(finding.Severity) >= threshold {
+			filtered.Findings = append(filtered.Findings, finding)
+		}
+	}
+	return filtered
+}
+
+func (r Document) Passed() bool {
+	return len(r.Findings) == 0
+}
+
+func (r Document) Markdown() string {
+	var out strings.Builder
+	out.WriteString("## Summary\n\n")
+	out.WriteString(strings.TrimSpace(r.Summary))
+	if len(r.Findings) == 0 {
+		out.WriteString("\n\nNo findings at or above the configured severity threshold.\n")
+		return out.String()
+	}
+	out.WriteString("\n\n## Findings\n")
+	for i, finding := range r.Findings {
+		fmt.Fprintf(&out, "\n### %d. %s\n\n", i+1, titleSeverity(finding.Severity))
+		if finding.Location != "" {
+			fmt.Fprintf(&out, "**Location:** %s\n\n", finding.Location)
+		}
+		fmt.Fprintf(&out, "**Problem:** %s\n\n", finding.Problem)
+		fmt.Fprintf(&out, "**Fix:** %s\n", finding.Fix)
+	}
+	return out.String()
+}
+
+func severityRank(severity string) int {
+	switch severity {
+	case "critical":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func titleSeverity(severity string) string {
+	if severity == "" {
+		return "Finding"
+	}
+	return strings.ToUpper(severity[:1]) + severity[1:]
+}

--- a/packages/roborev-ui/src/generated.ts
+++ b/packages/roborev-ui/src/generated.ts
@@ -1923,7 +1923,9 @@ export interface components {
             job_id: number;
             output: string;
             prompt: string;
-            structured_output?: unknown;
+            structured_output?: {
+                [key: string]: unknown;
+            };
             /** Format: date-time */
             synced_at?: string;
             /** Format: date-time */

--- a/packages/roborev-ui/src/generated.ts
+++ b/packages/roborev-ui/src/generated.ts
@@ -1923,6 +1923,7 @@ export interface components {
             job_id: number;
             output: string;
             prompt: string;
+            structured_output?: unknown;
             /** Format: date-time */
             synced_at?: string;
             /** Format: date-time */

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1900,21 +1900,21 @@ func (r Response) Validate() error {
 
 type Review struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema             *string    `json:"$schema,omitempty"`
-	Agent              string     `json:"agent" validate:"required"`
-	Closed             bool       `json:"closed"`
-	CreatedAt          time.Time  `json:"created_at" validate:"required"`
-	ID                 int64      `json:"id"`
-	Job                *ReviewJob `json:"job,omitempty"`
-	JobID              int64      `json:"job_id"`
-	Output             string     `json:"output" validate:"required"`
-	Prompt             string     `json:"prompt" validate:"required"`
-	StructuredOutput   *struct{}  `json:"structured_output,omitempty"`
-	SyncedAt           *time.Time `json:"synced_at,omitempty"`
-	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
-	UpdatedByMachineID *string    `json:"updated_by_machine_id,omitempty"`
-	UUID               *string    `json:"uuid,omitempty"`
-	VerdictBool        *int64     `json:"verdict_bool,omitempty"`
+	Schema             *string        `json:"$schema,omitempty"`
+	Agent              string         `json:"agent" validate:"required"`
+	Closed             bool           `json:"closed"`
+	CreatedAt          time.Time      `json:"created_at" validate:"required"`
+	ID                 int64          `json:"id"`
+	Job                *ReviewJob     `json:"job,omitempty"`
+	JobID              int64          `json:"job_id"`
+	Output             string         `json:"output" validate:"required"`
+	Prompt             string         `json:"prompt" validate:"required"`
+	StructuredOutput   map[string]any `json:"structured_output,omitempty"`
+	SyncedAt           *time.Time     `json:"synced_at,omitempty"`
+	UpdatedAt          *time.Time     `json:"updated_at,omitempty"`
+	UpdatedByMachineID *string        `json:"updated_by_machine_id,omitempty"`
+	UUID               *string        `json:"uuid,omitempty"`
+	VerdictBool        *int64         `json:"verdict_bool,omitempty"`
 }
 
 func (r Review) Validate() error {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1909,6 +1909,7 @@ type Review struct {
 	JobID              int64      `json:"job_id"`
 	Output             string     `json:"output" validate:"required"`
 	Prompt             string     `json:"prompt" validate:"required"`
+	StructuredOutput   *struct{}  `json:"structured_output,omitempty"`
 	SyncedAt           *time.Time `json:"synced_at,omitempty"`
 	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
 	UpdatedByMachineID *string    `json:"updated_by_machine_id,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2518,6 +2518,7 @@ components:
           type: string
         prompt:
           type: string
+        structured_output: {}
         synced_at:
           format: date-time
           type: string

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2518,7 +2518,9 @@ components:
           type: string
         prompt:
           type: string
-        structured_output: {}
+        structured_output:
+          additionalProperties: true
+          type: object
         synced_at:
           format: date-time
           type: string

--- a/web/src/lib/api/generated.ts
+++ b/web/src/lib/api/generated.ts
@@ -1923,7 +1923,9 @@ export interface components {
             job_id: number;
             output: string;
             prompt: string;
-            structured_output?: unknown;
+            structured_output?: {
+                [key: string]: unknown;
+            };
             /** Format: date-time */
             synced_at?: string;
             /** Format: date-time */

--- a/web/src/lib/api/generated.ts
+++ b/web/src/lib/api/generated.ts
@@ -1923,6 +1923,7 @@ export interface components {
             job_id: number;
             output: string;
             prompt: string;
+            structured_output?: unknown;
             /** Format: date-time */
             synced_at?: string;
             /** Format: date-time */


### PR DESCRIPTION
Adds named custom review types to repository and global configuration. A type supplies a Go template, optional named file includes, and optional agent, model, and reasoning overrides, so teams can package specialized rubrics and run them through the existing review, CI, and panel workflows.

Template and include files use the same `max_prompt_size` budget as the rest of the prompt. Paths are treated as user-selected inputs: repository-relative, absolute, home-relative, parent-relative, and symlinked files are accepted. CI reads in-repository relative files from the configured base ref, while external paths come from the filesystem. Runtime URL fetching remains outside this feature.

Custom types require native JSON Schema output from Codex, Claude Code, Pi, or Grok. Roborev owns the schema, including the `critical`, `high`, `medium`, and `low` severity enum, filters findings at the effective severity threshold, and derives pass or fail from the filtered JSON. The structured result and canonical verdict now flow through foreground reviews, queued jobs, panel synthesis, SQLite, and PostgreSQL sync without reparsing rendered Markdown. Built-in review types retain their existing prose behavior, and their names cannot be replaced by custom configuration.

The new documentation covers configuration precedence, templates and includes, path behavior, compatible agents, severity guidance, and a complete `thermonuclear` example using the Cursor Team Kit rubric.
