### PR TITLE
docs: add 0.67.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ closing the loop.
 CLI, Cursor, Factory Droid, Gemini CLI, Hermes, Qwen, and Grok Build harnesses
 and adds optional hooks after configured turn, commit, or failed-review
 thresholds are met. Reminders name exact review IDs, invoke the bundled
-`roborev-fix` skill, and include a complete CLI fallback when no roborev skill is
-installed; they do not run `roborev fix --open`. Supported profiles get current
-bundled skills during hook installation. Hermes delivers queued post-tool
-reminders at `Stop`; Cursor records the same events but emits no control response.
+`roborev-fix` skill, and never run `roborev fix --open`. Hook installation
+updates bundled skills for Claude Code, Codex, Factory Droid, and Grok Build.
+Other profiles receive no CLI fallback. Hermes delivers queued post-tool
+reminders at `Stop`; Cursor records the same events but emits no control
+response.
 Installed hooks post events to the regular roborev daemon. That daemon evaluates
 the reminders and persists session counters and delivered review IDs in
 `${ROBOREV_DATA_DIR:-~/.roborev}/agent-hook/state.json`. Hook callbacks fail open

--- a/cmd/roborev/quickstart_guide.md
+++ b/cmd/roborev/quickstart_guide.md
@@ -12,12 +12,12 @@ and the daemon API.
 **Layer 2 - Agent hook (CLI harnesses, optional).**
 The agent hook watches your coding-agent session (turns, commits, failed
 reviews). When review work piles up, it returns a self-contained fix instruction
-before the session goes cold - so the write -> review -> fix loop closes without
-you asking. `roborev agent-hook install` auto-detects Claude Code, Codex,
+before the session goes cold. The write -> review -> fix loop closes without you
+asking. `roborev agent-hook install` auto-detects Claude Code, Codex,
 Copilot CLI, Cursor, Factory Droid, Gemini CLI, Hermes, Qwen, and Grok Build.
-Bundled skills provide the richest path where available; every reminder-capable
-profile also gets a CLI fallback. Claude Desktop does not expose harness hooks,
-so only Layer 1 runs there.
+Hook installation updates bundled skills for Claude Code, Codex, Factory Droid,
+and Grok Build. Other profiles receive no CLI fallback. Claude Desktop does not
+expose harness hooks, so only Layer 1 runs there.
 
 Quickstart health checks cover Claude Code, Codex, and Grok Build. Use
 `roborev agent-hook install` and agent-native config inspection to manage the
@@ -35,9 +35,9 @@ Code and Codex as commands (Claude Code invokes them with `/`, Codex with `$`):
 - `/roborev-respond` - comment on a review and close it
 - `/roborev-design-review` - run a design-focused review (`/roborev-design-review-branch` for the branch)
 
-Invoke these directly whenever you want a review or a fix - they do not require
-the agent hook. Layer 2 uses `roborev-fix` when available and otherwise supplies
-the equivalent CLI workflow once findings pile up.
+Invoke these directly whenever you want a review or a fix. They do not require
+the agent hook. Layer 2 invokes `roborev-fix` with the exact review job IDs. It
+does not substitute a CLI workflow when the skill is unavailable.
 
 ### Finalize a branch with the refine loop
 

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -45,9 +45,9 @@ tracked git repository the hook returns an empty native response.
 The default instruction names the exact review job IDs and invokes the
 `roborev-fix` skill for only those jobs. It never runs `roborev fix --open` or
 discovers additional reviews. The skill treats every finding as an unverified
-claim: invalid findings are documented and closed without code changes, valid
-in-scope findings are fixed and verified, and valid out-of-scope or unclear
-findings remain open until the user gives direction.
+claim. It documents and closes invalid findings without changing code. It fixes
+and verifies valid findings that fall within the current task. It leaves valid
+out-of-scope or unclear findings open until the user gives direction.
 
 Delivered review IDs are acknowledged in the Agent Hook daemon's session state,
 scoped to the repository lineage. They do not trigger another reminder in that

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -193,10 +193,10 @@ need.
 Since
 [agy 1.1.3](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.3),
 print mode soft-denies tool calls that would need a permission confirmation
