### PR TITLE
feat(ui): show review types in queues and details

### DIFF
--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -673,6 +673,9 @@ func TestTUIJobCellsReviewTypeColumn(t *testing.T) {
 			assert.Equal(t, tc.want, cells[colReviewType-colRef])
 		})
 	}
+
+	panel := makeJob(2, withSynthesis("run-2", storage.PanelSummary{MembersTotal: 2}))
+	assert.Equal(t, "panel", m.jobCells(panel)[colReviewType-colRef])
 }
 
 func TestTUIJobCellsCost(t *testing.T) {
@@ -753,6 +756,30 @@ func TestTUIQueueShowsReviewTypeColumnByDefault(t *testing.T) {
 	assert.Contains(t, out, "project-conventions")
 	assert.Contains(t, out, "default")
 	assert.Contains(t, out, "def5678 [project-conventions]")
+}
+
+func TestTUIQueueKeepsIdentifyingColumnsAt80Characters(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 80
+	m.height = 30
+	m.jobs = []storage.ReviewJob{
+		makeJob(1,
+			withRef("abc1234"),
+			withBranch("feature"),
+			withRepoName("myrepo"),
+			withReviewType("security"),
+		),
+	}
+	m.selectedIdx = 0
+	m.selectedJobID = 1
+
+	out := stripTestANSI(m.renderQueueView())
+
+	assert.Contains(t, out, "Review Type")
+	assert.Contains(t, out, "abc1234")
+	assert.Contains(t, out, "feature")
+	assert.Contains(t, out, "myrepo")
+	assert.Contains(t, out, "security")
 }
 
 func TestTUIQueuePanelParentRendersPanelElapsedTime(t *testing.T) {

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -653,22 +653,23 @@ func TestTUIJobCellsReviewTypeColumn(t *testing.T) {
 
 	tests := []struct {
 		reviewType string
+		wantRef    string
 		want       string
 	}{
-		{"", "default"},
-		{"default", "default"},
-		{"general", "default"},
-		{"review", "default"},
-		{"security", "security"},
-		{"design", "design"},
-		{"project-conventions", "project-conventions"},
+		{"", "abc1234", "default"},
+		{"default", "abc1234", "default"},
+		{"general", "abc1234", "default"},
+		{"review", "abc1234", "default"},
+		{"security", "abc1234 [security]", "security"},
+		{"design", "abc1234 [design]", "design"},
+		{"project-conventions", "abc1234 [project-conventions]", "project-conventions"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.reviewType, func(t *testing.T) {
 			job := makeJob(1, withRef("abc1234"), withReviewType(tc.reviewType))
 			cells := m.jobCells(job)
-			assert.Equal(t, "abc1234", cells[0])
+			assert.Equal(t, tc.wantRef, cells[0])
 			assert.Equal(t, tc.want, cells[colReviewType-colRef])
 		})
 	}
@@ -751,7 +752,7 @@ func TestTUIQueueShowsReviewTypeColumnByDefault(t *testing.T) {
 	assert.Contains(t, out, "Review Type")
 	assert.Contains(t, out, "project-conventions")
 	assert.Contains(t, out, "default")
-	assert.NotContains(t, out, "def5678 [project-conventions]")
+	assert.Contains(t, out, "def5678 [project-conventions]")
 }
 
 func TestTUIQueuePanelParentRendersPanelElapsedTime(t *testing.T) {

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -569,16 +569,17 @@ func TestTUIJobCellsContent(t *testing.T) {
 		cells := m.jobCells(job)
 
 		assert.Contains(t, cells[0], "abc1234")
-		assert.Equal(t, "myrepo", cells[2])
-		assert.Equal(t, "test", cells[3])
-		assert.Equal(t, "Done", cells[6])
-		assert.Equal(t, "-", cells[7])
+		assert.Equal(t, "myrepo", cells[colRepo-colRef])
+		assert.Equal(t, "test", cells[colAgent-colRef])
+		assert.Equal(t, "default", cells[colReviewType-colRef])
+		assert.Equal(t, "Done", cells[colStatus-colRef])
+		assert.Equal(t, "-", cells[colPF-colRef])
 	})
 
 	t.Run("claude-code normalizes to claude", func(t *testing.T) {
 		job := makeJob(1, withAgent("claude-code"))
 		cells := m.jobCells(job)
-		assert.Equal(t, "claude", cells[3])
+		assert.Equal(t, "claude", cells[colAgent-colRef])
 	})
 
 	t.Run("verdict and handled values", func(t *testing.T) {
@@ -589,15 +590,15 @@ func TestTUIJobCellsContent(t *testing.T) {
 		job.Closed = &handled
 
 		cells := m.jobCells(job)
-		assert.Equal(t, "Done", cells[6])
-		assert.Equal(t, "P", cells[7])
-		assert.Equal(t, "yes", cells[8])
+		assert.Equal(t, "Done", cells[colStatus-colRef])
+		assert.Equal(t, "P", cells[colPF-colRef])
+		assert.Equal(t, "yes", cells[colHandled-colRef])
 	})
 
 	t.Run("panel member handled value is blank", func(t *testing.T) {
 		member := makeJob(11, withPanelMember("R", "security", 1), withClosed(new(false)))
 		cells := m.jobCells(member)
-		assert.Empty(t, cells[8])
+		assert.Empty(t, cells[colHandled-colRef])
 	})
 
 	t.Run("panel parent elapsed uses panel wall clock when members are cached", func(t *testing.T) {
@@ -647,29 +648,28 @@ func TestTUIJobCellsContent(t *testing.T) {
 	})
 }
 
-func TestTUIJobCellsReviewTypeTag(t *testing.T) {
+func TestTUIJobCellsReviewTypeColumn(t *testing.T) {
 	m := model{width: 80}
 
 	tests := []struct {
 		reviewType string
-		wantTag    bool
+		want       string
 	}{
-		{"", false},
-		{"default", false},
-		{"general", false},
-		{"review", false},
-		{"security", true},
-		{"design", true},
+		{"", "default"},
+		{"default", "default"},
+		{"general", "default"},
+		{"review", "default"},
+		{"security", "security"},
+		{"design", "design"},
+		{"project-conventions", "project-conventions"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.reviewType, func(t *testing.T) {
 			job := makeJob(1, withRef("abc1234"), withReviewType(tc.reviewType))
 			cells := m.jobCells(job)
-			ref := cells[0]
-			hasTag := strings.Contains(ref, "["+tc.reviewType+"]")
-			assert.False(t, tc.wantTag && !hasTag)
-			assert.False(t, !tc.wantTag && tc.reviewType != "" && hasTag)
+			assert.Equal(t, "abc1234", cells[0])
+			assert.Equal(t, tc.want, cells[colReviewType-colRef])
 		})
 	}
 }
@@ -733,6 +733,25 @@ func TestTUIQueueShowsCostColumnByDefault(t *testing.T) {
 		"Cost header should be visible by default")
 	assert.Contains(t, out, "~$0.42",
 		"cost value should render in the row")
+}
+
+func TestTUIQueueShowsReviewTypeColumnByDefault(t *testing.T) {
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width = 200
+	m.height = 30
+	m.jobs = []storage.ReviewJob{
+		makeJob(2, withRef("def5678"), withReviewType("project-conventions")),
+		makeJob(1, withRef("abc1234")),
+	}
+	m.selectedIdx = 0
+	m.selectedJobID = 2
+
+	out := stripTestANSI(m.renderQueueView())
+
+	assert.Contains(t, out, "Review Type")
+	assert.Contains(t, out, "project-conventions")
+	assert.Contains(t, out, "default")
+	assert.NotContains(t, out, "def5678 [project-conventions]")
 }
 
 func TestTUIQueuePanelParentRendersPanelElapsedTime(t *testing.T) {

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -232,6 +232,7 @@ const (
 	colBranch                   // Branch name
 	colRepo                     // Repository display name
 	colAgent                    // Agent name
+	colReviewType               // Review type (default, design, security, or custom)
 	colQueued                   // Enqueue timestamp
 	colElapsed                  // Elapsed time
 	colStatus                   // Job status
@@ -646,7 +647,7 @@ func (m model) renderQueueView() string {
 // so the cached map stays a superset that any pane-specific column subset
 // can safely index into.
 func (m model) queueContentWidths(rows []queueRow, visCols []int, hasAnyPanel, treeColor bool) map[int]int {
-	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
+	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Review Type", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
 	var contentWidth map[int]int
 	if m.queueColCache.gen == m.queueColGen {
 		contentWidth = m.queueColCache.contentWidths
@@ -677,7 +678,7 @@ func (m model) renderQueueTable(rows []queueRow, width, visibleRows int, visCols
 	compact := m.queueCompact()
 	hasAnyPanel := anyPanelRow(rows)
 	treeColor := queueColorEnabled()
-	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
+	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Review Type", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
 
 	visibleSelectedIdx := visibleSelectedRowIndex(rows, m.selectedJobID)
 	start, end := queueWindowStart(len(rows), visibleSelectedIdx, visibleRows)
@@ -709,6 +710,7 @@ func (m model) renderQueueTable(rows []queueRow, width, visibleRows int, visCols
 		colPF:                3,                                                    // "P/F" header = 3
 		colHandled:           max(contentWidth[colHandled], 6),                     // "Closed" header = 6
 		colAgent:             min(max(contentWidth[colAgent], 5), 12),              // "Agent" header = 5, cap at 12
+		colReviewType:        min(max(contentWidth[colReviewType], 11), 20),        // "Review Type" header = 11, cap at 20
 		colSessionID:         min(max(contentWidth[colSessionID], 7), 12),          // "Session" header = 7, cap at 12
 		colRequestedModel:    min(max(contentWidth[colRequestedModel], 9), 24),     // "Req Model" header = 9
 		colRequestedProvider: min(max(contentWidth[colRequestedProvider], 12), 24), // "Req Provider" header = 12
@@ -975,13 +977,10 @@ func (m model) renderQueueTable(rows []queueRow, width, visibleRows int, visCols
 }
 
 // jobCells returns plain text cell values for a job row.
-// Order: ref, branch, repo, agent, queued, elapsed, status, pf, handled,
-// session, requested model, requested provider, cost.
+// Order: ref, branch, repo, agent, review type, queued, elapsed, status, pf,
+// handled, session, requested model, requested provider, cost.
 func (m model) jobCells(job storage.ReviewJob) []string {
 	ref := shortJobRef(job)
-	if !config.IsDefaultReviewType(job.ReviewType) {
-		ref = ref + " [" + job.ReviewType + "]"
-	}
 
 	branch := m.getBranchForJob(job)
 
@@ -994,6 +993,7 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 	if agentName == "claude-code" {
 		agentName = "claude"
 	}
+	reviewType := displayReviewType(job.ReviewType)
 
 	enqueued := job.EnqueuedAt.Local().Format("Jan 02 15:04")
 
@@ -1025,7 +1025,16 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 
 	cost := m.jobCostCell(job)
 
-	return []string{ref, branch, repo, agentName, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider, cost}
+	return []string{ref, branch, repo, agentName, reviewType, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider, cost}
+}
+
+// displayReviewType returns the canonical label shown in the TUI. Legacy
+// aliases and older jobs with no stored value are standard reviews.
+func displayReviewType(reviewType string) string {
+	if config.IsDefaultReviewType(reviewType) {
+		return config.ReviewTypeDefault
+	}
+	return stripControlChars(reviewType)
 }
 
 func (m model) jobElapsedCell(job storage.ReviewJob) string {
@@ -1290,7 +1299,7 @@ func migrateColumnConfig(cfg *config.Config) bool {
 
 // toggleableColumns is the ordered list of columns the user can show/hide.
 // colSel and colJobID are always visible and not included here.
-var toggleableColumns = []int{colRef, colBranch, colRepo, colAgent, colQueued, colElapsed, colStatus, colPF, colHandled, colCost, colSessionID, colRequestedModel, colRequestedProvider}
+var toggleableColumns = []int{colRef, colBranch, colRepo, colAgent, colReviewType, colQueued, colElapsed, colStatus, colPF, colHandled, colCost, colSessionID, colRequestedModel, colRequestedProvider}
 
 // columnNames maps column constants to display names.
 var columnNames = map[int]string{
@@ -1298,6 +1307,7 @@ var columnNames = map[int]string{
 	colBranch:            "Branch",
 	colRepo:              "Repo",
 	colAgent:             "Agent",
+	colReviewType:        "Review Type",
 	colStatus:            "Status",
 	colQueued:            "Queued",
 	colElapsed:           "Elapsed",
@@ -1315,6 +1325,7 @@ var columnConfigNames = map[int]string{
 	colBranch:            "branch",
 	colRepo:              "repo",
 	colAgent:             "agent",
+	colReviewType:        "review_type",
 	colStatus:            "status",
 	colQueued:            "queued",
 	colElapsed:           "elapsed",

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -571,11 +571,14 @@ func (m model) renderQueueView() string {
 		// Determine which jobs to show, keeping selected item visible.
 		start, end = queueWindowStart(len(rows), visibleSelectedIdx, visibleRows)
 
-		// Determine visible columns (respects hidden columns)
+		// Determine visible columns (respects hidden columns).
 		visCols := m.visibleColumns()
 
 		// Compute per-column max content widths, using cache when data hasn't changed.
 		contentWidth := m.queueContentWidths(rows, visCols, hasAnyPanel, treeColor)
+		// At narrower widths, drop lower-priority columns before the identifying
+		// Ref, Branch, and Repo columns are reduced to unusable fragments.
+		visCols = m.queuePaneColumns(m.width, contentWidth)
 
 		tableLines := m.renderQueueTable(rows, m.width, visibleRows, visCols, contentWidth)
 		for _, line := range tableLines {
@@ -996,7 +999,7 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 	if agentName == "claude-code" {
 		agentName = "claude"
 	}
-	reviewType := displayReviewType(job.ReviewType)
+	reviewType := displayReviewType(job.ReviewType, job.PanelRole)
 
 	enqueued := job.EnqueuedAt.Local().Format("Jan 02 15:04")
 
@@ -1031,9 +1034,13 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 	return []string{ref, branch, repo, agentName, reviewType, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider, cost}
 }
 
-// displayReviewType returns the canonical label shown in the TUI. Legacy
-// aliases and older jobs with no stored value are standard reviews.
-func displayReviewType(reviewType string) string {
+// displayReviewType returns the canonical label shown in the TUI. Synthesis
+// rows identify the panel, while legacy aliases and older ordinary jobs with
+// no stored value are standard reviews.
+func displayReviewType(reviewType, panelRole string) string {
+	if panelRole == storage.PanelRoleSynthesis {
+		return "panel"
+	}
 	if config.IsDefaultReviewType(reviewType) {
 		return config.ReviewTypeDefault
 	}

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -981,6 +981,9 @@ func (m model) renderQueueTable(rows []queueRow, width, visibleRows int, visCols
 // handled, session, requested model, requested provider, cost.
 func (m model) jobCells(job storage.ReviewJob) []string {
 	ref := shortJobRef(job)
+	if !config.IsDefaultReviewType(job.ReviewType) {
+		ref = ref + " [" + job.ReviewType + "]"
+	}
 
 	branch := m.getBranchForJob(job)
 

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -115,25 +115,31 @@ func (m model) renderReviewView() string {
 		if tu := tokens.ParseJSON(review.Job.TokenUsage); tu != nil {
 			tokenSummary = tu.FormatSummary()
 		}
-		b.WriteString("\n")
-		b.WriteString(statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType)))
+		var metadata strings.Builder
+		metadata.WriteString(statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType, review.Job.PanelRole)))
 		if hasVerdict {
-			b.WriteString(" ")
+			metadata.WriteString(" ")
 			v := *review.Job.Verdict
 			if v == "P" {
-				b.WriteString(passStyle.Render("Verdict: Pass"))
+				metadata.WriteString(passStyle.Render("Verdict: Pass"))
 			} else {
-				b.WriteString(failStyle.Render("Verdict: Fail"))
+				metadata.WriteString(failStyle.Render("Verdict: Fail"))
 			}
 		}
 		if review.Closed {
-			b.WriteString(" ")
-			b.WriteString(closedStyle.Render("[CLOSED]"))
+			metadata.WriteString(" ")
+			metadata.WriteString(closedStyle.Render("[CLOSED]"))
 		}
 		if tokenSummary != "" {
-			b.WriteString(" ")
-			b.WriteString(statusStyle.Render("[" + tokenSummary + "]"))
+			metadata.WriteString(" ")
+			metadata.WriteString(statusStyle.Render("[" + tokenSummary + "]"))
 		}
+		metadataLine := metadata.String()
+		if m.width > 0 {
+			metadataLine = xansi.Truncate(metadataLine, m.width, "")
+		}
+		b.WriteString("\n")
+		b.WriteString(metadataLine)
 		b.WriteString("\x1b[K") // Clear to end of line
 		b.WriteString("\n")
 	} else {

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -108,37 +108,33 @@ func (m model) renderReviewView() string {
 		b.WriteString(statusStyle.Render(locationLine))
 		b.WriteString("\x1b[K") // Clear to end of line
 
-		// Show verdict, closed status, and token usage on next line (skip verdict for fix jobs)
+		// Show review type, verdict, closed status, and token usage on next line
+		// (skip verdict for fix jobs).
 		hasVerdict := review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob()
 		tokenSummary := ""
 		if tu := tokens.ParseJSON(review.Job.TokenUsage); tu != nil {
 			tokenSummary = tu.FormatSummary()
 		}
-		if hasVerdict || review.Closed || tokenSummary != "" {
-			b.WriteString("\n")
-			if hasVerdict {
-				v := *review.Job.Verdict
-				if v == "P" {
-					b.WriteString(passStyle.Render("Verdict: Pass"))
-				} else {
-					b.WriteString(failStyle.Render("Verdict: Fail"))
-				}
+		b.WriteString("\n")
+		b.WriteString(statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType)))
+		if hasVerdict {
+			b.WriteString(" ")
+			v := *review.Job.Verdict
+			if v == "P" {
+				b.WriteString(passStyle.Render("Verdict: Pass"))
+			} else {
+				b.WriteString(failStyle.Render("Verdict: Fail"))
 			}
-			// Show [CLOSED] with distinct color (after verdict if present)
-			if review.Closed {
-				if hasVerdict {
-					b.WriteString(" ")
-				}
-				b.WriteString(closedStyle.Render("[CLOSED]"))
-			}
-			if tokenSummary != "" {
-				if hasVerdict || review.Closed {
-					b.WriteString(" ")
-				}
-				b.WriteString(statusStyle.Render("[" + tokenSummary + "]"))
-			}
-			b.WriteString("\x1b[K") // Clear to end of line
 		}
+		if review.Closed {
+			b.WriteString(" ")
+			b.WriteString(closedStyle.Render("[CLOSED]"))
+		}
+		if tokenSummary != "" {
+			b.WriteString(" ")
+			b.WriteString(statusStyle.Render("[" + tokenSummary + "]"))
+		}
+		b.WriteString("\x1b[K") // Clear to end of line
 		b.WriteString("\n")
 	} else {
 		title = "Review"
@@ -184,12 +180,10 @@ func (m model) renderReviewView() string {
 		}
 	}
 
-	// Reserve title, location, footer status, help, and optional verdict.
+	// Reserve title, location, review metadata, footer status, and help.
 	headerHeight := titleLines + locationLines + 1 + helpLines
-	hasVerdict := review.Job != nil && review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob()
-	hasTokens := review.Job != nil && tokens.ParseJSON(review.Job.TokenUsage) != nil
-	if hasVerdict || review.Closed || hasTokens {
-		headerHeight++ // Add 1 for verdict/closed/tokens line
+	if review.Job != nil {
+		headerHeight++ // Review type/verdict/closed/tokens line
 	}
 	panelReserve := 0
 	if m.reviewFixPanelOpen {

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
 
 	"go.kenn.io/roborev/internal/storage"
@@ -441,4 +442,27 @@ func TestRenderReviewShowsReviewType(t *testing.T) {
 	out := stripANSI(m.renderReviewView())
 
 	assert.Contains(t, out, "Review type: project-conventions")
+}
+
+func TestRenderReviewMetadataFitsTerminalWidth(t *testing.T) {
+	reviewType := strings.Repeat("a", 64)
+	verdict := "P"
+	job := makeJob(42, withReviewType(reviewType))
+	job.Verdict = &verdict
+	review := makeReview(1, &job, withReviewOutput("Review output"))
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width, m.height = 80, 30
+	m.currentReview = review
+
+	out := m.renderReviewView()
+	metadataLine := ""
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(stripANSI(line), "Review type:") {
+			metadataLine = line
+			break
+		}
+	}
+	assert.NotEmpty(t, metadataLine)
+	assert.LessOrEqual(t, lipgloss.Width(strings.ReplaceAll(metadataLine, "\x1b[K", "")), m.width)
+	assert.Contains(t, stripANSI(metadataLine), reviewType)
 }

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -301,7 +301,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:                   "abc1234",
 			jobAgent:                 "codex",
 			jobVerdict:               nil,
-			wantVisibleLines:         5, // height 10 - 5 non-content = 5
+			wantVisibleLines:         4, // height 10 - 6 non-content = 4
 			checkVisibleContentCount: true,
 		},
 		{
@@ -320,7 +320,7 @@ func TestTUIVisibleLinesCalculationTable(t *testing.T) {
 			jobRef:           "abc1234",
 			jobAgent:         "codex",
 			jobVerdict:       nil,
-			wantVisibleLines: 4, // height 10 - 6 non-content = 4
+			wantVisibleLines: 3, // height 10 - 7 non-content = 3
 		},
 		{
 			name:             "narrow terminal with verdict",
@@ -429,4 +429,16 @@ func TestRenderReviewPrefixesPanelHeader(t *testing.T) {
 	assert.Contains(t, out, "2 reviewers")
 	assert.Contains(t, out, "default P")
 	assert.Contains(t, out, "Synthesized findings")
+}
+
+func TestRenderReviewShowsReviewType(t *testing.T) {
+	job := makeJob(42, withReviewType("project-conventions"))
+	review := makeReview(1, &job, withReviewOutput("Review output"))
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width, m.height = 120, 30
+	m.currentReview = review
+
+	out := stripANSI(m.renderReviewView())
+
+	assert.Contains(t, out, "Review type: project-conventions")
 }

--- a/cmd/roborev/tui/split_detail_pane.go
+++ b/cmd/roborev/tui/split_detail_pane.go
@@ -36,7 +36,7 @@ func (m model) reviewPaneHeaderLines(innerW int) []string {
 	out = append(out, xansi.Truncate(titleStyle.Render(title), innerW, ""))
 
 	verdictParts := []string{
-		statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType)),
+		statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType, review.Job.PanelRole)),
 	}
 	if review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob() {
 		if *review.Job.Verdict == "P" {
@@ -314,7 +314,7 @@ func (m model) renderJobStatusCard(job storage.ReviewJob, innerW int) []string {
 	add("Ref", shortJobRef(job))
 	add("Branch", m.getBranchForJob(job))
 	add("Agent", formatAgentLabel(job.Agent, job.Model))
-	add("Review type", displayReviewType(job.ReviewType))
+	add("Review type", displayReviewType(job.ReviewType, job.PanelRole))
 	if job.StartedAt != nil {
 		add("Elapsed", m.jobElapsedCell(job))
 	} else if !job.EnqueuedAt.IsZero() {

--- a/cmd/roborev/tui/split_detail_pane.go
+++ b/cmd/roborev/tui/split_detail_pane.go
@@ -35,7 +35,9 @@ func (m model) reviewPaneHeaderLines(innerW int) []string {
 		formatAgentLabel(review.Agent, review.Job.Model))
 	out = append(out, xansi.Truncate(titleStyle.Render(title), innerW, ""))
 
-	var verdictParts []string
+	verdictParts := []string{
+		statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType)),
+	}
 	if review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob() {
 		if *review.Job.Verdict == "P" {
 			verdictParts = append(verdictParts, passStyle.Render("Verdict: Pass"))
@@ -312,6 +314,7 @@ func (m model) renderJobStatusCard(job storage.ReviewJob, innerW int) []string {
 	add("Ref", shortJobRef(job))
 	add("Branch", m.getBranchForJob(job))
 	add("Agent", formatAgentLabel(job.Agent, job.Model))
+	add("Review type", displayReviewType(job.ReviewType))
 	if job.StartedAt != nil {
 		add("Elapsed", m.jobElapsedCell(job))
 	} else if !job.EnqueuedAt.IsZero() {

--- a/cmd/roborev/tui/split_queue_pane.go
+++ b/cmd/roborev/tui/split_queue_pane.go
@@ -16,6 +16,8 @@ func (m model) queuePaneColumns(paneW int, contentWidth map[int]int) []int {
 			return 2
 		case colRef, colBranch, colRepo:
 			return min(max(w, 4), 12)
+		case colReviewType:
+			return min(max(w, 11), 20)
 		default:
 			return w
 		}

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -74,9 +74,11 @@ func TestDetailPaneStates(t *testing.T) {
 	// Running job: status card.
 	m = splitModel(withSelection(0, 3))
 	m.currentReview = nil
-	lines = strings.Join(m.renderDetailPane(88, 25), "\n")
+	m.jobs[0].ReviewType = "security"
+	lines = stripANSI(strings.Join(m.renderDetailPane(88, 25), "\n"))
 	assert.Contains(lines, "running")
 	assert.Contains(lines, "codex")
+	assert.Contains(lines, "Review type: security")
 
 	// Done job, review not yet fetched: loading placeholder.
 	m = splitModel(withSelection(1, 2))
@@ -942,6 +944,7 @@ func TestRenderReviewPaneBody(t *testing.T) {
 	assert.Len(lines, 25)
 	joined := strings.Join(lines, "\n")
 	assert.Contains(joined, "Review #2")
+	assert.Contains(joined, "Review type: default")
 	assert.Contains(joined, "Verdict: Pass")
 	assert.Contains(joined, "first finding")
 	assert.NotContains(joined, "\x1b[K")

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -217,7 +217,8 @@ show separator lines between columns, set `column_borders = true`.
 
 The Review Type column identifies standard reviews as `default` and shows the
 configured name for specialized or custom reviews. The review detail view shows
-the same value in its metadata header.
+the same value in its metadata header. Panel synthesis rows show `panel`, while
+expanded panel members show their configured review types.
 
 The queue displays two separate status columns:
 

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -210,10 +210,14 @@ there you can reorder columns or toggle their visibility.
 Custom column order is saved to `column_order` (queue) and `task_column_order`
 (tasks) in `~/.roborev/config.toml`. Hidden columns are saved to
 `hidden_columns`, which accepts these names: `ref`, `branch`, `repo`, `agent`,
-`queued`, `elapsed`, `status`, `pf`, `closed`, `session_id`, `requested_model`,
-`requested_provider`, `cost`. When `hidden_columns` is not set, the Session, Req
-Model, and Req Provider columns are hidden by default. To show separator lines
-between columns, set `column_borders = true`.
+`review_type`, `queued`, `elapsed`, `status`, `pf`, `closed`, `session_id`,
+`requested_model`, `requested_provider`, `cost`. When `hidden_columns` is not
+set, the Session, Req Model, and Req Provider columns are hidden by default. To
+show separator lines between columns, set `column_borders = true`.
+
+The Review Type column identifies standard reviews as `default` and shows the
+configured name for specialized or custom reviews. The review detail view shows
+the same value in its metadata header.
 
 The queue displays two separate status columns:
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -53,7 +53,8 @@ toggle to narrow the list. Columns can be sorted after all matching rows are
 loaded. Panel reviews appear as a synthesis row that can be expanded to show its
 individual reviewers. The Review Type column identifies standard reviews as
 `default` and shows the configured name for specialized or custom reviews. The
-detail drawer repeats that value in its header.
+detail drawer repeats that value in its header. Panel synthesis rows show
+`panel`, while expanded panel members show their configured review types.
 
 Select a row to open its detail drawer without leaving the queue. The drawer
 provides:

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -51,7 +51,9 @@ The Reviews workspace follows the daemon's queue in real time. Use the
 repository and branch picker, status filter, ref search, and closed-review
 toggle to narrow the list. Columns can be sorted after all matching rows are
 loaded. Panel reviews appear as a synthesis row that can be expanded to show its
-individual reviewers.
+individual reviewers. The Review Type column identifies standard reviews as
+`default` and shows the configured name for specialized or custom reviews. The
+detail drawer repeats that value in its header.
 
 Select a row to open its detail drawer without leaving the queue. The drawer
 provides:

--- a/web/src/lib/components/reviews/JobRow.svelte
+++ b/web/src/lib/components/reviews/JobRow.svelte
@@ -6,6 +6,7 @@
     panelElapsedStart,
     panelStatusLabel,
   } from "../../utils/roborev-panel";
+  import { reviewTypeLabel } from "../../utils/roborev-review-type";
   import { formatRelativeTime } from "@kenn-io/kit-ui";
   import StatusBadge from "./StatusBadge.svelte";
   import VerdictBadge from "./VerdictBadge.svelte";
@@ -36,6 +37,7 @@
   }: Props = $props();
 
   const panelStatus = $derived(panelStatusLabel(job));
+  const reviewType = $derived(reviewTypeLabel(job.review_type));
 
   function formatElapsed(j: ReviewJob): string {
     const startedAt = panelElapsedStart(j, members);
@@ -126,6 +128,7 @@
     </span>
   </td>
   <td class="col-agent">{job.agent}</td>
+  <td class="col-review-type" title={reviewType}>{reviewType}</td>
   <td class="col-status">
     <StatusBadge status={job.status} />
   </td>
@@ -296,6 +299,14 @@
     max-width: 100px;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .col-review-type {
+    width: 110px;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text-secondary);
   }
 
   .col-status {

--- a/web/src/lib/components/reviews/JobRow.svelte
+++ b/web/src/lib/components/reviews/JobRow.svelte
@@ -37,7 +37,7 @@
   }: Props = $props();
 
   const panelStatus = $derived(panelStatusLabel(job));
-  const reviewType = $derived(reviewTypeLabel(job.review_type));
+  const reviewType = $derived(reviewTypeLabel(job.review_type, job.panel_role));
 
   function formatElapsed(j: ReviewJob): string {
     const startedAt = panelElapsedStart(j, members);

--- a/web/src/lib/components/reviews/JobRow.test.ts
+++ b/web/src/lib/components/reviews/JobRow.test.ts
@@ -114,6 +114,9 @@ describe("JobRow", () => {
 
       expect(screen.getByText("2 ok · 1 failed")).toBeTruthy();
       expect(screen.getByText("~$0.35")).toBeTruthy();
+      expect(document.querySelector(".col-review-type")).toHaveTextContent(
+        "panel",
+      );
       expect(
         screen.getByRole("button", { name: /expand panel/i }),
       ).toBeTruthy();

--- a/web/src/lib/components/reviews/JobRow.test.ts
+++ b/web/src/lib/components/reviews/JobRow.test.ts
@@ -44,6 +44,39 @@ describe("JobRow", () => {
     expect(screen.getByText("~$0.42")).toBeTruthy();
   });
 
+  it("renders review type separately from job type", () => {
+    const view = render(JobRow, {
+      props: {
+        job: { ...makeJob(), review_type: "project-conventions" },
+        selected: false,
+        highlighted: false,
+        onclick: () => {},
+      },
+    });
+
+    expect(view.container.querySelector(".col-review-type")).toHaveTextContent(
+      "project-conventions",
+    );
+    expect(view.container.querySelector(".col-type")).toHaveTextContent(
+      "review",
+    );
+  });
+
+  it("labels an omitted review type as default", () => {
+    const view = render(JobRow, {
+      props: {
+        job: makeJob(),
+        selected: false,
+        highlighted: false,
+        onclick: () => {},
+      },
+    });
+
+    expect(view.container.querySelector(".col-review-type")).toHaveTextContent(
+      "default",
+    );
+  });
+
   describe("panel rows", () => {
     it("renders a chevron, outcome split, and aggregate cost on a panel parent", () => {
       const parent: ReviewJob = {

--- a/web/src/lib/components/reviews/JobTable.svelte
+++ b/web/src/lib/components/reviews/JobTable.svelte
@@ -12,6 +12,7 @@
     | "status"
     | "verdict"
     | "agent"
+    | "review_type"
     | "elapsed"
     | "cost"
     | "job_type"
@@ -31,6 +32,7 @@
       sortable: false,
     },
     { key: "agent", label: "Agent", sortable: true },
+    { key: "review_type", label: "Review Type", sortable: true },
     { key: "status", label: "Status", sortable: true },
     { key: "verdict", label: "Verdict", sortable: true },
     {
@@ -45,7 +47,7 @@
     },
     {
       key: "job_type",
-      label: "Type",
+      label: "Job Type",
       sortable: true,
     },
     {

--- a/web/src/lib/components/reviews/ReviewDrawer.svelte
+++ b/web/src/lib/components/reviews/ReviewDrawer.svelte
@@ -187,7 +187,10 @@
             {/if}
           </span>
           <span class="review-type">
-            Review type: {reviewTypeLabel(selectedJob.review_type)}
+            Review type: {reviewTypeLabel(
+              selectedJob.review_type,
+              selectedJob.panel_role,
+            )}
           </span>
           {#if selectedJob.source === "auto_design"}
             <span class="review-type"> auto-design </span>

--- a/web/src/lib/components/reviews/ReviewDrawer.svelte
+++ b/web/src/lib/components/reviews/ReviewDrawer.svelte
@@ -24,6 +24,7 @@
     tokenUsageDetail,
     tokenUsageStats,
   } from "../../utils/roborev-usage";
+  import { reviewTypeLabel } from "../../utils/roborev-review-type";
 
   interface Props {
     activeTab?: "review" | "log" | "prompt";
@@ -185,11 +186,9 @@
               / {selectedJob.model}
             {/if}
           </span>
-          {#if selectedJob.review_type}
-            <span class="review-type">
-              {selectedJob.review_type}
-            </span>
-          {/if}
+          <span class="review-type">
+            Review type: {reviewTypeLabel(selectedJob.review_type)}
+          </span>
           {#if selectedJob.source === "auto_design"}
             <span class="review-type"> auto-design </span>
           {/if}

--- a/web/src/lib/components/reviews/ReviewDrawer.test.ts
+++ b/web/src/lib/components/reviews/ReviewDrawer.test.ts
@@ -24,6 +24,7 @@ const state = vi.hoisted(() => ({
   copyOutput: vi.fn(),
   jobStatus: "done",
   jobType: "review",
+  reviewType: undefined as string | undefined,
   agentic: false,
   promptPrebuilt: false,
   panelRole: undefined as string | undefined,
@@ -68,6 +69,7 @@ vi.mock("../../stores/context", () => ({
           ...job,
           status: state.jobStatus,
           job_type: state.jobType,
+          review_type: state.reviewType,
           agentic: state.agentic,
           prompt_prebuilt: state.promptPrebuilt,
           panel_role: state.panelRole,
@@ -113,6 +115,7 @@ describe("ReviewDrawer", () => {
     state.copyOutput.mockReset();
     state.jobStatus = "done";
     state.jobType = "review";
+    state.reviewType = undefined;
     state.agentic = false;
     state.promptPrebuilt = false;
     state.panelRole = undefined;
@@ -186,6 +189,18 @@ describe("ReviewDrawer", () => {
     expect(usage?.getAttribute("title")).toBe(
       "input 231,582 · cached input 189,952 · output 2,542 · peak context 47,248 · cost $0.347212",
     );
+  });
+
+  it("always labels the selected job's review type", () => {
+    const standard = render(ReviewDrawer);
+    expect(screen.getByText("Review type: default")).toBeInTheDocument();
+    standard.unmount();
+
+    state.reviewType = "project-conventions";
+    render(ReviewDrawer);
+    expect(
+      screen.getByText("Review type: project-conventions"),
+    ).toBeInTheDocument();
   });
 
   it("groups the footer actions as sibling shared buttons", () => {

--- a/web/src/lib/components/reviews/ReviewDrawer.test.ts
+++ b/web/src/lib/components/reviews/ReviewDrawer.test.ts
@@ -197,10 +197,16 @@ describe("ReviewDrawer", () => {
     standard.unmount();
 
     state.reviewType = "project-conventions";
-    render(ReviewDrawer);
+    const custom = render(ReviewDrawer);
     expect(
       screen.getByText("Review type: project-conventions"),
     ).toBeInTheDocument();
+    custom.unmount();
+
+    state.reviewType = undefined;
+    state.panelRole = "synthesis";
+    render(ReviewDrawer);
+    expect(screen.getByText("Review type: panel")).toBeInTheDocument();
   });
 
   it("groups the footer actions as sibling shared buttons", () => {

--- a/web/src/lib/stores/roborev/jobs.svelte.test.ts
+++ b/web/src/lib/stores/roborev/jobs.svelte.test.ts
@@ -337,6 +337,35 @@ describe("createJobsStore cost sorting", () => {
   });
 });
 
+describe("createJobsStore review type sorting", () => {
+  it("sorts synthesis jobs as panels", async () => {
+    const jobs: ReviewJob[] = [
+      { ...makeJob(1), review_type: "security" },
+      { ...makeJob(2), job_type: "synthesis", panel_role: "synthesis" },
+      makeJob(3),
+    ];
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: {
+          jobs,
+          has_more: false,
+          stats: { done: 3, closed: 0, open: 0 },
+        },
+        error: undefined,
+      }),
+    };
+    const store = createJobsStore({
+      client: client as never,
+      navigate: vi.fn(),
+    });
+
+    await loadJobs(store);
+    store.setSortColumn("review_type");
+
+    expect(store.getJobs().map((job) => job.id)).toEqual([3, 2, 1]);
+  });
+});
+
 describe("createJobsStore elapsed sorting", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/web/src/lib/stores/roborev/jobs.svelte.ts
+++ b/web/src/lib/stores/roborev/jobs.svelte.ts
@@ -11,6 +11,7 @@ import {
   panelCostUsd,
   panelElapsedStart,
 } from "../../utils/roborev-panel";
+import { reviewTypeLabel } from "../../utils/roborev-review-type";
 import {
   makeRoborevOwner,
   RoborevMutationError,
@@ -56,6 +57,7 @@ type SortColumn =
   | "status"
   | "verdict"
   | "agent"
+  | "review_type"
   | "elapsed"
   | "cost"
   | "job_type"
@@ -269,6 +271,8 @@ export function createJobsStore(opts: JobsStoreOptions) {
         return job.verdict ?? "";
       case "agent":
         return job.agent;
+      case "review_type":
+        return reviewTypeLabel(job.review_type);
       case "elapsed":
         return getElapsedSeconds(job);
       case "cost":

--- a/web/src/lib/stores/roborev/jobs.svelte.ts
+++ b/web/src/lib/stores/roborev/jobs.svelte.ts
@@ -272,7 +272,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       case "agent":
         return job.agent;
       case "review_type":
-        return reviewTypeLabel(job.review_type);
+        return reviewTypeLabel(job.review_type, job.panel_role);
       case "elapsed":
         return getElapsedSeconds(job);
       case "cost":

--- a/web/src/lib/utils/roborev-review-type.ts
+++ b/web/src/lib/utils/roborev-review-type.ts
@@ -1,0 +1,12 @@
+export function reviewTypeLabel(reviewType: string | undefined): string {
+  if (
+    reviewType === undefined ||
+    reviewType === "" ||
+    reviewType === "default" ||
+    reviewType === "general" ||
+    reviewType === "review"
+  ) {
+    return "default";
+  }
+  return reviewType;
+}

--- a/web/src/lib/utils/roborev-review-type.ts
+++ b/web/src/lib/utils/roborev-review-type.ts
@@ -1,4 +1,8 @@
-export function reviewTypeLabel(reviewType: string | undefined): string {
+export function reviewTypeLabel(
+  reviewType: string | undefined,
+  panelRole?: string,
+): string {
+  if (panelRole === "synthesis") return "panel";
   if (
     reviewType === undefined ||
     reviewType === "" ||


### PR DESCRIPTION
Review jobs did not consistently show whether they used the default review or a custom review type. The TUI now has a default-visible Review Type column and repeats the value in the full review view, split detail pane, and running-job status card. The existing custom-type suffix in the Ref column remains intact, and narrow queues drop lower-priority fields before crowding Ref, Branch, and Repo.

The web queue now has a sortable Review Type column, labels the existing type column as Job Type, and repeats the normalized review type in the selected-review drawer. Missing values and legacy default aliases display as `default`; custom names remain unchanged. Synthesis rows display `panel` in both interfaces, while expanded members retain their configured review types.
