### PR TITLE
fix(ci): route GitHub App auth to Enterprise API

### DIFF
--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -260,6 +260,17 @@ installation ID (either `github_app_installation_id` or entries in
 `github_app_installations`). If none are configured, the poller falls back to
 your personal `gh` auth.
 
+For GitHub Enterprise Server, set `github_api_url` to the instance's REST API
+base URL, including `/api/v3`. The poller uses this URL for GitHub App token
+exchange, repository lookup, PR polling, clone authentication, comments, and
+commit status checks. If `github_api_url` is unset, roborev checks
+`GITHUB_API_URL`, then `GH_HOST`, and finally uses public GitHub.
+
+```toml
+[ci]
+github_api_url = "https://github.example.com/api/v3"
+```
+
 #### Multiple Installations
 
 If your repos span multiple GitHub organizations or user accounts, each one has
@@ -785,6 +796,7 @@ Set under `[ci.quiet_hours]` (global config only). See
 
 | Option | Type | Description |
 |--------|------|-------------|
+| `github_api_url` | string | GitHub Enterprise REST API base URL, such as `https://github.example.com/api/v3` |
 | `github_app_id` | integer | App ID from the app settings page |
 | `github_app_private_key` | string | Path to PEM file, `${ENV_VAR}`, or inline PEM |
 | `github_app_installation_id` | integer | Installation ID (fallback for owners not in the installations map) |

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -264,7 +264,8 @@ For GitHub Enterprise Server, set `github_api_url` to the instance's REST API
 base URL, including `/api/v3`. The poller uses this URL for GitHub App token
 exchange, repository lookup, PR polling, clone authentication, comments, and
 commit status checks. If `github_api_url` is unset, roborev checks
