### PR TITLE
Skip CI reviews for labeled pull requests

### DIFF
--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -159,6 +159,7 @@ Under **Repository permissions**, set:
 - **Pull requests**: Read & write
 - **Contents**: Read-only
 - **Commit statuses**: Read & write
+- **Checks**: Read & write
 
 Leave everything else as "No access". Click **Create GitHub App**.
 
@@ -168,7 +169,8 @@ Leave everything else as "No access". Click **Create GitHub App**.
 
     1. Open app settings and go to **Permissions & events**.
     1. Set **Pull requests** to **Read and write**, **Contents** to **Read-only**,
-        and **Commit statuses** to **Read and write**.
+        **Commit statuses** to **Read and write**, and **Checks** to **Read and
+        write**.
     1. Save the app settings.
     1. For each existing installation, open installation settings and **accept the
         updated permissions**.
@@ -313,9 +315,12 @@ CI poller: GitHub App authentication enabled (app_id=123456)
 PR comments will now appear as **`your-app-name[bot]`**.
 
 When an open PR has a label listed in `skip_labels`, the CI poller does not
-create a review. It sets the roborev commit status to success with a message
-that names the matching label. Label matching is case-insensitive. Removing the
-label lets the poller review the current PR head on its next pass.
+create a review. With GitHub App authentication, it creates a roborev check with
+a `skipped` conclusion and a message that names the matching label. Label
+matching is case-insensitive. Removing the label lets the poller review the
+current PR head on its next pass. GitHub does not allow personal authentication
+to create check runs, so personal-auth setups suppress the review without
+publishing the skipped check.
 
 ## Setup with Personal Auth
 
@@ -392,13 +397,17 @@ The status context is `roborev` and progresses through these states:
 | `failure` | At least one member failed to run for a genuine reason while another member still produced usable review output |
 | `error` | No reviewer produced usable output because of no available agent, repeated genuine failures, or all member jobs failing |
 
-Status checks require the **Commit statuses: Read and write** permission on your
-GitHub App. The setup guide above already includes it. If your app predates that
-permission, add it:
+Label-based bypasses use a GitHub check run instead of a commit status because
+commit statuses do not have a skipped state. The roborev check run completes
+with a `skipped` conclusion.
+
+Status checks require **Commit statuses: Read and write**. Label-based skipped
+checks also require **Checks: Read and write**. The setup guide above includes
+both permissions. If your app predates either permission, add them:
 
 1. Open your GitHub App settings and go to **Permissions & events**
-1. Under **Repository permissions**, set **Commit statuses** to **Read and
-    write**
+1. Under **Repository permissions**, set **Commit statuses** and **Checks** to
+    **Read and write**
 1. Save and accept the updated permissions on each installation
 
 If no GitHub App is configured, or the app lacks the commit statuses permission,

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -227,6 +227,7 @@ poll_interval = "5m"
 repos = ["myorg/myrepo"]
 agents = ["codex"]
 review_types = ["security"]
+skip_labels = ["skip-review"]
 
 # GitHub App authentication
 github_app_id = 123456
