### PR TITLE
fix(agent-hook): warn when roborev-fix skill is stale

### DIFF
--- a/cmd/roborev/agent_hook_cmd.go
+++ b/cmd/roborev/agent_hook_cmd.go
@@ -129,6 +129,15 @@ func runLegacyAgentHook(
 		fmt.Fprintf(stderr, "roborev agent-hook: %v\n", err)
 		return json.NewEncoder(stdout).Encode(map[string]any{})
 	}
+	if resp.Triggered {
+		instruction := agenthook.StopReasonWithFixGuidelines(resp.Reason, opts.FixGuidelines)
+		resp.Reason = fmt.Sprintf(
+			"Warning: this legacy Agent Hook cannot verify the installed roborev-fix skill. "+
+				"Run 'roborev agent-hook install' before following this reminder.\n\n%s",
+			instruction,
+		)
+		return json.NewEncoder(stdout).Encode(agenthook.BuildOutput(input, resp))
+	}
 	return json.NewEncoder(stdout).Encode(agenthook.BuildOutputWithFixGuidelines(input, resp, opts.FixGuidelines))
 }
 

--- a/cmd/roborev/agent_hook_cmd.go
+++ b/cmd/roborev/agent_hook_cmd.go
@@ -95,6 +95,13 @@ func runGrokAgentHook(opts agenthook.Options, stdin io.Reader, stdout, stderr io
 		fmt.Fprintf(stderr, "roborev Grok Build: %v\n", err)
 		return json.NewEncoder(stdout).Encode(map[string]any{})
 	}
+	if resp.Triggered {
+		resp.Reason = prependAgentHookFixSkillWarning(
+			kitagenthook.Agent("grok"),
+			agenthook.StopReasonWithFixGuidelines(resp.Reason, opts.FixGuidelines),
+		)
+		return json.NewEncoder(stdout).Encode(agenthook.BuildOutput(input, resp))
+	}
 	return json.NewEncoder(stdout).Encode(agenthook.BuildOutputWithFixGuidelines(input, resp, opts.FixGuidelines))
 }
 

--- a/cmd/roborev/agent_hook_handler.go
+++ b/cmd/roborev/agent_hook_handler.go
@@ -9,7 +9,10 @@ import (
 	kitagenthook "go.kenn.io/kit/agenthook"
 
 	"go.kenn.io/roborev/internal/agenthook"
+	"go.kenn.io/roborev/internal/skills"
 )
+
+const agentHookSkillInstallCommand = "roborev skills install"
 
 type roborevAgentHookHandler struct {
 	kitagenthook.NoopHandler
@@ -94,8 +97,9 @@ func (h roborevAgentHookHandler) PostToolUse(
 		return kitagenthook.PostToolUseOutput{}, nil
 	}
 	return kitagenthook.PostToolUseOutput{
-		AdditionalContext: agenthook.PostToolUseAdditionalContextWithFixGuidelines(
-			resp.Reason, h.opts.FixGuidelines,
+		AdditionalContext: prependAgentHookFixSkillWarning(
+			h.agent,
+			agenthook.PostToolUseAdditionalContextWithFixGuidelines(resp.Reason, h.opts.FixGuidelines),
 		),
 	}, nil
 }
@@ -116,6 +120,54 @@ func (h roborevAgentHookHandler) Stop(
 	}
 	return kitagenthook.StopOutput{
 		Decision: kitagenthook.DecisionBlock,
-		Reason:   agenthook.StopReasonWithFixGuidelines(resp.Reason, h.opts.FixGuidelines),
+		Reason: prependAgentHookFixSkillWarning(
+			h.agent,
+			agenthook.StopReasonWithFixGuidelines(resp.Reason, h.opts.FixGuidelines),
+		),
 	}, nil
+}
+
+func prependAgentHookFixSkillWarning(agent kitagenthook.Agent, instruction string) string {
+	skillAgent, supported := mapAgentHookSkillAgent(agent)
+	if !supported {
+		return instruction
+	}
+
+	status, found := skills.StatusForAgent(skillAgent)
+	if !found {
+		return instruction
+	}
+	state, installed := status.Skills["roborev-fix"]
+	if !installed {
+		state = skills.SkillMissing
+	}
+	switch state {
+	case skills.SkillMissing:
+		return fmt.Sprintf(
+			"Warning: the roborev-fix skill is missing. Run '%s' before following this reminder.\n\n%s",
+			agentHookSkillInstallCommand, instruction,
+		)
+	case skills.SkillOutdated:
+		return fmt.Sprintf(
+			"Warning: the installed roborev-fix skill is outdated. Run '%s' before following this reminder.\n\n%s",
+			agentHookSkillInstallCommand, instruction,
+		)
+	default:
+		return instruction
+	}
+}
+
+func mapAgentHookSkillAgent(agent kitagenthook.Agent) (skills.Agent, bool) {
+	switch agent {
+	case kitagenthook.AgentClaude:
+		return skills.AgentClaude, true
+	case kitagenthook.AgentCodex:
+		return skills.AgentCodex, true
+	case kitagenthook.AgentDroid:
+		return skills.AgentDroid, true
+	case kitagenthook.Agent("grok"):
+		return skills.AgentGrok, true
+	default:
+		return "", false
+	}
 }