-instead of silently auto-approving them. Reviews can hit this on the model's
-first tool call — typically a file read or a terminal command: agy exits cleanly
-having produced no review, and roborev fails the job (retrying, then failing
-over to a configured backup agent when one is available). Before each
+instead of silently auto-approving them. A review can hit this on the model's
+first tool call, usually a file read or terminal command. In that case, `agy`
+exits successfully without producing a review. Roborev marks the job failed,
+retries it, then uses a configured backup agent if one is available. Before each
 non-agentic review, roborev automatically merges the required allow-rules into
 `~/.gemini/antigravity-cli/settings.json`:
 
@@ -223,17 +223,17 @@ rules. `read_file(*)` is the rule that matters: agy's native read tools (view
 file, search, list directory) do the real work of a review once file reads are
 allowed. The `command` rules keep inspect commands from aborting the run.
 
-These rules are global to every agy session, and command targets are prefix
-matchers (see the
-[agy permissions docs](https://antigravity.google/docs/cli-permissions)), so
-treat any `command(...)` rule as broad shell authority rather than a read-only
-grant. The same global scope applies to `read_file(*)`, which auto-approves
-reads of any path on the system — narrow its target to your source roots if that
-is broader than you want. Review jobs run without agy's OS-level `--sandbox`, so
-these command permissions are not confined to agy's scratch directory. Avoid
-`command(*)` and `unsandboxed(*)`, which broaden permission scope further.
-Agentic jobs are unaffected by this merge because
-`--dangerously-skip-permissions` auto-approves all tools.
+These rules apply to every `agy` session. Command targets use prefix matching,
+as described in the
+[agy permissions docs](https://antigravity.google/docs/cli-permissions). Treat
+any `command(...)` rule as broad shell authority rather than a read-only grant.
+The `read_file(*)` rule also applies globally and auto-approves reads of any
+path on the system. Narrow its target to your source roots if necessary. Review
+jobs run without agy's OS-level `--sandbox`, so these command permissions are
+not confined to agy's scratch directory. Avoid `command(*)` and
+`unsandboxed(*)`, which broaden permission scope further. Agentic jobs are
+unaffected by this merge because `--dangerously-skip-permissions` auto-approves
+all tools.
 
 Roborev does not currently provide an opt-out for the automatic settings merge
 when using `agy`. To avoid Antigravity's global settings and unsandboxed review

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -180,13 +180,17 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 npm install -g @google/gemini-cli
 ```
 
-Antigravity runs in print mode — the prompt is passed via `--prompt` on `agy` >=
-1.1.1 and piped over stdin with a bare `--print` on older versions (roborev
-probes `agy --version` to pick the contract). Review jobs omit both `--sandbox`
-and `--dangerously-skip-permissions`; agentic jobs use
-`--dangerously-skip-permissions`. Omitting `--sandbox` is intentional because
-agy's print-mode sandbox can deny the read-only workspace probes that reviews
-need.
+Antigravity runs in print mode. Roborev probes `agy --version` to choose how to
+send the prompt. Version 1.1.1 and newer receive prompts through `--prompt` when
+the text fits within the platform's command-line size limit. Older versions read
+the prompt from standard input with a bare `--print`. On newer versions, Roborev
+sends an oversized prompt through standard input without a prompt flag. This
+prevents the operating system from rejecting the process before `agy` starts.
+
+Review jobs omit both `--sandbox` and `--dangerously-skip-permissions`; agentic
+jobs use `--dangerously-skip-permissions`. Omitting `--sandbox` is intentional
+because agy's print-mode sandbox can deny the read-only workspace probes that
+reviews need.
 
 Since
 [agy 1.1.3](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.3),

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -180,17 +180,13 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 npm install -g @google/gemini-cli
 ```
 
-Antigravity runs in print mode. Roborev probes `agy --version` to choose how to
-send the prompt. Version 1.1.1 and newer receive prompts through `--prompt` when
-the text fits within the platform's command-line size limit. Older versions read
-the prompt from standard input with a bare `--print`. On newer versions, Roborev
-sends an oversized prompt through standard input without a prompt flag. This
-prevents the operating system from rejecting the process before `agy` starts.
-
-Review jobs omit both `--sandbox` and `--dangerously-skip-permissions`; agentic
-jobs use `--dangerously-skip-permissions`. Omitting `--sandbox` is intentional
-because agy's print-mode sandbox can deny the read-only workspace probes that
-reviews need.
+Antigravity runs in print mode — the prompt is passed via `--prompt` on `agy` >=
+1.1.1 and piped over stdin with a bare `--print` on older versions (roborev
+probes `agy --version` to pick the contract). Review jobs omit both `--sandbox`
+and `--dangerously-skip-permissions`; agentic jobs use
+`--dangerously-skip-permissions`. Omitting `--sandbox` is intentional because
+agy's print-mode sandbox can deny the read-only workspace probes that reviews
+need.
 
 Since
 [agy 1.1.3](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.3),

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -180,10 +180,12 @@ curl -fsSL https://antigravity.google/cli/install.sh | bash
 npm install -g @google/gemini-cli
 ```
 
-Antigravity runs in print mode — the prompt is passed via `--prompt` on `agy` >=
-1.1.1 and piped over stdin with a bare `--print` on older versions (roborev
-probes `agy --version` to pick the contract). Review jobs omit both `--sandbox`
-and `--dangerously-skip-permissions`; agentic jobs use
+Antigravity runs in print mode. Roborev probes `agy --version` and checks the
+prompt size to choose the transport. Version 1.1.1 and newer receive prompts
+through `--prompt` when the text fits within the platform's command-line size
+limit. Other prompts use standard input, with a bare `--print` flag on older
+versions. Review jobs omit both `--sandbox` and
+`--dangerously-skip-permissions`; agentic jobs use
 `--dangerously-skip-permissions`. Omitting `--sandbox` is intentional because
 agy's print-mode sandbox can deny the read-only workspace probes that reviews
 need.

--- a/docs/automation/post-commit-reviews.md
+++ b/docs/automation/post-commit-reviews.md
@@ -42,10 +42,11 @@ one review for the full range. Values below `2`, including the default of `1`,
 keep the usual one-review-per-commit behavior.
 
 Pending commits are tracked separately for each branch and shared across linked
-worktrees. A pre-push hook flushes a partial batch before those commits are
-pushed. After a rebase or amend, the next review covers everything since the
-last commit the rewritten branch still shares with its old history, so pending
-work is never skipped (rewritten commits may be re-reviewed). Run `roborev init`
+worktrees. The pre-push hook attempts to queue a partial batch before those
+commits are pushed. It does not block the push if queueing fails, and the batch
+remains pending for a later hook. After a rebase or amend, the next review
+covers everything since the last commit the rewritten branch still shares with
+its old history. Rewritten commits may be reviewed again. Run `roborev init`
 after upgrading roborev to install or update the pre-push hook.
 
 Batching changes review frequency, not review scope. With

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,8 +43,7 @@ All notable changes to roborev, grouped by minor release.
 **Bug fixes**
 
 - Antigravity review jobs now pass oversized prompts through standard input and
-    allow the workspace inspection commands needed by non-agentic reviews. See
-    [Gemini: Antigravity vs Legacy CLI](/agents/#gemini-antigravity-vs-legacy-cli).
+    allow the workspace inspection commands needed by non-agentic reviews.
 - Split-screen TUI review details now release mouse capture while focused, so
     terminal drag selection works without changing queue mouse controls. See
     [Split-Screen Review](/integrations/tui/#split-screen-review).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,8 @@ All notable changes to roborev, grouped by minor release.
     [GitHub Integration](/integrations/github/#setup-with-github-app-recommended).
 - Repository-local `post_commit_batch_size` can combine several automatic
     post-commit reviews into one accumulated-range review. Pending batches are
-    tracked per branch across linked worktrees and flushed before push. See
+    tracked per branch across linked worktrees, and the pre-push hook attempts
+    to queue partial batches before push. See
     [Post-Commit Reviews](/automation/post-commit-reviews/#batch-small-commits).
 
 **Improvements**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,10 +5,23 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
-## Unreleased
+## 0.67.0
+
+<small>2026-08-26</small>
 
 **New features**
 
+- Named review configuration experiments can assign a source branch to a stable
+    default or experimental arm for daemon-backed reviews and CI poller reviews.
+    Experimental settings merge into the frozen review plan, while explicit
+    request values still take precedence. Use `roborev config validate` to check
+    definitions without starting a review. See
+    [Review Configuration Experiments](/configuration/#review-configuration-experiments).
+- CI poller operators can list pull request labels in `[ci].skip_labels` to
+    suppress reviews. GitHub App installations publish a check with a `skipped`
+    conclusion; personal authentication suppresses the review without creating a
+    check. Removing the label makes the current head eligible again. See
+    [GitHub Integration](/integrations/github/#setup-with-github-app-recommended).
 - Repository-local `post_commit_batch_size` can combine several automatic
     post-commit reviews into one accumulated-range review. Pending batches are
     tracked per branch across linked worktrees and flushed before push. See
@@ -29,10 +42,26 @@ All notable changes to roborev, grouped by minor release.
 
 **Bug fixes**
 
+- Antigravity review jobs now pass oversized prompts through standard input and
+    allow the workspace inspection commands needed by non-agentic reviews. See
+    [Gemini: Antigravity vs Legacy CLI](/agents/#gemini-antigravity-vs-legacy-cli).
+- Split-screen TUI review details now release mouse capture while focused, so
+    terminal drag selection works without changing queue mouse controls. See
+    [Split-Screen Review](/integrations/tui/#split-screen-review).
 - Agent Hook remembers delivered review IDs per agent session and repository
     lineage, preventing repeated reminders for the same reviews while allowing
     newly created reviews to trigger. Deferred reminders acknowledge IDs only
     when they are delivered.
+
+**Acknowledgements**
+
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for review
+    configuration experiments, label-based CI review skips, and the Agent Hook
+    reminder changes.
+- Thanks to [Wes McKinney](https://github.com/wesm) for automatic post-commit
+    review batching and restored TUI text selection.
+- Thanks to [Shun Kakinoki](https://github.com/shunkakinoki) for reliable large
+    Antigravity prompts and workspace inspection.
 
 ______________________________________________________________________
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,8 +223,9 @@ The default `content` profile includes the raw review output text exactly as
 stored, subject to a large size cap. The `metadata` profile keeps the same
 review metadata but sets `content` fields to `null`.
 
-Each top-level review includes an `experiments` array. Every assignment contains
-the experiment `id`, `arm`, `subject_hash`, `definition_hash`, and
+Each top-level review has an `experiments` field. It is an array of assignments
+when an experiment applies and `null` otherwise. Every assignment contains the
+experiment `id`, `arm`, `subject_hash`, `definition_hash`, and
 `effective_config_hash`.
 
 Only finished review jobs with a verdict are exported. Task, fix, insights,
@@ -295,8 +296,8 @@ roborev export ci-metrics --legacy
 panel runs for external turnaround-time analysis. Each panel records its GitHub
 repository, pull request, head SHA, timestamps, attempt count, terminal outcome,
 and synthesis agent and model. It also includes retained member and synthesis
-jobs with their timing and model metadata. The panel's `experiments` array
-records its experiment assignments.
+jobs with their timing and model metadata. The panel's `experiments` field is an
+array of assignments when an experiment applies and `null` otherwise.
 
 Terminal outcomes distinguish `review_posted`, `no_review_posted`,
 `giveup_posted`, and `abandoned`. roborev backfills metrics for older finalized
@@ -340,7 +341,8 @@ roborev export ci-costs --legacy
 records for CI review work. Eligible terminal attempts are included even when a
 later retry replaced them in a panel. Skipped, passthrough, pre-agent, and
 manual jobs are excluded. Each row contains `job_uuid`, `finished_at`, `agent`,
-`role`, `status`, `cost_usd`, and its `experiments` assignments.
+`role`, `status`, and `cost_usd`. Its `experiments` field is an array of
+assignments when an experiment applies and `null` otherwise.
 
 Cost is approximate and can be partial. A job whose agent ran but whose usage
 cannot be priced remains in the export with `cost_usd: null`. A known zero-cost

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,6 +223,10 @@ The default `content` profile includes the raw review output text exactly as
 stored, subject to a large size cap. The `metadata` profile keeps the same
 review metadata but sets `content` fields to `null`.
 
+Each top-level review includes an `experiments` array. Every assignment contains
+the experiment `id`, `arm`, `subject_hash`, `definition_hash`, and
+`effective_config_hash`.
+
 Only finished review jobs with a verdict are exported. Task, fix, insights,
 compact, queued, running, failed, and canceled jobs are excluded. Panel reviews
 export as one top-level synthesis review with completed member reviews nested
@@ -289,9 +293,10 @@ roborev export ci-metrics --legacy
 
 `roborev export ci-metrics` emits one JSON document containing finalized CI
 panel runs for external turnaround-time analysis. Each panel records its GitHub
-repository, pull request, head SHA, creation and posting times, first-attempt
-time, attempt count, terminal outcome, synthesis agent/model snapshot, and the
-retained member and synthesis jobs with their timing and model metadata.
+repository, pull request, head SHA, timestamps, attempt count, terminal outcome,
+and synthesis agent and model. It also includes retained member and synthesis
+jobs with their timing and model metadata. The panel's `experiments` array
+records its experiment assignments.
 
 Terminal outcomes distinguish `review_posted`, `no_review_posted`,
 `giveup_posted`, and `abandoned`. roborev backfills metrics for older finalized
@@ -335,7 +340,7 @@ roborev export ci-costs --legacy
 records for CI review work. Eligible terminal attempts are included even when a
 later retry replaced them in a panel. Skipped, passthrough, pre-agent, and
 manual jobs are excluded. Each row contains `job_uuid`, `finished_at`, `agent`,
-`role`, `status`, and `cost_usd`.
+`role`, `status`, `cost_usd`, and its `experiments` assignments.
 
 Cost is approximate and can be partial. A job whose agent ran but whose usage
 cannot be priced remains in the export with `cost_usd: null`. A known zero-cost
@@ -952,7 +957,8 @@ post_commit_batch_size = 5
 ```
 
 The hook queues one review after five commits instead of one review per commit.
-A partial batch is flushed before push. Values below `2` disable batching.
+The pre-push hook attempts to queue a partial batch before push, but it does not
+block the push if queueing fails. Values below `2` disable batching.
 
 See: [Configuration](/configuration/#post-commit-review-mode) and
 [Post-Commit Review Batching](/configuration/#post-commit-review-batching)
@@ -997,7 +1003,7 @@ hooks. Replace `--codex-config` or `--claude-config` with
 `--agent NAME --config PATH`; remove `--scope user`.
 
 See [Agent Hook](/agent-hook/) for profile detection, threshold configuration,
-the fallback fix workflow, and declarative config details.
+the exact-ID fix workflow, and declarative config details.
 
 ## Checking Agents
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -512,7 +512,7 @@ Global and repo panel maps are merged by name, with repo entries overriding
 global entries. See [Subagent Review Panels](/advanced/subagent-review-panels/)
 for the full reference.
 
-### Review Configuration Experiments
+### Review configuration experiments
 
 Use a named experiment to compare the normal review configuration with one
 configuration overlay. Roborev deterministically assigns a repository-scoped
@@ -563,6 +563,13 @@ enabled = false
 
 At most one enabled experiment may apply to a workflow. Disabled experiments do
 not record assignments.
+
+Review, CI metrics, and CI cost exports include an `experiments` array. Each
+assignment records the experiment ID, arm, subject hash, definition hash, and
+effective configuration hash. Use these fields to group outcomes by experiment
+and arm. See [Exporting Reviews](/commands/#exporting-reviews),
+[Exporting CI Metrics](/commands/#exporting-ci-metrics), and
+[Exporting CI Costs](/commands/#exporting-ci-costs).
 
 ### Backup Agents
 
@@ -782,7 +789,7 @@ HEAD, or any error, the hook falls back to a single-commit review.
 This setting only affects the post-commit hook. `roborev review` is not changed
 by this option.
 
-### Post-Commit Review Batching
+### Post-commit review batching
 
 By default, the post-commit hook queues a review after every commit. To combine
 several small commits into one automatic review, set a repository-local batch
@@ -797,10 +804,11 @@ commits has accumulated. It then queues one review over the accumulated range.
 Values below `2`, including the default of `1`, disable batching.
 
 Batch checkpoints are stored per branch in shared Git metadata, so linked
-worktrees use the same pending range. A partial batch is flushed by the pre-push
-hook before its branch is pushed. After a rebase or amend, the next review
-covers everything since the last commit still shared with the old history, so
-pending work is never skipped. Run `roborev init` after upgrading roborev to
+worktrees use the same pending range. The pre-push hook attempts to queue a
+partial batch before its branch is pushed. It does not block the push if
+queueing fails, and the checkpoint remains pending for a later hook. After a
+rebase or amend, the next review covers everything since the last commit still
+shared with the old history. Run `roborev init` after upgrading roborev to
 install or update the pre-push hook.
 
 When `post_commit_review = "branch"` is also set, the batch size controls when a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -564,7 +564,8 @@ enabled = false
 At most one enabled experiment may apply to a workflow. Disabled experiments do
 not record assignments.
 
-Review, CI metrics, and CI cost exports include an `experiments` array. Each
+Review, CI metrics, and CI cost exports include an `experiments` field. It is an
+array of assignments when an experiment applies and `null` otherwise. Each
 assignment records the experiment ID, arm, subject hash, definition hash, and
 effective configuration hash. Use these fields to group outcomes by experiment
 and arm. See [Exporting Reviews](/commands/#exporting-reviews),

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -89,8 +89,10 @@ review automatically.
 Press `Tab` to focus the detail pane and `Esc` to return to the queue. Review
 actions and scrolling work in the focused detail pane. `Enter` is intentionally
 a no-op while the split queue is focused because the detail already follows the
-selection. Mouse clicks focus either pane, and the wheel scrolls the pane below
-the pointer.
+selection. While the queue has focus, mouse clicks focus either pane and the
+wheel scrolls the pane below the pointer. When the detail pane has focus,
+Roborev releases terminal mouse capture so you can drag to select review text.
+Press `Esc` to restore the queue's mouse controls.
 
 Press `L` to lock the stacked or split preference for the TUI session. A split
 preference falls back to stacked when the terminal is too small and returns when


### PR DESCRIPTION
Documents the published 0.67.0 release in the changelog. The reference docs for branch experiments, CI skip labels, post-commit batching, and exact-review Agent Hook reminders already shipped with those changes. This PR adds the release history, documents focus-dependent mouse capture in split-screen TUI details, and corrects the existing Antigravity transport summary so it matches the shipped version and prompt-size branches. The Antigravity fix remains a release-note item rather than a new reference section.