### PR TITLE
fix(skills): point Codex at AGENTS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Test with coverage
         # Race coverage runs in the test and daemon-race jobs; repeating it here
         # makes the daemon package exceed its timeout without improving coverage.
-        run: go test -timeout 30m -shuffle=on -tags integration -coverprofile=coverage.out ./...
+        run: go test -timeout 45m -shuffle=on -tags integration -coverprofile=coverage.out ./...
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0

--- a/internal/skills/codex/roborev-design-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-design-review-branch/SKILL.md
@@ -39,7 +39,7 @@ This skill requires you to **execute bash commands** to validate inputs and run 
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-design-review/SKILL.md
+++ b/internal/skills/codex/roborev-design-review/SKILL.md
@@ -39,7 +39,7 @@ This skill requires you to **execute bash commands** to validate the commit and 
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-fix/SKILL.md
+++ b/internal/skills/codex/roborev-fix/SKILL.md
@@ -63,7 +63,7 @@ An Agent Hook invocation does not broaden the user's current task:
 
 ## IMPORTANT
 
-You must **execute bash commands** to complete this task. Skip steps already satisfied by conversation context. Defer to CLAUDE.md when it conflicts.
+You must **execute bash commands** to complete this task. Skip steps already satisfied by conversation context. Defer to AGENTS.md when it conflicts.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-lookahead-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-lookahead-review-branch/SKILL.md
@@ -42,7 +42,7 @@ This skill requires you to **execute bash commands** to validate inputs and run 
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-lookahead-review/SKILL.md
+++ b/internal/skills/codex/roborev-lookahead-review/SKILL.md
@@ -42,7 +42,7 @@ This skill requires you to **execute bash commands** to validate the commit and 
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-refine/SKILL.md
+++ b/internal/skills/codex/roborev-refine/SKILL.md
@@ -56,7 +56,7 @@ finishes and you present the result to the user.
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 
@@ -149,7 +149,7 @@ before proceeding.
 
 #### 3c. Commit, then record comment and close review
 
-Commit first per the project's conventions (see CLAUDE.md). Only after the
+Commit first per the project's conventions (see AGENTS.md). Only after the
 commit succeeds, record a summary comment on the review and close it:
 
 ```bash

--- a/internal/skills/codex/roborev-respond/SKILL.md
+++ b/internal/skills/codex/roborev-respond/SKILL.md
@@ -33,7 +33,7 @@ This skill requires you to **execute bash commands** to record the comment and c
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -39,7 +39,7 @@ This skill requires you to **execute bash commands** to validate inputs and run 
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-review/SKILL.md
+++ b/internal/skills/codex/roborev-review/SKILL.md
@@ -39,7 +39,7 @@ This skill requires you to **execute bash commands** to validate the commit and 
 
 These instructions are guidelines, not a rigid script. Use the conversation
 context. Skip steps that are already satisfied. Defer to project-level
-CLAUDE.md instructions when they conflict with these steps.
+AGENTS.md instructions when they conflict with these steps.
 
 ## Instructions
 

--- a/internal/skills/codex/roborev-snooze/SKILL.md
+++ b/internal/skills/codex/roborev-snooze/SKILL.md
@@ -35,7 +35,7 @@ sandboxed status probe cannot reach it.
 ## Instructions
 
 This skill requires you to execute the matching command and report its result.
-Defer to project-level CLAUDE.md instructions when they conflict with these
+Defer to project-level AGENTS.md instructions when they conflict with these
 steps.
 
 - With no action, or with `on`, run `roborev snooze on`. If the user supplied a

--- a/internal/skills/derive.go
+++ b/internal/skills/derive.go
@@ -70,7 +70,6 @@ func skillDerivations() []skillDerivation {
 				New: ", or structured\nFactory skill selection",
 			},
 			{Old: "$roborev", New: "/roborev"},
-			{Old: "CLAUDE.md", New: "AGENTS.md"},
 			{
 				Old: "`sandbox_permissions: \"require_escalated\"`",
 				New: "the runtime's supported sandbox escalation mechanism",
@@ -95,6 +94,7 @@ func skillDerivations() []skillDerivation {
 				New: ", or structured\nClaude Code skill selection",
 			},
 			{Old: "$roborev", New: "/roborev"},
+			{Old: "AGENTS.md", New: "CLAUDE.md"},
 			{Old: "Retry the same command with", New: "Retry the same Bash command with"},
 			{
 				Old: "`sandbox_permissions: \"require_escalated\"`",
@@ -125,8 +125,6 @@ func skillDerivations() []skillDerivation {
 				New: ", or structured\nGrok Build skill selection",
 			},
 			{Old: "$roborev", New: "/roborev"},
-			// Grok project rules use AGENTS.md (CLAUDE.md is a compatibility alias).
-			{Old: "CLAUDE.md", New: "AGENTS.md"},
 			{
 				Old: "`sandbox_permissions: \"require_escalated\"`",
 				New: "the runtime's supported sandbox escalation mechanism",

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -918,12 +918,23 @@ func TestDirNameEnumerationDoesNotReadContent(t *testing.T) {
 	}
 }
 
+func TestCodexSkillsUseCodexProjectInstructions(t *testing.T) {
+	spec, ok := lookupAgent(AgentCodex)
+	require.True(t, ok)
+	skills, err := embeddedSkillsForAgent(spec)
+	require.NoError(t, err)
+	require.NotEmpty(t, skills)
+	for _, skill := range skills {
+		assert.Contains(t, string(skill.Content), "AGENTS.md",
+			"codex skill %s should reference Codex project instructions", skill.DirName)
+	}
+}
+
 func TestDroidSkillsUseDroidAdaptations(t *testing.T) {
 	// Droid skills are derived from the Codex skills (agent-agnostic, synchronous
 	// --wait, no Claude-specific Task tool) with two Factory-specific
 	// adaptations: slash invocation (/roborev-X, matching Factory's /skill-name
-	// convention) and AGENTS.md (Factory's project-instructions file) instead of
-	// the Codex $roborev-X and CLAUDE.md forms.
+	// convention) and Factory-specific sandbox escalation wording.
 	spec, ok := lookupAgent(AgentDroid)
 	require.True(t, ok)
 	skills, err := embeddedSkillsForAgent(spec)


### PR DESCRIPTION
Codex now receives bundled RoboRev skills that defer to `AGENTS.md`, matching
the project policy file Codex loads. Previously, all ten Codex skills named
`CLAUDE.md`, so repositories with separate agent policies could steer Codex
with Claude Code-specific instructions.

The Codex skill files now keep `AGENTS.md` as their source text. The derivation
step translates that name to `CLAUDE.md` only for Claude Code, while the Droid
and Grok variants retain `AGENTS.md` without another replacement.

Coverage keeps the package concurrency restored on `main` and gives each test
package 45 minutes instead of 30. The daemon package reached the old deadline
on repeated public-runner jobs while different tests were active; the separate
daemon race shards keep their existing limits.

Closes #1111.