-`GITHUB_API_URL`, then `GH_HOST`, and finally uses public GitHub.
+`GITHUB_API_URL`, then `GH_HOST`, and finally uses public GitHub. Restart the
+daemon after changing `github_api_url`.
 
 ```toml
 [ci]
@@ -796,7 +797,7 @@ Set under `[ci.quiet_hours]` (global config only). See
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `github_api_url` | string | GitHub Enterprise REST API base URL, such as `https://github.example.com/api/v3` |
+| `github_api_url` | string | GitHub Enterprise REST API base URL, such as `https://github.example.com/api/v3`; requires a daemon restart after changes |
 | `github_app_id` | integer | App ID from the app settings page |
 | `github_app_private_key` | string | Path to PEM file, `${ENV_VAR}`, or inline PEM |
 | `github_app_installation_id` | integer | Installation ID (fallback for owners not in the installations map) |

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -14,6 +14,9 @@ import (
 // GitHubAppConfig holds GitHub App authentication settings.
 // Extracted from CIConfig for cohesion; embedded so TOML keys remain flat under [ci].
 type GitHubAppConfig struct {
+	// GitHubAPIURL is the REST API base URL. GitHub Enterprise Server uses
+	// https://HOST/api/v3. Empty uses GITHUB_API_URL, GH_HOST, or public GitHub.
+	GitHubAPIURL            string `toml:"github_api_url"`
 	GitHubAppID             int64  `toml:"github_app_id"`
 	GitHubAppPrivateKey     string `toml:"github_app_private_key" sensitive:"true"` // PEM file path or inline; supports ${ENV_VAR}
 	GitHubAppInstallationID int64  `toml:"github_app_installation_id"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3251,6 +3251,18 @@ RoboRev-Dev = 222222
 	}
 }
 
+func TestLoadGlobalFrom_GitHubEnterpriseAPIURL(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+[ci]
+github_api_url = "https://github.example.com/api/v3"
+`), 0o600))
+
+	cfg, err := LoadGlobalFrom(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.example.com/api/v3", cfg.CI.GitHubAPIURL)
+}
+
 func TestGitHubAppConfigured_MultiInstall(t *testing.T) {
 	t.Run("configured with map only", func(t *testing.T) {
 		ci := CIConfig{

--- a/internal/config/keyval_test.go
+++ b/internal/config/keyval_test.go
@@ -86,6 +86,7 @@ func newComplexTestConfig() *Config {
 		CI: CIConfig{
 			PollInterval: "10m",
 			GitHubAppConfig: GitHubAppConfig{
+				GitHubAPIURL:        "https://github.example.com/api/v3",
 				GitHubAppID:         12345,
 				GitHubAppPrivateKey: "test-private-key",
 			},
@@ -106,6 +107,7 @@ func TestGetConfigValue(t *testing.T) {
 		{"sync.enabled", "true"},
 		{"sync.postgres_url", "postgres://localhost/test"},
 		{"ci.poll_interval", "10m"},
+		{"ci.github_api_url", "https://github.example.com/api/v3"},
 		{"ci.github_app_id", "12345"},
 		{"ci.github_app_private_key", "test-private-key"},
 	}
@@ -157,6 +159,14 @@ func TestSetConfigValue(t *testing.T) {
 			val:  "true",
 			verify: func(t *testing.T, c *Config) {
 				assert.True(t, c.Sync.Enabled)
+			},
+		},
+		{
+			name: "set GitHub API URL",
+			key:  "ci.github_api_url",
+			val:  "https://github.example.com/api/v3",
+			verify: func(t *testing.T, c *Config) {
+				assert.Equal(t, "https://github.example.com/api/v3", c.CI.GitHubAPIURL)
 			},
 		},
 		{
@@ -612,6 +622,7 @@ func TestIsValidKey(t *testing.T) {
 		{"sync.enabled", true},
 		{"sync.repo_names", true},
 		{"ci.github_app_id", true},
+		{"ci.github_api_url", true},
 		{"ci.github_app_private_key", true},
 		{"hooks", true},
 		{"post_commit_batch_size", true},

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -91,6 +91,7 @@ type CIPoller struct {
 	cfgGetter     ConfigGetter
 	broadcaster   Broadcaster
 	tokenProvider *GitHubAppTokenProvider
+	githubAPIURL  string // Startup value; changing hosts requires a daemon restart.
 
 	// Test seams for mocking side effects (gh/git/LLM) in unit tests.
 	// Nil means use the real implementation.
@@ -143,10 +144,16 @@ type ciRepoConfigSource = config.RepoConfigSource
 // If GitHub App is configured, it initializes a token provider so gh commands
 // authenticate as the app bot instead of the user's personal account.
 func NewCIPoller(db *storage.DB, cfgGetter ConfigGetter, broadcaster Broadcaster) *CIPoller {
+	cfg := cfgGetter.Config()
+	githubAPIURL := strings.TrimSpace(cfg.CI.GitHubAPIURL)
+	if githubAPIURL == "" {
+		githubAPIURL = strings.TrimSpace(os.Getenv("GITHUB_API_URL"))
+	}
 	p := &CIPoller{
 		db:                 db,
 		cfgGetter:          cfgGetter,
 		broadcaster:        broadcaster,
+		githubAPIURL:       githubAPIURL,
 		discordQuotaDedupe: make(map[string]time.Time),
 		discordNowFn:       time.Now,
 		nowFn:              time.Now,
@@ -182,7 +189,6 @@ func NewCIPoller(db *storage.DB, cfgGetter ConfigGetter, broadcaster Broadcaster
 	}
 	p.postPRCommentFn = p.postPRComment
 
-	cfg := cfgGetter.Config()
 	if cfg.CI.GitHubAppConfigured() {
 		pemData, err := cfg.CI.GitHubAppPrivateKeyResolved()
 		if err != nil {
@@ -1933,18 +1939,7 @@ func (p *CIPoller) githubClientForRepo(ghRepo string) (*ghpkg.Client, error) {
 }
 
 func (p *CIPoller) githubAPIBaseURL() string {
-	if p.cfgGetter != nil {
-		if configured := strings.TrimSpace(p.cfgGetter.Config().CI.GitHubAPIURL); configured != "" {
-			return configured
-		}
-	}
-	if configured := strings.TrimSpace(os.Getenv("GITHUB_API_URL")); configured != "" {
-		return configured
-	}
-	if p.tokenProvider != nil {
-		return strings.TrimSpace(p.tokenProvider.baseURL)
-	}
-	return ""
+	return p.githubAPIURL
 }
 
 // listOpenPRs uses go-github to list open PRs for a GitHub repo.

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -189,6 +189,13 @@ func NewCIPoller(db *storage.DB, cfgGetter ConfigGetter, broadcaster Broadcaster
 			log.Printf("CI poller: failed to load GitHub App private key: %v", err)
 		} else {
 			tp, err := NewGitHubAppTokenProvider(cfg.CI.GitHubAppID, pemData)
+			if err == nil {
+				var apiBaseURL string
+				apiBaseURL, err = ghpkg.GitHubAPIBaseURL(p.githubAPIBaseURL())
+				if err == nil {
+					tp.baseURL = strings.TrimRight(apiBaseURL, "/")
+				}
+			}
 			if err != nil {
 				log.Printf("CI poller: failed to create GitHub App token provider: %v", err)
 			} else {
@@ -1926,6 +1933,14 @@ func (p *CIPoller) githubClientForRepo(ghRepo string) (*ghpkg.Client, error) {
 }
 
 func (p *CIPoller) githubAPIBaseURL() string {
+	if p.cfgGetter != nil {
+		if configured := strings.TrimSpace(p.cfgGetter.Config().CI.GitHubAPIURL); configured != "" {
+			return configured
+		}
+	}
+	if configured := strings.TrimSpace(os.Getenv("GITHUB_API_URL")); configured != "" {
+		return configured
+	}
 	if p.tokenProvider != nil {
 		return strings.TrimSpace(p.tokenProvider.baseURL)
 	}

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -645,7 +646,11 @@ func TestGitHubClientForRepo_UsesEnterpriseBaseURL(t *testing.T) {
 	}
 	cfg := config.DefaultConfig()
 	cfg.CI.GitHubAppInstallationID = 111111
-	p := &CIPoller{tokenProvider: provider, cfgGetter: NewStaticConfig(cfg)}
+	p := &CIPoller{
+		tokenProvider: provider,
+		cfgGetter:     NewStaticConfig(cfg),
+		githubAPIURL:  provider.baseURL,
+	}
 
 	prs, err := p.listOpenPRs(context.Background(), "acme/api")
 	require.NoError(t, err)
@@ -684,10 +689,18 @@ func TestNewCIPoller_GitHubAppUsesConfiguredEnterpriseAPIURL(t *testing.T) {
 	cfg.CI.GitHubAppPrivateKey = pemData
 	cfg.CI.GitHubAppInstallationID = 111111
 	p := NewCIPoller(nil, NewStaticConfig(cfg), nil)
+	var reloadedRequests atomic.Int32
+	reloadedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reloadedRequests.Add(1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer reloadedSrv.Close()
+	cfg.CI.GitHubAPIURL = reloadedSrv.URL + "/api/v3"
 
 	prs, err := p.listOpenPRs(context.Background(), "acme/api")
 	require.NoError(t, err)
 	assert.Empty(t, prs)
+	assert.Zero(t, reloadedRequests.Load())
 	assert.Equal(t, []string{
 		"/api/v3/app/installations/111111/access_tokens",
 		"/api/v3/repos/acme/api/pulls",

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -601,6 +601,7 @@ func TestGitHubTokenForRepo_CaseInsensitiveOwner(t *testing.T) {
 }
 
 func TestGitHubClientForRepo_UsesEnterpriseBaseURL(t *testing.T) {
+	t.Setenv("GITHUB_API_URL", "")
 	var authHeader string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader = r.Header.Get("Authorization")

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -655,6 +655,44 @@ func TestGitHubClientForRepo_UsesEnterpriseBaseURL(t *testing.T) {
 	assert.Equal(t, []string{"skip-review"}, prs[0].Labels)
 }
 
+func TestNewCIPoller_GitHubAppUsesConfiguredEnterpriseAPIURL(t *testing.T) {
+	_, pemData := testKey(t)
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v3/app/installations/111111/access_tokens":
+			assert.Contains(t, r.Header.Get("Authorization"), "Bearer ")
+			w.WriteHeader(http.StatusCreated)
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"token":      "ghs_enterprise_token",
+				"expires_at": time.Now().Add(time.Hour),
+			}))
+		case "/api/v3/repos/acme/api/pulls":
+			assert.Equal(t, "Bearer ghs_enterprise_token", r.Header.Get("Authorization"))
+			assert.NoError(t, json.NewEncoder(w).Encode([]any{}))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.CI.GitHubAPIURL = srv.URL + "/api/v3"
+	cfg.CI.GitHubAppID = testAppID
+	cfg.CI.GitHubAppPrivateKey = pemData
+	cfg.CI.GitHubAppInstallationID = 111111
+	p := NewCIPoller(nil, NewStaticConfig(cfg), nil)
+
+	prs, err := p.listOpenPRs(context.Background(), "acme/api")
+	require.NoError(t, err)
+	assert.Empty(t, prs)
+	assert.Equal(t, []string{
+		"/api/v3/app/installations/111111/access_tokens",
+		"/api/v3/repos/acme/api/pulls",
+	}, paths)
+}
+
 func TestFormatRawBatchComment_Truncation(t *testing.T) {
 	reviews := []review.ReviewResult{
 		{Agent: "codex", ReviewType: "security", Output: strings.Repeat("x", 20000), Status: "done"},

--- a/internal/daemon/config_watcher.go
+++ b/internal/daemon/config_watcher.go
@@ -40,7 +40,8 @@ func (sc *StaticConfig) Config() *config.Config {
 // agent_quota_cooldown, allow_unsafe_agents, anthropic_api_key,
 // review_context_count.
 //
-// Settings requiring restart: server_addr, max_workers, [web], [sync] section.
+// Settings requiring restart: server_addr, max_workers, ci.github_api_url,
+// [web], [sync] section.
 // These are read at startup and the running values are preserved even if the
 // config file changes. CLI flag overrides (--addr, --workers) only apply to
 // restart-required settings, so they remain in effect for the daemon's lifetime.
@@ -263,5 +264,8 @@ func logConfigChanges(old, new *config.Config) {
 	}
 	if old.ServerAddr != new.ServerAddr {
 		log.Printf("Config change: server_addr %q -> %q (requires daemon restart to take effect)", old.ServerAddr, new.ServerAddr)
+	}
+	if old.CI.GitHubAPIURL != new.CI.GitHubAPIURL {
+		log.Printf("Config change: ci.github_api_url %q -> %q (requires daemon restart to take effect)", old.CI.GitHubAPIURL, new.CI.GitHubAPIURL)
 	}
 }

--- a/internal/daemon/githubapp.go
+++ b/internal/daemon/githubapp.go
@@ -29,8 +29,7 @@ type GitHubAppTokenProvider struct {
 	appID int64
 	key   *rsa.PrivateKey
 
-	// baseURL overrides the GitHub API base URL for testing.
-	// Empty string means https://api.github.com.
+	// baseURL is the GitHub REST API base URL. Empty uses public GitHub.
 	baseURL string
 
 	mu     sync.Mutex


### PR DESCRIPTION
GitHub Enterprise Server CI pollers now use one configured REST API base URL for GitHub App token exchange and every repository operation. Previously the installation-token exchange still called public GitHub, which returned `Integration not found` and forced the poller onto personal-token fallback even when later clients knew the Enterprise host.

Administrators can set `ci.github_api_url` to `https://HOST/api/v3`. The poller keeps that startup value for its lifetime, so changing it requires a daemon restart. `GITHUB_API_URL` and `GH_HOST` remain supported fallbacks, while installations without Enterprise configuration continue to use public GitHub.

Closes #1050.
