### PR TITLE
feat(list): support --all-branches

### DIFF
--- a/cmd/roborev/list.go
+++ b/cmd/roborev/list.go
@@ -21,13 +21,14 @@ import (
 
 func listCmd() *cobra.Command {
 	var (
-		branch     string
-		repoPath   string
-		limit      int
-		status     string
-		jsonOutput bool
-		closed     bool
-		open       bool
+		branch      string
+		allBranches bool
+		repoPath    string
+		limit       int
+		status      string
+		jsonOutput  bool
+		closed      bool
+		open        bool
 	)
 
 	cmd := &cobra.Command{
@@ -41,11 +42,16 @@ Examples:
   roborev list                        # Jobs for current repo/branch
   roborev list --json                 # Output as JSON
   roborev list --branch main          # Jobs for main branch
+  roborev list --all-branches         # Jobs across all branches
   roborev list --status done          # Only completed jobs
   roborev list --open                 # Only open (unresolved) reviews
   roborev list --closed               # Only closed reviews
   roborev list --limit 5              # Show at most 5 jobs`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if branch != "" && allBranches {
+				return usageErr(cmd, fmt.Errorf("--branch and --all-branches are mutually exclusive"))
+			}
+
 			ctx := cmd.Context()
 			if err := ensureDaemon(); err != nil {
 				return fmt.Errorf("daemon not running: %w", err)
@@ -75,7 +81,7 @@ Examples:
 				}
 			}
 			// Auto-resolve branch from the target repo when not specified.
-			if branch == "" && localRepoPath != "" {
+			if branch == "" && !allBranches && localRepoPath != "" {
 				branch = gitrepo.CurrentBranch(ctx, localRepoPath)
 			}
 
@@ -164,6 +170,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&branch, "branch", "", "filter by branch (default: current branch)")
+	cmd.Flags().BoolVar(&allBranches, "all-branches", false, "include jobs from all branches")
 	cmd.Flags().StringVar(&repoPath, "repo", "", "filter by repo path (default: current repo)")
 	cmd.Flags().IntVar(&limit, "limit", 50, "max number of jobs to return")
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (queued, running, done, failed)")

--- a/cmd/roborev/list_test.go
+++ b/cmd/roborev/list_test.go
@@ -162,6 +162,18 @@ func TestListCommand(t *testing.T) {
 			wantQuery: []string{"branch="},
 		},
 		{
+			name:         "--all-branches omits branch filter",
+			args:         []string{"--all-branches"},
+			handler:      jobsHandler([]storage.ReviewJob{}, false),
+			notWantQuery: []string{"branch="},
+		},
+		{
+			name:      "--all-branches and --branch conflict",
+			args:      []string{"--all-branches", "--branch", "main"},
+			handler:   jobsHandler([]storage.ReviewJob{}, false),
+			wantError: "--branch and --all-branches are mutually exclusive",
+		},
+		{
 			name: "worktree sends main repo path as repo param",
 			repoSetup: func(t *testing.T) repoSetupResult {
 				repo := newTestGitRepo(t)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -138,6 +138,7 @@ roborev show <job_id>            # Show review by job ID
 roborev show --job <id>          # Force interpretation as job ID
 roborev show --prompt <job_id>   # Show the prompt sent to the agent
 roborev list                     # List jobs for current repo/branch
+roborev list --all-branches      # List jobs for every branch in the current repo
 roborev list --open              # List only open reviews
 roborev list --closed            # List only closed reviews
 roborev tui                      # Interactive terminal UI
@@ -152,6 +153,9 @@ roborev log <job_id>             # View job log
 | `--job` | Force interpretation as job ID |
 | `--prompt` | Show the prompt sent to the agent instead of the review output |
 | `--json` | Output as JSON for machine-readable workflows |
+
+`roborev list` filters to the current branch by default. Use `--all-branches` to
+omit the branch filter. `--all-branches` and `--branch` cannot be combined.
 
 When the argument is a numeric job ID, `--prompt` can display the stored prompt
 while the job is queued or running; review output does not exist until the job


### PR DESCRIPTION
Add `roborev list --all-branches` so users can list jobs across every branch in the current repository without calling the daemon API directly. The flag keeps the repository filter, skips automatic branch resolution, and conflicts with an explicit `--branch` selection.

Closes #1098