@@ -310,6 +311,11 @@ CI poller: GitHub App authentication enabled (app_id=123456)
 ```
 
 PR comments will now appear as **`your-app-name[bot]`**.
+
+When an open PR has a label listed in `skip_labels`, the CI poller does not
+create a review. It sets the roborev commit status to success with a message
+that names the matching label. Label matching is case-insensitive. Removing the
+label lets the poller review the current PR head on its next pass.
 
 ## Setup with Personal Auth
 
@@ -731,6 +737,7 @@ set, it takes priority over the matrix fields for that repo.
 | `poll_interval` | string | `"5m"` | How often to check for PRs (minimum 30s, invalid values default to 5m) |
 | `repos` | array | `[]` | GitHub repos to poll in `"owner/repo"` format. Supports glob patterns (e.g. `"myorg/*"`, `"myorg/api-*"`). |
 | `exclude_repos` | array | `[]` | Glob patterns to exclude from the resolved repo list |
+| `skip_labels` | array | `[]` | GitHub PR labels that skip CI reviews (case-insensitive) |
 | `max_repos` | int | `100` | Safety cap on total expanded repos (explicit repos have priority over wildcard-expanded ones) |
 | `panel` | string | | Named `[review.panels.<name>]` panel for CI reviews. When set, overrides `agents`, `review_types`, and `reviews`. |
 | `review_types` | array | `["security"]` | Review types to run for each PR: `security`, `design`, `lookahead`, or `default`. `"review"` and `"general"` are accepted as aliases for `"default"`. |

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -112,6 +112,10 @@ type CIConfig struct {
 	// Applies to both exact entries and wildcard-expanded entries.
 	ExcludeRepos []string `toml:"exclude_repos"`
 
+	// SkipLabels is a list of GitHub PR labels that prevent CI reviews.
+	// Label matching is case-insensitive.
+	SkipLabels []string `toml:"skip_labels"`
+
 	// MaxRepos is a safety cap on the total number of expanded repos. Default: 100.
 	MaxRepos int `toml:"max_repos"`
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2821,6 +2821,18 @@ max_repos = 50
 	})
 }
 
+func TestCIConfigSkipLabels(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+[ci]
+skip_labels = ["skip-review", "dependencies"]
+`), 0o644))
+
+	cfg, err := LoadGlobalFrom(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"skip-review", "dependencies"}, cfg.CI.SkipLabels)
+}
+
 func TestCIConfigDiscordWebhookURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -96,6 +96,7 @@ type CIPoller struct {
 	buildReviewPromptFn func(context.Context, string, string, int64, int, string, string, string, string, *config.Config) (string, error)
 	postPRCommentFn     func(string, int, string) error
 	setCommitStatusFn   func(ghRepo, sha, state, description string) error
+	setSkippedCheckFn   func(ghRepo, sha, summary string) error
 	agentResolverFn     func(name string) (string, error)      // returns resolved agent name
 	jobCancelFn         func(jobID int64)                      // kills running worker process (optional)
 	isPROpenFn          func(ghRepo string, prNumber int) bool // checks if a PR is still open
@@ -573,10 +574,8 @@ func (p *CIPoller) setNoAgentStatus(ghRepo string, pr ghPR) {
 func (p *CIPoller) skipLabeledPR(ghRepo string, pr ghPR, label string) {
 	description := fmt.Sprintf("Review skipped: label %s", label)
 	log.Printf("CI poller: skipping %s#%d because it has label %q", ghRepo, pr.Number, label)
-	if err := p.callSetCommitStatus(
-		ghRepo, pr.HeadRefOid, "success", description,
-	); err != nil {
-		log.Printf("CI poller: failed to set skipped status for %s#%d: %v", ghRepo, pr.Number, err)
+	if err := p.callSetSkippedCheck(ghRepo, pr.HeadRefOid, description); err != nil {
+		log.Printf("CI poller: failed to set skipped check for %s#%d: %v", ghRepo, pr.Number, err)
 	}
 }
 
@@ -3107,6 +3106,13 @@ func (p *CIPoller) callSetCommitStatus(ghRepo, sha, state, description string) e
 	return p.setCommitStatus(ghRepo, sha, state, description)
 }
 
+func (p *CIPoller) callSetSkippedCheck(ghRepo, sha, summary string) error {
+	if p.setSkippedCheckFn != nil {
+		return p.setSkippedCheckFn(ghRepo, sha, summary)
+	}
+	return p.setSkippedCheck(ghRepo, sha, summary)
+}
+
 // callIsPROpen checks whether a PR is still open. Uses the test seam
 // if set, otherwise calls isPROpen.
 func (p *CIPoller) callIsPROpen(
@@ -3362,6 +3368,20 @@ func (p *CIPoller) setCommitStatus(ghRepo, sha, state, description string) error
 		return err
 	}
 	return client.SetCommitStatus(context.Background(), ghRepo, sha, state, description)
+}
+
+// setSkippedCheck publishes a real skipped conclusion through GitHub's Checks
+// API. GitHub only grants write access to this API to GitHub Apps, so personal
+// authentication still suppresses the review but cannot publish the check.
+func (p *CIPoller) setSkippedCheck(ghRepo, sha, summary string) error {
+	if p.tokenProvider == nil {
+		return nil
+	}
+	client, err := p.githubClientForRepo(ghRepo)
+	if err != nil {
+		return err
+	}
+	return client.EnsureSkippedCheckRun(context.Background(), ghRepo, sha, summary)
 }
 
 // toReviewResults converts storage batch results to the

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -56,6 +56,7 @@ type ghPR struct {
 	BaseRefName string     `json:"baseRefName"`
 	Title       string     `json:"title"`
 	Author      ghPRAuthor `json:"author"`
+	Labels      []string   `json:"labels"`
 }
 
 type panelPostTarget struct {
@@ -63,6 +64,7 @@ type panelPostTarget struct {
 	HeadSHA     string
 	BaseRefName string
 	AuthorLogin string
+	Labels      []string
 }
 
 const (
@@ -413,6 +415,10 @@ func (p *CIPoller) processPR(ctx context.Context, ghRepo string, pr ghPR, cfg *c
 	if reviewed {
 		return nil
 	}
+	if label, skip := matchingCISkipLabel(pr.Labels, cfg.CI.SkipLabels); skip {
+		p.skipLabeledPR(ghRepo, pr, label)
+		return nil
+	}
 
 	// Throttle: skip if this PR was reviewed recently (any SHA).
 	dec, err := p.throttlePR(ghRepo, pr, cfg)
@@ -562,6 +568,29 @@ func (p *CIPoller) setNoAgentStatus(ghRepo string, pr ghPR) {
 	); err != nil {
 		log.Printf("CI poller: failed to set error status for %s#%d: %v", ghRepo, pr.Number, err)
 	}
+}
+
+func (p *CIPoller) skipLabeledPR(ghRepo string, pr ghPR, label string) {
+	description := fmt.Sprintf("Review skipped: label %s", label)
+	log.Printf("CI poller: skipping %s#%d because it has label %q", ghRepo, pr.Number, label)
+	if err := p.callSetCommitStatus(
+		ghRepo, pr.HeadRefOid, "success", description,
+	); err != nil {
+		log.Printf("CI poller: failed to set skipped status for %s#%d: %v", ghRepo, pr.Number, err)
+	}
+}
+
+func matchingCISkipLabel(prLabels, skipLabels []string) (string, bool) {
+	for _, label := range prLabels {
+		label = strings.TrimSpace(label)
+		for _, configured := range skipLabels {
+			configured = strings.TrimSpace(configured)
+			if configured != "" && strings.EqualFold(label, configured) {
+				return label, true
+			}
+		}
+	}
+	return "", false
 }
 
 // loadCIRepoConfigFor loads the repo's config via the configured loader (the
@@ -1792,6 +1821,7 @@ func (p *CIPoller) listOpenPRs(ctx context.Context, ghRepo string) ([]ghPR, erro
 			BaseRefName: pr.BaseRefName,
 			Title:       pr.Title,
 			Author:      ghPRAuthor{Login: pr.AuthorLogin},
+			Labels:      pr.Labels,
 		})
 	}
 	return prs, nil
@@ -2612,6 +2642,15 @@ func (p *CIPoller) retryDueReviewAttempt(
 		}
 		return false // PR advanced; the new HEAD already has its own attempt
 	}