--- a/cmd/roborev/agent_hook_test.go
+++ b/cmd/roborev/agent_hook_test.go
@@ -18,6 +18,7 @@ import (
 	kitagenthook "go.kenn.io/kit/agenthook"
 
 	"go.kenn.io/roborev/internal/agenthook"
+	"go.kenn.io/roborev/internal/skills"
 )
 
 func TestAgentHookInstallSupportsExplicitQwenProfile(t *testing.T) {
@@ -236,6 +237,72 @@ func TestRunAgentHookEncodesKitStopResponse(t *testing.T) {
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
 	assert.Equal(t, "block", output["decision"])
 	assert.Equal(t, "resolve reviews", output["reason"])
+}
+
+func TestRunAgentHookReportsCodexFixSkillStateInTriggeredReminder(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		install     func(*testing.T, string)
+		wantWarning string
+	}{
+		{name: "missing", wantWarning: "roborev-fix skill is missing"},
+		{
+			name: "outdated",
+			install: func(t *testing.T, skillsDir string) {
+				skillDir := filepath.Join(skillsDir, "roborev-fix")
+				require.NoError(t, os.MkdirAll(skillDir, 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("stale skill"), 0o644))
+			},
+			wantWarning: "installed roborev-fix skill is outdated",
+		},
+		{
+			name: "current",
+			install: func(t *testing.T, skillsDir string) {
+				_, err := skills.InstallToPath(skills.AgentCodex, skillsDir)
+				require.NoError(t, err)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			codexHome := t.TempDir()
+			t.Setenv("CODEX_HOME", codexHome)
+			skillsDir := filepath.Join(codexHome, "skills")
+			if tc.install != nil {
+				tc.install(t, skillsDir)
+			}
+
+			oldPost := postAgentHook
+			postAgentHook = func(context.Context, string, agenthook.Request) (agenthook.Response, error) {
+				return agenthook.Response{
+					Triggered: true,
+					Reason:    "Invoke $roborev-fix for review jobs 17 and 23.",
+				}, nil
+			}
+			t.Cleanup(func() { postAgentHook = oldPost })
+
+			var stdout bytes.Buffer
+			err := runAgentHook(
+				kitagenthook.AgentCodex,
+				agenthook.DefaultOptions(),
+				strings.NewReader(`{"session_id":"s1","hook_event_name":"Stop"}`),
+				&stdout,
+				io.Discard,
+			)
+			require.NoError(t, err)
+
+			var output map[string]any
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+			reason, ok := output["reason"].(string)
+			require.True(t, ok)
+			assert.Contains(t, reason, "Invoke $roborev-fix for review jobs 17 and 23.")
+			if tc.wantWarning == "" {
+				assert.NotContains(t, reason, agentHookSkillInstallCommand)
+				return
+			}
+			assert.Contains(t, reason, tc.wantWarning)
+			assert.Contains(t, reason, agentHookSkillInstallCommand)
+		})
+	}
 }
 
 // If kit-backed profiles omit policy composition, most supported hooks keep

--- a/cmd/roborev/agent_hook_test.go
+++ b/cmd/roborev/agent_hook_test.go
@@ -144,7 +144,13 @@ func TestAgentHookRunSupportsLegacyProfilelessRegistration(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, "legacy-1", got.Event.SessionID)
-	assert.JSONEq(t, `{"decision":"block","reason":"resolve reviews"}`, stdout.String())
+	var output map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &output))
+	reason, ok := output["reason"].(string)
+	require.True(t, ok)
+	assert.Contains(t, reason, "legacy Agent Hook cannot verify the installed roborev-fix skill")
+	assert.Contains(t, reason, "roborev agent-hook install")
+	assert.Contains(t, reason, "resolve reviews")
 }
 
 // If a legacy or Grok encoder bypasses policy-aware output, users get different

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -143,6 +143,12 @@ The CLI flag migration is:
 
 Removed flags are not retained as aliases.
 
+Until it is replaced, a profile-less legacy hook cannot identify whether Claude
+Code or Codex invoked it and therefore cannot verify that profile's
+`roborev-fix` skill. Triggered reminders from that hook warn you to run
+`roborev agent-hook install`, which replaces the registration and updates its
+skills.
+
 Persisted session state is also read forward during this window. A legacy
 session-wide Stop count moves to its single identifiable recent workspace;
 ambiguous multi-workspace progress resets instead of being assigned to the wrong

