### PR TITLE
agent-hook: add OpenCode authoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ You can also choose the exact binary path with
 - **Auto-Fix** - `roborev fix` feeds review findings to an agent that
   applies fixes and commits. `roborev refine` iterates until reviews pass.
 - **Agent Hook** - Optional hooks for Claude Code, Codex, Copilot CLI, Cursor,
-  Factory Droid, Gemini CLI, Hermes, and Qwen bring open findings back into the
-  active agent session.
+  Factory Droid, Gemini CLI, Hermes, OpenCode, and Qwen bring open findings back
+  into the active agent session.
 - **Code Analysis** - Built-in analysis types (duplication, complexity,
   refactoring, test fixtures, dead code, security) that agents can fix
   automatically.
@@ -100,9 +100,9 @@ changes and commits. The new commit gets reviewed automatically,
 closing the loop.
 
 `roborev agent-hook install` auto-detects installed Claude Code, Codex, Copilot
-CLI, Cursor, Factory Droid, Gemini CLI, Hermes, Qwen, and Grok Build harnesses
-and adds optional hooks after configured turn, commit, or failed-review
-thresholds are met. Reminders name exact review IDs, invoke the bundled
+CLI, Cursor, Factory Droid, Gemini CLI, Hermes, OpenCode, Qwen, and Grok Build
+harnesses and adds optional hooks after configured turn, commit, or
+failed-review thresholds are met. Reminders name exact review IDs, invoke the bundled
 `roborev-fix` skill, and include a complete CLI fallback when no roborev skill is
 installed; they do not run `roborev fix --open`. Supported profiles get current
 bundled skills during hook installation. Hermes delivers queued post-tool
@@ -211,7 +211,7 @@ leaving Markdown tables unchanged. Use `make check-renovate-config` to validate
 | `roborev refine` | Auto-fix loop: fix, re-review, repeat |
 | `roborev analyze <type>` | Run code analysis with optional auto-fix |
 | `roborev agent-hook install` | Install hooks for detected coding agents |
-| `roborev agent-hook install --agent all` | Install all nine supported integrations |
+| `roborev agent-hook install --agent all` | Install all ten supported integrations |
 | `roborev snooze` | Silence Agent Hook reminders in the current worktree and branch |
 | `roborev snooze off` | Resume Agent Hook reminders in the current worktree and branch |
 | `roborev compact` | Verify and consolidate open review findings |

--- a/cmd/roborev/agent_hook_handler.go
+++ b/cmd/roborev/agent_hook_handler.go
@@ -79,6 +79,28 @@ func (h roborevAgentHookHandler) PreToolUse(
 	return kitagenthook.PreToolUseOutput{}, nil
 }
 