+	if label, skip := matchingCISkipLabel(pr.Labels, cfg.CI.SkipLabels); skip {
+		if err := p.db.DeleteReviewAttempt(ghRepo, attempt.PRNumber, attempt.HeadSHA); err != nil {
+			log.Printf("CI poller: error deleting deferred attempt skipped by label for %s#%d@%s: %v",
+				ghRepo, attempt.PRNumber, gitpkg.ShortSHA(attempt.HeadSHA), err)
+			return false
+		}
+		p.skipLabeledPR(ghRepo, pr, label)
+		return false
+	}
 	claimed, attemptNumber, firstAttemptAt, err := p.db.ClaimDueReviewAttempt(ghRepo, attempt.PRNumber, attempt.HeadSHA, now)
 	if err != nil {
 		log.Printf("CI poller: error claiming due review attempt for %s#%d@%s: %v",
@@ -2677,6 +2716,7 @@ func (p *CIPoller) retryAttemptPR(
 		Number:      attempt.PRNumber,
 		HeadRefOid:  headSHA,
 		BaseRefName: baseRefName,
+		Labels:      target.Labels,
 		// Preserve the author so kata trust gating in enqueuePanelRun does
 		// not fail closed for trusted authors on the retry path.
 		Author: ghPRAuthor{Login: target.AuthorLogin},
@@ -3142,6 +3182,7 @@ func (p *CIPoller) panelPostTarget(
 		HeadSHA:     pr.HeadRefOID,
 		BaseRefName: pr.BaseRefName,
 		AuthorLogin: pr.AuthorLogin,
+		Labels:      pr.Labels,
 	}, nil
 }
 

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -597,6 +597,7 @@ func TestGitHubClientForRepo_UsesEnterpriseBaseURL(t *testing.T) {
 		headRef := "feature"
 		baseRef := "main"
 		login := "alice"
+		label := "skip-review"
 
 		assert.NoError(t, json.NewEncoder(w).Encode([]*googlegithub.PullRequest{
 			{
@@ -613,6 +614,7 @@ func TestGitHubClientForRepo_UsesEnterpriseBaseURL(t *testing.T) {
 				User: &googlegithub.User{
 					Login: &login,
 				},
+				Labels: []*googlegithub.Label{{Name: label}},
 			},
 		}))
 	}))
@@ -634,6 +636,7 @@ func TestGitHubClientForRepo_UsesEnterpriseBaseURL(t *testing.T) {
 	assert.Equal(t, "Bearer ghs_enterprise_token", authHeader)
 	assert.Equal(t, 42, prs[0].Number)
 	assert.Equal(t, "head-sha", prs[0].HeadRefOid)
+	assert.Equal(t, []string{"skip-review"}, prs[0].Labels)
 }
 
 func TestFormatRawBatchComment_Truncation(t *testing.T) {
@@ -784,6 +787,35 @@ func TestCIPollerPollRepo_UsesPRListAndProcessesEach(t *testing.T) {
 
 	assert.True(t, h.hasPanel(t, "acme/api", 7, "11111111aaaaaaaa"), "expected panel for PR 7")
 	assert.True(t, h.hasPanel(t, "acme/api", 8, "22222222bbbbbbbb"), "expected panel for PR 8")
+}
+
+func TestCIPollerProcessPR_SkipsConfiguredLabel(t *testing.T) {
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+	h.Cfg.CI.SkipLabels = []string{"  do not review  "}
+	h.Cfg.CI.ReviewTypes = []string{"security"}
+	h.Cfg.CI.Agents = []string{"codex"}
+	h.stubProcessPRGit()
+	statuses := h.CaptureCommitStatuses()
+
+	pr := ghPR{
+		Number:      9,
+		HeadRefOid:  "skipped-head-sha",
+		BaseRefName: "main",
+		Labels:      []string{"Do Not Review"},
+	}
+	err := h.Poller.processPR(context.Background(), "acme/api", pr, h.Cfg)
+	require.NoError(t, err)
+
+	assert.False(t, h.hasPanel(t, "acme/api", 9, "skipped-head-sha"))
+	assert.Equal(t, []capturedStatus{{
+		Repo: "acme/api", SHA: "skipped-head-sha", State: "success",
+		Desc: "Review skipped: label Do Not Review",
+	}}, *statuses)
+
+	pr.Labels = nil
+	require.NoError(t, h.Poller.processPR(
+		context.Background(), "acme/api", pr, h.Cfg))
+	assert.True(t, h.hasPanel(t, "acme/api", 9, "skipped-head-sha"))
 }
 
 // drivePanelOutcome resolves the panel run for a PR HEAD and drives every
@@ -4405,6 +4437,43 @@ func TestRetryDueReviewAttemptFetchesPRMissingFromOpenPage(t *testing.T) {
 		"retry direct-lookup path must persist the PR base branch on the synthesis job")
 	assert.Empty(synth.Branch,
 		"CI synthesis job must not record a local branch (it would leak into fix/refine discovery)")
+}
+
+func TestRetryDueReviewAttemptSkipsConfiguredLabel(t *testing.T) {
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
+	h.Cfg.CI.SkipLabels = []string{"skip-review"}
+	statuses := h.CaptureCommitStatuses()
+
+	const headSHA = "labeleddeferred01"
+	const prNum = 133
+	now := time.Now()
+	created, err := h.DB.ReserveReviewAttempt(
+		"acme/api", prNum, headSHA, now.Add(-time.Hour))
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, h.DB.DeferReviewAttempt(
+		"acme/api", prNum, headSHA, "transient", "provider unavailable",
+		"old-run", now.Add(-time.Minute), false))
+
+	h.Poller.prPostTargetFn = func(
+		context.Context, string, int,
+	) (panelPostTarget, error) {
+		return panelPostTarget{
+			Open: true, HeadSHA: headSHA, BaseRefName: "main",
+			Labels: []string{"Skip-Review"},
+		}, nil
+	}
+	h.Poller.retryDueReviewAttempts(
+		context.Background(), "acme/api", nil, h.Cfg)
+
+	attempt, err := h.DB.GetReviewAttempt("acme/api", prNum, headSHA)
+	require.NoError(t, err)
+	assert.Nil(t, attempt)
+	assert.False(t, h.hasPanel(t, "acme/api", prNum, headSHA))
+	assert.Equal(t, []capturedStatus{{
+		Repo: "acme/api", SHA: headSHA, State: "success",
+		Desc: "Review skipped: label Skip-Review",
+	}}, *statuses)
 }
 
 // TestReconcileStuckAttempt covers the crash/stuck reconcile: a pending attempt

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -108,6 +108,9 @@ func stubCIPollerGitHubSideEffects(p *CIPoller) {
 	p.setCommitStatusFn = func(string, string, string, string) error {
 		return nil
 	}
+	p.setSkippedCheckFn = func(string, string, string) error {
+		return nil
+	}
 }
 
 func TestCIPollerHarnessProcessPRGitStubsGitHubSideEffects(t *testing.T) {
@@ -198,6 +201,19 @@ func (h *ciPollerHarness) CaptureCommitStatuses() *[]capturedStatus {
 	var captured []capturedStatus
 	h.Poller.setCommitStatusFn = func(repo, sha, state, desc string) error {
 		captured = append(captured, capturedStatus{repo, sha, state, desc})
+		return nil
+	}
+	return &captured
+}
+
+type capturedSkippedCheck struct {
+	Repo, SHA, Summary string
+}
+
+func (h *ciPollerHarness) CaptureSkippedChecks() *[]capturedSkippedCheck {
+	var captured []capturedSkippedCheck
+	h.Poller.setSkippedCheckFn = func(repo, sha, summary string) error {
+		captured = append(captured, capturedSkippedCheck{repo, sha, summary})
 		return nil
 	}
 	return &captured
@@ -796,6 +812,7 @@ func TestCIPollerProcessPR_SkipsConfiguredLabel(t *testing.T) {
 	h.Cfg.CI.Agents = []string{"codex"}
 	h.stubProcessPRGit()
 	statuses := h.CaptureCommitStatuses()
+	skippedChecks := h.CaptureSkippedChecks()
 
 	pr := ghPR{
 		Number:      9,
@@ -807,10 +824,11 @@ func TestCIPollerProcessPR_SkipsConfiguredLabel(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, h.hasPanel(t, "acme/api", 9, "skipped-head-sha"))
-	assert.Equal(t, []capturedStatus{{
-		Repo: "acme/api", SHA: "skipped-head-sha", State: "success",
-		Desc: "Review skipped: label Do Not Review",
-	}}, *statuses)
+	assert.Empty(t, *statuses)
+	assert.Equal(t, []capturedSkippedCheck{{
+		Repo: "acme/api", SHA: "skipped-head-sha",
+		Summary: "Review skipped: label Do Not Review",
+	}}, *skippedChecks)
 
 	pr.Labels = nil
 	require.NoError(t, h.Poller.processPR(
@@ -4443,6 +4461,7 @@ func TestRetryDueReviewAttemptSkipsConfiguredLabel(t *testing.T) {
 	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
 	h.Cfg.CI.SkipLabels = []string{"skip-review"}
 	statuses := h.CaptureCommitStatuses()
+	skippedChecks := h.CaptureSkippedChecks()
 
 	const headSHA = "labeleddeferred01"
 	const prNum = 133
@@ -4470,10 +4489,11 @@ func TestRetryDueReviewAttemptSkipsConfiguredLabel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, attempt)
 	assert.False(t, h.hasPanel(t, "acme/api", prNum, headSHA))
-	assert.Equal(t, []capturedStatus{{
-		Repo: "acme/api", SHA: headSHA, State: "success",
-		Desc: "Review skipped: label Skip-Review",
-	}}, *statuses)
+	assert.Empty(t, *statuses)
+	assert.Equal(t, []capturedSkippedCheck{{
+		Repo: "acme/api", SHA: headSHA,
+		Summary: "Review skipped: label Skip-Review",
+	}}, *skippedChecks)
 }
 
 // TestReconcileStuckAttempt covers the crash/stuck reconcile: a pending attempt

--- a/internal/github/repo_ops.go
+++ b/internal/github/repo_ops.go
@@ -17,6 +17,7 @@ type OpenPullRequest struct {
 	BaseRefName string
 	Title       string
 	AuthorLogin string
+	Labels      []string
 }
 
 type PullRequestInfo struct {
@@ -25,6 +26,7 @@ type PullRequestInfo struct {
 	HeadRefOID  string
 	BaseRefName string
 	AuthorLogin string
+	Labels      []string
 }
 
 func (c *Client) ListOpenPullRequests(ctx context.Context, ghRepo string, limit int) ([]OpenPullRequest, error) {
@@ -57,6 +59,7 @@ func (c *Client) ListOpenPullRequests(ctx context.Context, ghRepo string, limit 
 			BaseRefName: pr.GetBase().GetRef(),
 			Title:       pr.GetTitle(),
 			AuthorLogin: pr.GetUser().GetLogin(),
+			Labels:      pullRequestLabelNames(pr.GetLabels()),
 		})
 	}
 	return result, nil
@@ -86,7 +89,18 @@ func (c *Client) GetPullRequest(ctx context.Context, ghRepo string, prNumber int
 		HeadRefOID:  pr.GetHead().GetSHA(),
 		BaseRefName: pr.GetBase().GetRef(),
 		AuthorLogin: pr.GetUser().GetLogin(),
+		Labels:      pullRequestLabelNames(pr.GetLabels()),
 	}, nil
+}
+
+func pullRequestLabelNames(labels []*googlegithub.Label) []string {
+	names := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if name := strings.TrimSpace(label.GetName()); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func (c *Client) ListOwnerRepos(ctx context.Context, owner string, limit int) ([]string, error) {

--- a/internal/github/repo_ops.go
+++ b/internal/github/repo_ops.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	googlegithub "github.com/google/go-github/v90/github"
 )
@@ -152,6 +153,54 @@ func (c *Client) SetCommitStatus(ctx context.Context, ghRepo, sha, state, descri
 	})
 	if err != nil {
 		return fmt.Errorf("create commit status: %w", err)
+	}
+	return nil
+}
+
+// EnsureSkippedCheckRun creates a completed roborev check run with a skipped
+// conclusion unless an equivalent check already exists for the commit.
+func (c *Client) EnsureSkippedCheckRun(ctx context.Context, ghRepo, sha, summary string) error {
+	owner, repo, err := parseRepo(ghRepo)
+	if err != nil {
+		return err
+	}
+
+	const checkName = "roborev"
+	runs, _, err := c.api.Checks.ListCheckRunsForRef(
+		ctx, owner, repo, sha,
+		&googlegithub.ListCheckRunsOptions{
+			CheckName: ptr(checkName),
+			Status:    ptr("completed"),
+			Filter:    ptr("latest"),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("list roborev check runs: %w", err)
+	}
+	for _, run := range runs.CheckRuns {
+		if run.GetConclusion() == "skipped" &&
+			run.GetOutput().GetSummary() == summary {
+			return nil
+		}
+	}
+
+	completedAt := &googlegithub.Timestamp{Time: time.Now().UTC()}
+	_, _, err = c.api.Checks.CreateCheckRun(
+		ctx, owner, repo,
+		googlegithub.CreateCheckRunOptions{
+			Name:        checkName,
+			HeadSHA:     sha,
+			Status:      ptr("completed"),
+			Conclusion:  ptr("skipped"),
+			CompletedAt: completedAt,
+			Output: &googlegithub.CheckRunOutput{
+				Title:   ptr("Review skipped"),
+				Summary: ptr(summary),
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("create skipped check run: %w", err)
 	}
 	return nil
 }

--- a/internal/github/repo_ops_test.go
+++ b/internal/github/repo_ops_test.go
@@ -116,6 +116,63 @@ func TestListOwnerRepos_KeepsPublicReposWhenAuthenticatedListingFails(t *testing
 	assert.Equal(t, []string{"jane/app"}, repos)
 }
 
+func TestEnsureSkippedCheckRunCreatesSkippedConclusionOnce(t *testing.T) {
+	var created []googlegithub.CreateCheckRunOptions
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/repos/acme/api/commits/head-sha/check-runs":
+			assert.Equal(t, "roborev", r.URL.Query().Get("check_name"))
+			assert.Equal(t, "completed", r.URL.Query().Get("status"))
+			assert.Equal(t, "latest", r.URL.Query().Get("filter"))
+			if len(created) == 0 {
+				assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"total_count": 0,
+					"check_runs":  []any{},
+				}))
+				return
+			}
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 1,
+				"check_runs": []any{map[string]any{
+					"name":       "roborev",
+					"conclusion": "skipped",
+					"output": map[string]any{
+						"summary": "Review skipped: label do-not-review",
+					},
+				}},
+			}))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/repos/acme/api/check-runs":
+			var opts googlegithub.CreateCheckRunOptions
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&opts))
+			created = append(created, opts)
+			w.WriteHeader(http.StatusCreated)
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": 1}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient("token", WithBaseURL(server.URL+"/"))
+	require.NoError(t, err)
+	for range 2 {
+		require.NoError(t, client.EnsureSkippedCheckRun(
+			context.Background(), "acme/api", "head-sha",
+			"Review skipped: label do-not-review",
+		))
+	}
+
+	require.Len(t, created, 1)
+	assert.Equal(t, "roborev", created[0].Name)
+	assert.Equal(t, "head-sha", created[0].HeadSHA)
+	assert.Equal(t, "completed", created[0].GetStatus())
+	assert.Equal(t, "skipped", created[0].GetConclusion())
+	require.NotNil(t, created[0].CompletedAt)
+	assert.Equal(t, "Review skipped", created[0].Output.GetTitle())
+	assert.Equal(t, "Review skipped: label do-not-review", created[0].Output.GetSummary())
+}
+
 func TestNewClient_DefaultHTTPTimeout(t *testing.T) {
 	client, err := NewClient("")
 	require.NoError(t, err)


### PR DESCRIPTION
The CI poller can now treat labels in the operator-owned `[ci].skip_labels` list as explicit review bypasses. Matching is case-insensitive, and a matching pull request does not create a review panel. Deferred attempts honor the same gate and are removed, so the same head becomes eligible again after a maintainer removes the label. Pull request branches cannot change this global policy.

With GitHub App authentication, roborev publishes the bypass as a check run with a `skipped` conclusion. It does not report the bypass as a successful review. Repeated polls reuse the existing skipped check, and GitHub App setups need the Checks read/write permission. GitHub does not permit personal authentication to create check runs, so those setups still suppress the review but cannot publish the skipped result.