--- a/docs/agent-hook.md
+++ b/docs/agent-hook.md
@@ -57,6 +57,13 @@ their IDs only when delivered.
 `instruction` is a complete override. Custom instructions are emitted without
 the built-in scope or continuation guidance.
 
+When a reminder triggers for Claude Code, Codex, Factory Droid, or Grok Build,
+the hook compares that agent's installed `roborev-fix` skill with the version
+embedded in the running roborev binary. If the skill is missing or outdated, the
+reminder begins with a warning to run `roborev skills install`. The original
+instruction and its exact review job IDs are still delivered. The hook never
+updates skills automatically.
+
 ## Install
 
 Install hooks for every locally detected coding agent:

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -414,58 +414,73 @@ func ListSkills() ([]SkillInfo, error) {
 
 // Status returns per-agent, per-skill installation state.
 func Status() []AgentStatus {
-	var out []AgentStatus
+	out := make([]AgentStatus, 0, len(supportedAgents))
 	for _, spec := range supportedAgents {
 		home, err := homeDirForAgent(spec)
 		if err != nil {
 			return nil
 		}
-		status := AgentStatus{
-			Agent:  spec.agent,
-			Skills: make(map[string]SkillState),
-		}
+		out = append(out, statusForAgent(spec, home))
+	}
+	return out
+}
 
-		configDir := agentConfigDir(home, spec)
-		if _, err := os.Stat(configDir); err != nil {
-			out = append(out, status)
-			continue
-		}
-		status.Available = true
+// StatusForAgent returns one agent's embedded skill installation state.
+func StatusForAgent(agent Agent) (AgentStatus, bool) {
+	spec, ok := lookupAgent(agent)
+	if !ok {
+		return AgentStatus{}, false
+	}
+	home, err := homeDirForAgent(spec)
+	if err != nil {
+		return AgentStatus{}, false
+	}
+	return statusForAgent(spec, home), true
+}
 
-		skills, err := embeddedSkillsForAgent(spec)
+func statusForAgent(spec agentSpec, home string) AgentStatus {
+	status := AgentStatus{
+		Agent:  spec.agent,
+		Skills: make(map[string]SkillState),
+	}
+
+	configDir := agentConfigDir(home, spec)
+	if _, err := os.Stat(configDir); err != nil {
+		return status
+	}
+	status.Available = true
+
+	embedded, err := embeddedSkillsForAgent(spec)
+	if err != nil {
+		return status
+	}
+
+	skillsDir := agentSkillsDir(home, spec)
+	for _, skill := range embedded {
+		installedPath := skillInstallPath(skillsDir, skill.DirName)
+
+		installedContent, err := os.ReadFile(installedPath)
 		if err != nil {
-			out = append(out, status)
+			status.Skills[skill.DirName] = SkillMissing
 			continue
 		}
 
-		skillsDir := agentSkillsDir(home, spec)
-		for _, skill := range skills {
-			installedPath := skillInstallPath(skillsDir, skill.DirName)
+		if !bytes.Equal(installedContent, skill.Content) {
+			status.Skills[skill.DirName] = SkillOutdated
+			continue
+		}
 
-			installedContent, err := os.ReadFile(installedPath)
-			if err != nil {
-				status.Skills[skill.DirName] = SkillMissing
-				continue
-			}
-
-			if !bytes.Equal(installedContent, skill.Content) {
+		if skill.OpenAIYAML != nil {
+			installedPolicy, err := os.ReadFile(filepath.Join(skillsDir, skill.DirName, "agents", "openai.yaml"))
+			if err != nil || !bytes.Equal(installedPolicy, skill.OpenAIYAML) {
 				status.Skills[skill.DirName] = SkillOutdated
 				continue
 			}
-
-			if skill.OpenAIYAML != nil {
-				installedPolicy, err := os.ReadFile(filepath.Join(skillsDir, skill.DirName, "agents", "openai.yaml"))
-				if err != nil || !bytes.Equal(installedPolicy, skill.OpenAIYAML) {
-					status.Skills[skill.DirName] = SkillOutdated
-					continue
-				}
-			}
-			status.Skills[skill.DirName] = SkillCurrent
 		}
-
-		out = append(out, status)
+		status.Skills[skill.DirName] = SkillCurrent
 	}
-	return out
+
+	return status
 }
 
 // parseFrontmatter extracts name and description from YAML frontmatter.


### PR DESCRIPTION
Agent Hook reminders can invoke an installed `roborev-fix` skill whose policy
predates the running roborev binary. This change checks only the active Claude
Code, Codex, Factory Droid, or Grok Build profile and prepends a warning when
that skill is missing or differs from the embedded version.

Profile-less legacy hooks cannot identify the active agent, so their reminders
instead warn users to run `roborev agent-hook install`. The normal scoped
instruction and exact review job IDs remain intact, and hooks never change a
skill installation themselves.

<sup>generated by a clanker</sup>