+func (h roborevAgentHookHandler) UserPromptSubmit(
+	ctx context.Context,
+	input kitagenthook.UserPromptSubmitInput,
+) (kitagenthook.UserPromptSubmitOutput, error) {
+	req, err := h.request(input.CommonInput, "", nil)
+	if err != nil {
+		return kitagenthook.UserPromptSubmitOutput{}, err
+	}
+	// OpenCode has no controllable Stop hook. Its mutable chat.message hook runs
+	// once at the start of each real user turn, so use the existing Stop cadence.
+	req.Event.HookEventName = string(kitagenthook.EventStop)
+	resp, ok := h.post(ctx, req)
+	if !ok || !resp.Triggered {
+		return kitagenthook.UserPromptSubmitOutput{}, nil
+	}
+	return kitagenthook.UserPromptSubmitOutput{
+		AdditionalContext: agenthook.StopReasonWithFixGuidelines(
+			resp.Reason, h.opts.FixGuidelines,
+		),
+	}, nil
+}
+
 func (h roborevAgentHookHandler) PostToolUse(
 	ctx context.Context,
 	input kitagenthook.PostToolUseInput,

--- a/cmd/roborev/agent_hook_test.go
+++ b/cmd/roborev/agent_hook_test.go
@@ -238,6 +238,36 @@ func TestRunAgentHookEncodesKitStopResponse(t *testing.T) {
 	assert.Equal(t, "resolve reviews", output["reason"])
 }
 
+func TestRunAgentHookInjectsOpenCodePromptContext(t *testing.T) {
+	oldPost := postAgentHook
+	var got agenthook.Request
+	postAgentHook = func(_ context.Context, _ string, req agenthook.Request) (agenthook.Response, error) {
+		got = req
+		return agenthook.Response{Triggered: true, Reason: "resolve reviews"}, nil
+	}
+	t.Cleanup(func() { postAgentHook = oldPost })
+
+	var stdout bytes.Buffer
+	err := runAgentHook(
+		kitagenthook.AgentOpenCode,
+		agenthook.DefaultOptions(),
+		strings.NewReader(`{
+  "session_id":"session-1",
+  "hook_event_name":"chat.message",
+  "turn_id":"message-1",
+  "cwd":"/tmp/worktree",
+  "prompt":"continue"
+}`),
+		&stdout,
+		io.Discard,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Stop", got.Event.HookEventName)
+	assert.Equal(t, "session-1", got.Event.SessionID)
+	assert.JSONEq(t, `{"additionalContext":"resolve reviews"}`, stdout.String())
+}
+
 // If kit-backed profiles omit policy composition, most supported hooks keep
 // applying review findings without the user's evaluation policy.
 func TestRunAgentHookAppendsFixGuidelinesToKitOutput(t *testing.T) {

--- a/cmd/roborev/quickstart_guide.md
+++ b/cmd/roborev/quickstart_guide.md
@@ -14,7 +14,8 @@ The agent hook watches your coding-agent session (turns, commits, failed
 reviews). When review work piles up, it returns a self-contained fix instruction
 before the session goes cold - so the write -> review -> fix loop closes without
 you asking. `roborev agent-hook install` auto-detects Claude Code, Codex,
-Copilot CLI, Cursor, Factory Droid, Gemini CLI, Hermes, Qwen, and Grok Build.
+Copilot CLI, Cursor, Factory Droid, Gemini CLI, Hermes, OpenCode, Qwen, and Grok
+Build.
 Bundled skills provide the richest path where available; every reminder-capable
 profile also gets a CLI fallback. Claude Desktop does not expose harness hooks,
 so only Layer 1 runs there.

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -4,8 +4,9 @@ description: Bring background roborev findings back into active coding-agent ses
 ---
 
 `roborev agent-hook` connects roborev's asynchronous reviews to coding-agent
-harness hooks. It records shell-tool and stop events, checks for open failed
-reviews, and reminds the active agent to fix them before the session goes cold.
+harness hooks. It records shell-tool and turn-boundary events, checks for open
+failed reviews, and reminds the active agent to fix them before the session goes
+cold.
 
 The integration supports every profile in
 [`go.kenn.io/kit/agenthook`](https://pkg.go.dev/go.kenn.io/kit/agenthook):
@@ -17,6 +18,7 @@ The integration supports every profile in
 - Factory Droid
 - Gemini CLI
 - Hermes Agent
+- OpenCode
 - Qwen Code
 
 Kit owns each harness's native config format, event names, command quoting,
@@ -33,7 +35,8 @@ selection, reminder policy, and local session state.
 
 Agent Hook tracks three signals per session:
 
-- **Turns:** `Stop` events, for periodic repair during long sessions.
+- **Turns:** `Stop` events, or OpenCode's next `chat.message`, for periodic
+    repair during long sessions.
 - **Commits:** normalized shell `PreToolUse` and `PostToolUse` events. Kit maps
     each harness's native shell tool to the common `Bash` vocabulary.
 - **Failed reviews:** open, non-closed roborev reviews with a failed verdict.
@@ -67,9 +70,9 @@ roborev agent-hook install
 
 An agent is detected when its executable is on `PATH` or its config directory
 already exists. The executable candidates are `claude`, `codex`, `copilot`,
-`agent` (Cursor), `droid`, `gemini`, `hermes`, `qwen`, and `grok`.
+`agent` (Cursor), `droid`, `gemini`, `hermes`, `opencode`, `qwen`, and `grok`.
 
-Select one profile or deliberately install all nine integrations (the eight kit
+Select one profile or deliberately install all ten integrations (the nine kit
 profiles plus Grok Build):
 
 ```bash
@@ -87,10 +90,11 @@ Automatic and `all` installs attempt every selected profile and report all
 errors after preserving successful installs. `--dry-run` plans the same changes
 without writing.
 
-For Claude Code, Codex, Factory Droid, and Grok Build, installation also creates
-or updates that profile's bundled roborev skills before activating the hook.
-Other hook profiles do not currently have bundled skill variants and receive no
-CLI fallback.
+For Claude Code, Codex, Factory Droid, OpenCode, and Grok Build, installation
+also creates or updates that profile's bundled roborev skills before activating
+the hook. OpenCode receives the Claude-compatible skill files. Other hook
+profiles do not currently have bundled skill variants and receive no CLI
+fallback.
 
 Factory Droid remains user-scoped. Roborev rejects project `.factory/hooks.json`
 paths because they are executable repository-local configuration.
@@ -152,9 +156,10 @@ roborev agent-hook dump --agent qwen
 roborev agent-hook dump --agent hermes
 ```
 
-JSON-backed harnesses produce JSON. Hermes produces YAML. Use `--config` to
-merge an existing file into the plan. Binary-resolution diagnostics stay on
-stderr so stdout remains safe to pipe into declarative configuration tooling.
+JSON-backed harnesses produce JSON, Hermes produces YAML, and OpenCode produces
+an ES module plugin. Use `--config` to merge an existing file into the plan.
+Binary-resolution diagnostics stay on stderr so stdout remains safe to pipe into
+declarative configuration tooling.
 
 ## Runtime Model
 
@@ -188,6 +193,18 @@ Persisting reminder state is the at-most-once delivery boundary. Cancellation
 observed before that commit leaves a reminder queued; a disconnect after the
 commit can consume it because coding-agent hook protocols do not acknowledge
 receipt.
+
+### OpenCode
+
+OpenCode's generated global plugin runs shell checks at
+`tool.execute.before`/`tool.execute.after`. Post-tool reminders are appended to
+the current tool result. Because OpenCode has no controllable `Stop` hook, the
+plugin checks the same turn cadence at `chat.message` and appends any reminder
+to the next real user prompt. It passes OpenCode's session, call, directory, and
+worktree identifiers directly; it does not poll or guess an active session. The
+same global plugin runs in the interactive TUI and `opencode run`. Neither mode
+is woken while idle; a late reminder is surfaced when the user or caller submits
+the next prompt.
 
 ### Hermes
 

--- a/docs/automation/post-commit-reviews.md
+++ b/docs/automation/post-commit-reviews.md
@@ -85,9 +85,9 @@ See [Agent Hook](../agent-hook.md) for thresholds and configuration.
 ### Why CLI, not Desktop?
 
 The agent hook relies on harness lifecycle hooks supplied by Claude Code, Codex,
-Copilot CLI, Cursor, Factory Droid, Gemini CLI, Hermes, and Qwen. Claude Desktop
-does not expose these hooks, so Layer 2 does not run there. Layer 1 (post-commit
-reviews) works regardless of which agent or app you use.
+Copilot CLI, Cursor, Factory Droid, Gemini CLI, Hermes, OpenCode, and Qwen.
+Claude Desktop does not expose these hooks, so Layer 2 does not run there. Layer
+1 (post-commit reviews) works regardless of which agent or app you use.
 
 ## Let an agent finish setup
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -957,11 +957,12 @@ See: [Configuration](/configuration/#post-commit-review-mode) and
 
 ```bash
 roborev agent-hook install              # Install profiles for detected agents
-roborev agent-hook install --agent all  # Install all nine integrations
+roborev agent-hook install --agent all  # Install all ten integrations
 roborev agent-hook install --agent hermes --config ~/.hermes/config.yaml
 roborev agent-hook install --binary ~/.local/bin/roborev
 roborev agent-hook dump --agent qwen    # Native JSON config on stdout
 roborev agent-hook dump --agent hermes  # Native YAML config on stdout
+roborev agent-hook dump --agent opencode # Native JavaScript plugin on stdout
 roborev agent-hook run --agent cursor   # Harness runtime; --agent is required
 roborev agent-hook status               # Tracked session counters as JSON
 roborev agent-hook reset <session-id>   # Reset one session (or --all)

--- a/internal/agenthook/install.go
+++ b/internal/agenthook/install.go
@@ -152,6 +152,8 @@ func installAgentHookSkills(agent kitagenthook.Agent, configPath string) error {
 		skillAgent = skills.AgentClaude
 	case kitagenthook.AgentCodex:
 		skillAgent = skills.AgentCodex
+	case kitagenthook.AgentOpenCode:
+		skillAgent = skills.AgentClaude
 	case kitagenthook.AgentDroid:
 		skillAgent = skills.AgentDroid
 	case AgentGrok:
@@ -162,6 +164,9 @@ func installAgentHookSkills(agent kitagenthook.Agent, configPath string) error {
 
 	configDir := filepath.Dir(configPath)
 	if agent == AgentGrok && strings.EqualFold(filepath.Base(configDir), "hooks") {
+		configDir = filepath.Dir(configDir)
+	}
+	if agent == kitagenthook.AgentOpenCode && strings.EqualFold(filepath.Base(configDir), "plugins") {
 		configDir = filepath.Dir(configDir)
 	}
 	if _, err := skills.InstallToPath(skillAgent, filepath.Join(configDir, "skills")); err != nil {
@@ -204,16 +209,20 @@ func kitInstallOptions(agent kitagenthook.Agent, opts InstallOptions) kitagentho
 	if command != "" {
 		command += " " + agentHookMarker
 	}
+	hooks := []kitagenthook.Hook{
+		{Event: kitagenthook.EventPreToolUse, Matcher: kitagenthook.ToolBash, Timeout: opts.Timeout},
+		{Event: kitagenthook.EventPostToolUse, Matcher: kitagenthook.ToolBash, Timeout: opts.Timeout},
+		{Event: kitagenthook.EventStop, Timeout: opts.Timeout},
+	}
+	if agent == kitagenthook.AgentOpenCode {
+		hooks[2] = kitagenthook.Hook{Event: kitagenthook.EventUserPromptSubmit, Timeout: opts.Timeout}
+	}
 	kitOpts := kitagenthook.InstallOptions{
 		ConfigPath: opts.ConfigPath,
 		Executable: opts.Executable,
 		Command:    command,
 		Marker:     agentHookMarker,
-		Hooks: []kitagenthook.Hook{
-			{Event: kitagenthook.EventPreToolUse, Matcher: kitagenthook.ToolBash, Timeout: opts.Timeout},
-			{Event: kitagenthook.EventPostToolUse, Matcher: kitagenthook.ToolBash, Timeout: opts.Timeout},
-			{Event: kitagenthook.EventStop, Timeout: opts.Timeout},
-		},
+		Hooks:      hooks,
 	}
 	if opts.Command == "" {
 		kitOpts.Arguments = []string{

--- a/internal/agenthook/kit_install_test.go
+++ b/internal/agenthook/kit_install_test.go
@@ -94,6 +94,7 @@ func TestRunInstallInstallsAndUpdatesBundledSkillsForSupportedProfiles(t *testin
 	}{
 		{agent: "claude", configName: "settings.json"},
 		{agent: "codex", configName: "hooks.json"},
+		{agent: "opencode", configName: filepath.Join("plugins", "roborev-agent-hook.js")},
 		{agent: "droid", configName: "hooks.json"},
 		{agent: "grok", configName: filepath.Join("hooks", "roborev.json")},
 	}

--- a/internal/agenthook/profiles.go
+++ b/internal/agenthook/profiles.go
@@ -15,15 +15,16 @@ import (
 const AgentGrok kitagenthook.Agent = "grok"
 
 var profileExecutables = map[kitagenthook.Agent][]string{
-	kitagenthook.AgentClaude:  {"claude"},
-	kitagenthook.AgentCodex:   {"codex"},
-	kitagenthook.AgentCopilot: {"copilot"},
-	kitagenthook.AgentCursor:  {"agent"},
-	kitagenthook.AgentDroid:   {"droid"},
-	kitagenthook.AgentGemini:  {"gemini"},
-	kitagenthook.AgentHermes:  {"hermes"},
-	kitagenthook.AgentQwen:    {"qwen"},
-	AgentGrok:                 {"grok"},
+	kitagenthook.AgentClaude:   {"claude"},
+	kitagenthook.AgentCodex:    {"codex"},
+	kitagenthook.AgentOpenCode: {"opencode"},
+	kitagenthook.AgentCopilot:  {"copilot"},
+	kitagenthook.AgentCursor:   {"agent"},
+	kitagenthook.AgentDroid:    {"droid"},
+	kitagenthook.AgentGemini:   {"gemini"},
+	kitagenthook.AgentHermes:   {"hermes"},
+	kitagenthook.AgentQwen:     {"qwen"},
+	AgentGrok:                  {"grok"},
 }
 
 func SelectProfiles(raw string) ([]kitagenthook.Agent, error) {

--- a/internal/agenthook/profiles_test.go
+++ b/internal/agenthook/profiles_test.go
@@ -28,6 +28,7 @@ func TestSelectProfilesAutoDetectsExecutableOrConfigDirectory(t *testing.T) {
 		"GEMINI_CLI_HOME":   "gemini",
 		"HERMES_HOME":       "hermes",
 		"QWEN_HOME":         "qwen",
+		"XDG_CONFIG_HOME":   "opencode",
 	} {
 		t.Setenv(name, filepath.Join(root, "agent-homes", dir))
 	}
@@ -56,6 +57,7 @@ func TestSelectProfilesAllUsesKitOrderThenGrok(t *testing.T) {
 	assert.Equal(t, []kitagenthook.Agent{
 		kitagenthook.AgentClaude,
 		kitagenthook.AgentCodex,
+		kitagenthook.AgentOpenCode,
 		kitagenthook.AgentCopilot,
 		kitagenthook.AgentCursor,
 		kitagenthook.AgentDroid,
@@ -80,6 +82,7 @@ func TestSelectProfilesDoesNotTreatGrokAgentAliasAsCursor(t *testing.T) {
 	for _, name := range []string{
 		"CODEX_HOME", "CLAUDE_CONFIG_DIR", "COPILOT_HOME",
 		"GEMINI_CLI_HOME", "HERMES_HOME", "QWEN_HOME",
+		"XDG_CONFIG_HOME",
 	} {
 		t.Setenv(name, filepath.Join(root, "agent-homes", name))
 	}

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,7 +10,8 @@ roborev skills install
 
 Skills are updated automatically when you run `roborev update`.
 `roborev agent-hook install` also installs or updates the matching bundled
-skills for Claude Code, Codex, Factory Droid, and Grok Build.
+skills for Claude Code, Codex, Factory Droid, OpenCode, and Grok Build. OpenCode
+uses the Claude-compatible skill files.
 
 ## Skills
 


### PR DESCRIPTION
OpenCode can author commits reviewed by roborev, but it has no Agent Hook profile to return completed findings to the active authoring session.

This adds the thin roborev side of the integration: detect OpenCode, install the existing Claude-compatible `roborev-fix` skill in OpenCode's global skill directory, use Kit's OpenCode plugin profile, and map `chat.message` to the existing Stop reminder cadence. Post-tool reminders continue in the same turn; late reviews surface on the next real user prompt without polling or session guessing.

Depends on the accompanying `go.kenn.io/kit/agenthook` OpenCode profile in kenn-io/kit#75 and remains draft until that change is merged and released.
