### PR TITLE
chore: ignore local env files and move changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ docs/.env*.local
 
 # roborev snapshots
 /.roborev/
+.env*

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -14,6 +14,7 @@ use_directory_urls = true
 nav = [
   {"Quick Start" = "quickstart.md"},
   {"Installation" = "installation.md"},
+  {"Changelog" = "changelog.md"},
   {"Automation" = [
     {"Post-Commit Reviews" = "automation/post-commit-reviews.md"},
     {"Agent Hook"          = "agent-hook.md"},
@@ -49,7 +50,6 @@ nav = [
   ]},
   {"Troubleshooting" = "guides/troubleshooting.md"},
   {"Development" = "development.md"},
-  {"Changelog" = "changelog.md"},
 ]
 
 [project.extra]


### PR DESCRIPTION
Local environment files such as `.env.local` are now ignored by the repository,
so maintainer checkouts do not report them as changes. The published docs
navigation also puts Changelog immediately below Installation, making release
history easier to find.

The docs build and validation checks pass with `make docs-check`.
