### PR TITLE
Preserve historical identity in restoration fixes

### DIFF
--- a/cmd/roborev/analyze.go
+++ b/cmd/roborev/analyze.go
@@ -18,6 +18,7 @@ import (
 	gitrepo "go.kenn.io/kit/git/repo"
 
 	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/autofix"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/daemon"
 	"go.kenn.io/roborev/internal/git"
@@ -760,6 +761,8 @@ func buildFixPromptWithMetadata(
 	fmt.Fprintf(&sb, "An analysis of type **%s** was performed and produced the following findings:\n\n", analysisType.Name)
 	sb.WriteString("## Analysis Findings\n\n")
 	sb.WriteString(analysisOutput)
+	sb.WriteString("\n\n## Restoration History\n\n")
+	sb.WriteString(autofix.RestorationHistoryGuidance)
 	sb.WriteString("\n\n## Instructions\n\n")
 	sb.WriteString("Please apply the suggested changes from the analysis above. ")
 	sb.WriteString("Make the necessary edits to address each finding. ")

--- a/cmd/roborev/analyze_test.go
+++ b/cmd/roborev/analyze_test.go
@@ -213,6 +213,8 @@ func TestBuildFixPrompt(t *testing.T) {
 	assertContains(t, prompt, "apply the suggested changes", "prompt should include fix instructions")
 	assertContains(t, prompt, "compiles", "prompt should mention verification steps")
 	assertContains(t, prompt, "tests", "prompt should mention verification steps")
+	assertContains(t, prompt, "inspect the relevant repository history", "prompt should include restoration guidance")
+	assertContains(t, prompt, "schema object names", "prompt should preserve established identities")
 }
 
 func TestBuildFixPromptWithCommitMetadata(t *testing.T) {

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -1141,7 +1141,10 @@ func fixSingleJob(cmd *cobra.Command, repoRoot string, jobID int64, opts fixOpti
 		Metadata:      metadata,
 		FixGuidelines: fixCfg.FixGuidelines,
 		Classify:      opts.classify,
-	}, buildGenericFixPromptWithMetadata(review.Output, minSev, comments, metadata, fixCfg.FixGuidelines))
+	}, buildGenericFixPromptWithMetadataForRef(
+		review.Output, minSev, comments, metadata, fixCfg.FixGuidelines,
+		reviewedRefForFix(job),
+	))
 	// Flush capture FIRST so session extraction completes before reading SessionID.
 	capture.Flush()
 	if fmtr != nil {
@@ -1528,10 +1531,11 @@ const (
 )
 
 func buildBatchPromptHeader(fixGuidelines string) string {
+	header := batchPromptHeaderWithGuidelines
 	if strings.TrimSpace(fixGuidelines) == "" {
-		return batchPromptHeader
+		header = batchPromptHeader
 	}
-	return batchPromptHeaderWithGuidelines
+	return header + autofix.RestorationHistoryGuidance + "\n\n"
 }
 
 func batchPromptOverhead(metadata config.FixCommitMetadata, fixGuidelines string) int {
@@ -1551,6 +1555,7 @@ func buildBatchPromptFooter(metadata config.FixCommitMetadata, fixGuidelines str
 func batchEntrySize(index int, e batchEntry) int {
 	toolAttempts, userComments := prompt.SplitResponses(e.comments)
 	size := len(fmt.Sprintf("## Review %d (Job %d — %s)\n\n%s\n\n", index, e.jobID, gitrepo.ShortSHA(e.job.GitRef), e.review.Output))
+	size += len(autofix.FormatReviewedRef(reviewedRefForFix(e.job)))
 	size += len(prompt.FormatToolAttempts(toolAttempts))
 	size += len(prompt.FormatUserComments(userComments))
 	return size
@@ -1629,6 +1634,7 @@ func buildBatchFixPromptWithMetadata(
 	for i, e := range entries {
 		toolAttempts, userComments := prompt.SplitResponses(e.comments)
 		fmt.Fprintf(&sb, "## Review %d (Job %d — %s)\n\n", i+1, e.jobID, gitrepo.ShortSHA(e.job.GitRef))
+		sb.WriteString(autofix.FormatReviewedRef(reviewedRefForFix(e.job)))
 		sb.WriteString(e.review.Output)
 		sb.WriteString("\n\n")
 		sb.WriteString(prompt.FormatToolAttempts(toolAttempts))
@@ -1803,6 +1809,17 @@ func buildGenericFixPromptWithMetadata(
 	metadata config.FixCommitMetadata,
 	fixGuidelines string,
 ) string {
+	return buildGenericFixPromptWithMetadataForRef(
+		analysisOutput, minSeverity, responses, metadata, fixGuidelines, "",
+	)
+}
+
+func buildGenericFixPromptWithMetadataForRef(
+	analysisOutput, minSeverity string,
+	responses []storage.Response,
+	metadata config.FixCommitMetadata,
+	fixGuidelines, reviewedRef string,
+) string {
 	toolAttempts, userComments := prompt.SplitResponses(responses)
 	var sb strings.Builder
 	sb.WriteString("# Fix Request\n\n")
@@ -1816,6 +1833,10 @@ func buildGenericFixPromptWithMetadata(
 	sb.WriteString("\n\n")
 	sb.WriteString(prompt.FormatToolAttempts(toolAttempts))
 	sb.WriteString(prompt.FormatUserComments(userComments))
+	sb.WriteString("## Restoration History\n\n")
+	sb.WriteString(autofix.RestorationHistoryGuidance)
+	sb.WriteString("\n\n")
+	sb.WriteString(autofix.FormatReviewedRef(reviewedRef))
 	sb.WriteString("## Instructions\n\n")
 	if strings.TrimSpace(fixGuidelines) == "" {
 		sb.WriteString("Please apply the suggested changes from the analysis above. ")
@@ -1831,6 +1852,13 @@ func buildGenericFixPromptWithMetadata(
 	sb.WriteString("3. Create a git commit with a descriptive message summarizing the changes\n")
 	sb.WriteString(formatFixCommitMetadataInstructions(metadata))
 	return autofix.AppendGuidelines(sb.String(), fixGuidelines)
+}
+
+func reviewedRefForFix(job *storage.ReviewJob) string {
+	if job == nil || !job.IsReviewJob() || job.IsDirtyJob() {
+		return ""
+	}
+	return strings.TrimSpace(job.GitRef)
 }
 
 // buildGenericCommitPrompt creates a prompt to commit uncommitted changes

--- a/cmd/roborev/fix_test.go
+++ b/cmd/roborev/fix_test.go
@@ -96,6 +96,24 @@ func TestBuildGenericFixPrompt(t *testing.T) {
 	assert.Contains(t, prompt, "git commit")
 }
 
+func TestBuildGenericFixPromptIncludesRestorationHistoryGuidance(t *testing.T) {
+	prompt := buildGenericFixPrompt("Restore the removed constraint", "", nil)
+
+	assert.Contains(t, prompt, "inspect the relevant repository history")
+	assert.Contains(t, prompt, "Preserve established identifiers")
+	assert.NotContains(t, prompt, "Reviewed git ref:")
+}
+
+func TestBuildGenericFixPromptIncludesReviewedRef(t *testing.T) {
+	prompt := buildGenericFixPromptWithMetadataForRef(
+		"Restore the removed constraint", "", nil,
+		config.FixCommitMetadata{}, "", "abc123def456",
+	)
+
+	assert.Contains(t, prompt, "Reviewed git ref: \"abc123def456\".")
+	assert.Contains(t, prompt, "apply the fix to the current checkout")
+}
+
 func TestBuildGenericFixPromptWithComments(t *testing.T) {
 	comments := []storage.Response{
 		{Responder: "dev", Response: "Don't touch the helper function", CreatedAt: time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)},
@@ -732,6 +750,35 @@ func TestFixSingleJobPassesGlobalFixGuidelinesToAgent(t *testing.T) {
 	calls := tester.Calls()
 	require.NotEmpty(t, calls)
 	assert.Contains(t, calls[0].Prompt, "Direct policy sentinel")
+}
+
+func TestFixSingleJobPassesReviewedRefToAgent(t *testing.T) {
+	repo := createTestRepo(t, map[string]string{"main.go": "package main\n"})
+	ts, _ := newMockServer(t, MockServerOpts{
+		ReviewOutput: "## Issues\n- Restore removed behavior",
+		OnJobs: func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(w, map[string]any{"jobs": []storage.ReviewJob{{
+				ID:      99,
+				Status:  storage.JobStatusDone,
+				Agent:   "test",
+				JobType: storage.JobTypeReview,
+				GitRef:  "abc123def456",
+			}}})
+		},
+	})
+	patchServerAddr(t, ts.URL)
+
+	tester := agent.NewTestAgent()
+	tracker := &fixSessionTracker{base: tester, out: io.Discard}
+	cmd, _ := newTestCmd(t)
+	require.NoError(t, fixSingleJob(
+		cmd, repo.Dir, 99,
+		fixOptions{agentName: "test", reasoning: "fast"}, tracker,
+	))
+
+	calls := tester.Calls()
+	require.NotEmpty(t, calls)
+	assert.Contains(t, calls[0].Prompt, "Reviewed git ref: \"abc123def456\".")
 }
 
 // If the batch production path omits policy routing, batch fixes behave
@@ -2020,12 +2067,12 @@ func TestBuildBatchFixPrompt(t *testing.T) {
 	entries := []batchEntry{
 		{
 			jobID:  123,
-			job:    &storage.ReviewJob{GitRef: "abc123def456"},
+			job:    &storage.ReviewJob{GitRef: "abc123def456", JobType: storage.JobTypeReview},
 			review: &storage.Review{Output: "Found bug in foo.go"},
 		},
 		{
 			jobID:  456,
-			job:    &storage.ReviewJob{GitRef: "deadbeef1234"},
+			job:    &storage.ReviewJob{GitRef: "deadbeef1234", JobType: storage.JobTypeReview},
 			review: &storage.Review{Output: "Missing error check in bar.go"},
 		},
 	}
@@ -2038,9 +2085,12 @@ func TestBuildBatchFixPrompt(t *testing.T) {
 
 	// Per-review sections with numbered headers
 	assert.Contains(t, prompt, "## Review 1 (Job 123 — abc123d)")
+	assert.Contains(t, prompt, "Reviewed git ref: \"abc123def456\".")
 	assert.Contains(t, prompt, "Found bug in foo.go")
 	assert.Contains(t, prompt, "## Review 2 (Job 456 — deadbee)")
+	assert.Contains(t, prompt, "Reviewed git ref: \"deadbeef1234\".")
 	assert.Contains(t, prompt, "Missing error check in bar.go")
+	assert.Contains(t, prompt, "inspect the relevant repository history")
 
 	// Instructions footer
 	assert.Contains(t, prompt, "## Instructions")

--- a/docs/guides/responding-to-reviews.md
+++ b/docs/guides/responding-to-reviews.md
@@ -30,6 +30,11 @@ The agent reads the review, applies changes, commits, and closes the review.
 This is a one-shot fix. For an iterative loop with re-review, see
 [Auto-Fix with Refine](/guides/auto-fixing/).
 
+When a finding asks to restore prior behavior, the fix prompt directs the agent
+to inspect relevant repository history before editing. The reviewed git ref is
+included when available so established identifiers, schema object names, public
+APIs, paths, and migration semantics can be preserved when still compatible.
+
 ## Copying Reviews
 
 Press `y` in the TUI to copy the full review content to your clipboard,

--- a/internal/autofix/history.go
+++ b/internal/autofix/history.go
@@ -1,0 +1,21 @@
+package autofix
+
+import (
+	"strconv"
+	"strings"
+)
+
+// RestorationHistoryGuidance tells fix agents to recover established object
+// identity before recreating behavior that a reviewed change removed.
+const RestorationHistoryGuidance = `When a finding asks to restore, revert, or reinstate prior behavior, inspect the relevant repository history before editing. If a reviewed git ref is supplied, start with that ref and its parent commits, but apply the fix to the current checkout. Preserve established identifiers, schema object names, public API shapes, file paths, and migration semantics when they remain compatible. If history is unavailable or conflicts with current requirements, state the ambiguity instead of silently inventing a replacement identity.`
+
+// FormatReviewedRef returns a prompt-safe line identifying the change that
+// produced the findings. strconv.Quote keeps control characters and prompt
+// delimiters in an untrusted stored ref from changing the prompt structure.
+func FormatReviewedRef(gitRef string) string {
+	gitRef = strings.TrimSpace(gitRef)
+	if gitRef == "" {
+		return ""
+	}
+	return "Reviewed git ref: " + strconv.Quote(gitRef) + ".\n\n"
+}

--- a/internal/autofix/history_test.go
+++ b/internal/autofix/history_test.go
@@ -1,0 +1,21 @@
+package autofix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatReviewedRef(t *testing.T) {
+	assert.Empty(t, FormatReviewedRef(" \n\t"))
+	assert.Equal(t, "Reviewed git ref: \"abc123\".\n\n", FormatReviewedRef(" abc123 "))
+	assert.Equal(t, "Reviewed git ref: \"abc\\n123\".\n\n", FormatReviewedRef("abc\n123"))
+}
+
+func TestRestorationHistoryGuidancePreservesExistingIdentity(t *testing.T) {
+	assert := assert.New(t)
+	assert.Contains(RestorationHistoryGuidance, "inspect the relevant repository history")
+	assert.Contains(RestorationHistoryGuidance, "schema object names")
+	assert.Contains(RestorationHistoryGuidance, "migration semantics")
+	assert.Contains(RestorationHistoryGuidance, "current checkout")
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -24,6 +24,7 @@ import (
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/agenthook"
+	"go.kenn.io/roborev/internal/autofix"
 	"go.kenn.io/roborev/internal/backfill"
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/git"
@@ -1175,7 +1176,7 @@ func parseDuration(s string) (time.Duration, error) {
 // buildFixPromptWithInstructions constructs a fix prompt that includes the review
 // findings, optional user-provided instructions, and any comments/responses
 // (split into tool attempts and user comments for proper framing).
-func buildFixPromptWithInstructions(reviewOutput, userInstructions, minSeverity string, responses []storage.Response) string {
+func buildFixPromptWithInstructions(reviewOutput, userInstructions, minSeverity string, responses []storage.Response, reviewedRef string) string {
 	toolAttempts, userComments := prompt.SplitResponses(responses)
 	p := "# Fix Request\n\n" +
 		"An analysis was performed and produced the following findings:\n\n"
@@ -1186,6 +1187,9 @@ func buildFixPromptWithInstructions(reviewOutput, userInstructions, minSeverity 
 		reviewOutput + "\n\n"
 	p += prompt.FormatToolAttempts(toolAttempts)
 	p += prompt.FormatUserComments(userComments)
+	p += "## Restoration History\n\n" +
+		autofix.RestorationHistoryGuidance + "\n\n" +
+		autofix.FormatReviewedRef(reviewedRef)
 	if userInstructions != "" {
 		p += "## Additional Instructions\n\n" +
 			userInstructions + "\n\n"
@@ -3252,8 +3256,12 @@ func (s *Server) humaFixJob(
 				req.ParentJobID, commentsErr,
 			)
 		}
+		reviewedRef := ""
+		if parentJob.IsReviewJob() && !parentJob.IsDirtyJob() {
+			reviewedRef = parentJob.GitRef
+		}
 		fixPrompt = buildFixPromptWithInstructions(
-			review.Output, req.Prompt, fixMinSev, comments,
+			review.Output, req.Prompt, fixMinSev, comments, reviewedRef,
 		)
 	}
 

--- a/internal/daemon/server_fix_prompt_test.go
+++ b/internal/daemon/server_fix_prompt_test.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildFixPromptWithInstructionsIncludesRestorationContext(t *testing.T) {
+	prompt := buildFixPromptWithInstructions(
+		"Restore the removed database constraint.",
+		"Keep the change narrowly scoped.",
+		"",
+		nil,
+		"abc123def456",
+	)
+
+	assert := assert.New(t)
+	assert.Contains(prompt, "inspect the relevant repository history")
+	assert.Contains(prompt, "Preserve established identifiers")
+	assert.Contains(prompt, "Reviewed git ref: \"abc123def456\".")
+	assert.Contains(prompt, "Keep the change narrowly scoped.")
+}


### PR DESCRIPTION
Closes #1113.

Restoration findings often describe the invariant that should return without
repeating the exact identifier or migration definition that existed before the
reviewed change. A fix agent can therefore implement equivalent behavior under
a new identity, leaving upgraded and fresh installations with different
schemas even when immediate behavior checks pass.

This change makes history recovery part of RoboRev's correction context. A
shared instruction now tells foreground, batch, analysis, and background fix
agents to inspect relevant history for restore/revert/reinstate findings and to
preserve established identifiers and migration semantics when compatible.
Review-backed fixes also include the stored reviewed git ref while making clear
that edits still belong on the current checkout.

The guidance is conditional rather than schema-specific, so it also covers
restored APIs, configuration keys, and paths. When history is unavailable or
conflicts with current requirements, the agent is asked to surface the
ambiguity instead of silently inventing a replacement identity.
