### PR TITLE
fix(review): reject output without a verdict

### DIFF
--- a/cmd/roborev/main_integration_test.go
+++ b/cmd/roborev/main_integration_test.go
@@ -28,7 +28,7 @@ func TestRunRefineAgentErrorRetriesWithoutApplyingChanges(t *testing.T) {
 	defer md.Close()
 
 	md.State.reviews[headSHA] = &storage.Review{
-		ID: 1, JobID: 7, Output: "**Bug found**: fail", Closed: false,
+		ID: 1, JobID: 7, Output: "**Bug found**: fail", VerdictBool: new(0), Closed: false,
 	}
 
 	// Use 2 iterations so we can verify retry behavior

--- a/cmd/roborev/main_test.go
+++ b/cmd/roborev/main_test.go
@@ -212,7 +212,7 @@ func TestRunRefineSurfacesResponseErrors(t *testing.T) {
 	md := NewMockDaemon(t, MockRefineHooks{
 		OnReview: func(w http.ResponseWriter, r *http.Request, state *mockRefineState) bool {
 			json.NewEncoder(w).Encode(storage.Review{
-				ID: 1, JobID: 1, Output: "**Bug found**: fail", Closed: false,
+				ID: 1, JobID: 1, Output: "**Bug found**: fail", VerdictBool: new(0), Closed: false,
 			})
 			return true
 		},
@@ -301,7 +301,7 @@ func TestRunRefineQuietNonTTYTimerOutput(t *testing.T) {
 	defer md.Close()
 
 	md.State.reviews[headSHA] = &storage.Review{
-		ID: 1, JobID: 42, Output: "**Bug found**: fail", Closed: false,
+		ID: 1, JobID: 42, Output: "**Bug found**: fail", VerdictBool: new(0), Closed: false,
 	}
 
 	origIsTerminal := isTerminal
@@ -326,7 +326,7 @@ func TestRunRefineStopsLiveTimerOnAgentError(t *testing.T) {
 	defer md.Close()
 
 	md.State.reviews[headSHA] = &storage.Review{
-		ID: 1, JobID: 7, Output: "**Bug found**: fail", Closed: false,
+		ID: 1, JobID: 7, Output: "**Bug found**: fail", VerdictBool: new(0), Closed: false,
 	}
 
 	origIsTerminal := isTerminal
@@ -364,7 +364,7 @@ func TestRefineLoopFindFailedReviewPath(t *testing.T) {
 			ID: 1, JobID: 1, Output: "No issues found. LGTM!",
 		}
 		client.reviews["commit2sha"] = &storage.Review{
-			ID: 2, JobID: 2, Output: "**Bug**: Missing error handling in foo.go:42",
+			ID: 2, JobID: 2, Output: "**Bug**: Missing error handling in foo.go:42", VerdictBool: new(0),
 		}
 
 		commits := []string{"commit1sha", "commit2sha", "commit3sha"}
@@ -381,7 +381,7 @@ func TestRefineLoopFindFailedReviewPath(t *testing.T) {
 		client := newMockDaemonClient()
 		// Failed but already closed
 		client.reviews["commit1sha"] = &storage.Review{
-			ID: 1, JobID: 1, Output: "**Bug**: error", Closed: true,
+			ID: 1, JobID: 1, Output: "**Bug**: error", VerdictBool: new(0), Closed: true,
 		}
 
 		commits := []string{"commit1sha"}

--- a/cmd/roborev/refine_test.go
+++ b/cmd/roborev/refine_test.go
@@ -286,8 +286,8 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 			name: "oldest first",
 			setup: func(c *mockDaemonClient) {
 				c.WithReview("oldest123", 100, "No issues found.", false).
-					WithReview("middle456", 200, "Found a bug in the code.", false).
-					WithReview("newest789", 300, "Security vulnerability detected.", false)
+					WithReview("middle456", 200, "Verdict: FAIL\n\nFound a bug in the code.", false).
+					WithReview("newest789", 300, "Verdict: FAIL\n\nSecurity vulnerability detected.", false)
 			},
 			commits:       []string{"oldest123", "middle456", "newest789"},
 			wantJobID:     200,
@@ -305,9 +305,9 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 		{
 			name: "skips closed",
 			setup: func(c *mockDaemonClient) {
-				c.WithReview("commit1", 100, "Bug found.", false).
-					WithReview("commit2", 200, "Another bug.", true).
-					WithReview("commit3", 300, "More issues.", false)
+				c.WithReview("commit1", 100, "Verdict: FAIL\n\nBug found.", false).
+					WithReview("commit2", 200, "Verdict: FAIL\n\nAnother bug.", true).
+					WithReview("commit3", 300, "Verdict: FAIL\n\nMore issues.", false)
 			},
 			commits:   []string{"commit1", "commit2", "commit3"},
 			wantJobID: 100,
@@ -315,8 +315,8 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 		{
 			name: "skips given up reviews",
 			setup: func(c *mockDaemonClient) {
-				c.WithReview("commit1", 100, "Bug found.", false).
-					WithReview("commit2", 200, "Another bug.", false).
+				c.WithReview("commit1", 100, "Verdict: FAIL\n\nBug found.", false).
+					WithReview("commit2", 200, "Verdict: FAIL\n\nAnother bug.", false).
 					WithReview("commit3", 300, "No issues found.", false)
 			},
 			commits:   []string{"commit1", "commit2", "commit3"},
@@ -326,8 +326,8 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 		{
 			name: "all skipped returns nil",
 			setup: func(c *mockDaemonClient) {
-				c.WithReview("commit1", 100, "Bug found.", false).
-					WithReview("commit2", 200, "Another.", false)
+				c.WithReview("commit1", 100, "Verdict: FAIL\n\nBug found.", false).
+					WithReview("commit2", 200, "Verdict: FAIL\n\nAnother.", false)
 			},
 			commits:   []string{"commit1", "commit2"},
 			skip:      map[int64]bool{1: true, 2: true},
@@ -363,7 +363,7 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 			name: "marks passing before failure",
 			setup: func(c *mockDaemonClient) {
 				c.WithReview("commit1", 100, "No issues found.", false).
-					WithReview("commit2", 200, "Bug found.", false)
+					WithReview("commit2", 200, "Verdict: FAIL\n\nBug found.", false)
 			},
 			commits:       []string{"commit1", "commit2"},
 			wantJobID:     200,
@@ -373,7 +373,7 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 			name: "does not mark already closed",
 			setup: func(c *mockDaemonClient) {
 				c.WithReview("commit1", 100, "No issues found.", true).
-					WithReview("commit2", 200, "Bug found.", false)
+					WithReview("commit2", 200, "Verdict: FAIL\n\nBug found.", false)
 			},
 			commits:   []string{"commit1", "commit2"},
 			wantJobID: 200,
@@ -383,9 +383,9 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 			setup: func(c *mockDaemonClient) {
 				c.WithReview("commit1", 100, "No issues found.", false).
 					WithReview("commit2", 200, "No issues.", true).
-					WithReview("commit3", 300, "Bug found.", true).
+					WithReview("commit3", 300, "Verdict: FAIL\n\nBug found.", true).
 					WithReview("commit4", 400, "No findings detected.", false).
-					WithReview("commit5", 500, "Critical error.", false)
+					WithReview("commit5", 500, "Verdict: FAIL\n\nCritical error.", false)
 			},
 			commits:       []string{"commit1", "commit2", "commit3", "commit4", "commit5"},
 			wantJobID:     500,
@@ -394,9 +394,9 @@ func TestFindFailedReviewForBranch(t *testing.T) {
 		{
 			name: "stops at first failure",
 			setup: func(c *mockDaemonClient) {
-				c.WithReview("commit1", 100, "Bug found.", false).
+				c.WithReview("commit1", 100, "Verdict: FAIL\n\nBug found.", false).
 					WithReview("commit2", 200, "No issues found.", false).
-					WithReview("commit3", 300, "Another bug.", false)
+					WithReview("commit3", 300, "Verdict: FAIL\n\nAnother bug.", false)
 			},
 			commits:   []string{"commit1", "commit2", "commit3"},
 			wantJobID: 100,

--- a/cmd/roborev/wait_test.go
+++ b/cmd/roborev/wait_test.go
@@ -210,7 +210,7 @@ func TestWait_Scenarios(t *testing.T) {
 			args: []string{"--sha", "HEAD", "--quiet"},
 			mock: mockConfig{
 				Jobs:   []storage.ReviewJob{{ID: 1, Agent: "test", Status: "done"}},
-				Review: &storage.Review{ID: 1, JobID: 1, Agent: "test", Output: "Found 2 issues:\n1. Bug\n2. Missing check"},
+				Review: &storage.Review{ID: 1, JobID: 1, Agent: "test", Output: "Found 2 issues:\n1. Bug\n2. Missing check", VerdictBool: new(0)},
 			},
 			expectErr:     true,
 			expectErrCode: 1,
@@ -312,7 +312,7 @@ func TestWaitMultipleJobIDsOneFails(t *testing.T) {
 		},
 		20: {
 			job:    storage.ReviewJob{ID: 20, Agent: "test", Status: "done"},
-			review: &storage.Review{ID: 2, JobID: 20, Agent: "test", Output: "Found 1 issue:\n1. Bug"},
+			review: &storage.Review{ID: 2, JobID: 20, Agent: "test", Output: "Found 1 issue:\n1. Bug", VerdictBool: new(0)},
 		},
 	})
 	newWaitEnv(t, handler)
@@ -333,7 +333,7 @@ func TestWaitMultipleJobIDsOneFailsReportsOutput(t *testing.T) {
 		},
 		20: {
 			job:    storage.ReviewJob{ID: 20, Agent: "test", Status: "done"},
-			review: &storage.Review{ID: 2, JobID: 20, Agent: "test", Output: "Found 1 issue:\n1. Bug"},
+			review: &storage.Review{ID: 2, JobID: 20, Agent: "test", Output: "Found 1 issue:\n1. Bug", VerdictBool: new(0)},
 		},
 	})
 	newWaitEnv(t, handler)

--- a/internal/agent/acp_agent.go
+++ b/internal/agent/acp_agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -185,8 +186,9 @@ func (a *ACPAgent) Review(ctx context.Context, repoPath, commitSHA, prompt strin
 
 // Synthesize combines supplied review outputs without wrapping the prompt as a
 // code review or advertising repository capabilities.
-func (a *ACPAgent) Synthesize(ctx context.Context, prompt string, output io.Writer) (string, error) {
-	return a.runPrompt(ctx, "", prompt, output, false)
+func (a *ACPAgent) Synthesize(ctx context.Context, prompt string, output io.Writer) (json.RawMessage, error) {
+	result, err := a.runPrompt(ctx, "", prompt, output, false)
+	return json.RawMessage(result), err
 }
 
 func (a *ACPAgent) runPrompt(

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -136,9 +137,10 @@ func SupportsSessionResume(name string) bool {
 }
 
 // SynthesisAgent is implemented by agents that can combine review outputs
-// without wrapping the prompt as a code-review request.
+// without wrapping the prompt as a code-review request. The result is one JSON
+// document matching the synthesis schema supplied in the prompt.
 type SynthesisAgent interface {
-	Synthesize(ctx context.Context, prompt string, output io.Writer) (result string, err error)
+	Synthesize(ctx context.Context, prompt string, output io.Writer) (json.RawMessage, error)
 }
 
 // Registry holds available agents

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -355,8 +355,9 @@ func (a *GrokAgent) Review(ctx context.Context, repoPath, commitSHA, prompt stri
 }
 
 // Synthesize combines review outputs without wrapping them as a code-review prompt.
-func (a *GrokAgent) Synthesize(ctx context.Context, prompt string, output io.Writer) (string, error) {
-	return a.run(ctx, "", prompt, output)
+func (a *GrokAgent) Synthesize(ctx context.Context, prompt string, output io.Writer) (json.RawMessage, error) {
+	result, err := a.run(ctx, "", prompt, output)
+	return json.RawMessage(result), err
 }
 
 func (a *GrokAgent) run(ctx context.Context, repoPath, prompt string, output io.Writer) (string, error) {

--- a/internal/agent/test_agent.go
+++ b/internal/agent/test_agent.go
@@ -44,7 +44,7 @@ type testAgentState struct {
 // NewTestAgent creates a new test agent with its own per-instance counter.
 func NewTestAgent() *TestAgent {
 	return &TestAgent{
-		Output:    "Test review output: This commit looks good. No issues found.",
+		Output:    "No issues found. Test review output: this commit looks good.",
 		Reasoning: ReasoningStandard,
 		state:     &testAgentState{},
 	}

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -3699,6 +3699,8 @@ func formatPanelReviewerStatus(member storage.BatchReviewResult) string {
 		return "skipped"
 	case reviewpkg.IsTransientFailure(result):
 		return "skipped"
+	case reviewpkg.IsNoVerdictFailure(result):
+		return "no verdict"
 	}
 	status := strings.TrimSpace(member.Status)
 	if status == "" {

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -447,7 +447,7 @@ func TestBuildSynthesisPrompt(t *testing.T) {
 
 	assertContainsAll(t, prompt, "prompt",
 		"Deduplicate findings",
-		"Organize by severity",
+		"Order findings by severity",
 		"### Review 1",
 		"### Review 2",
 		"[FAILED]",

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -5166,3 +5166,19 @@ func TestRetryAttemptPRCarriesAuthor(t *testing.T) {
 	assert.Equal(t, "alice", pr.Author.Login,
 		"direct lookup must reconstruct the PR with its author preserved")
 }
+
+func TestFormatPanelReviewerStatusLabelsNoVerdict(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("no verdict", formatPanelReviewerStatus(storage.BatchReviewResult{
+		Status: string(storage.JobStatusFailed),
+		Error:  review.NoVerdictMessage(&review.NoVerdictError{Output: "unable to read the diff"}),
+	}))
+	assert.Equal("failed", formatPanelReviewerStatus(storage.BatchReviewResult{
+		Status: string(storage.JobStatusFailed),
+		Error:  "agent: exit status 1",
+	}))
+	assert.Equal("skipped", formatPanelReviewerStatus(storage.BatchReviewResult{
+		Status: string(storage.JobStatusFailed),
+		Error:  review.QuotaErrorPrefix + "exhausted",
+	}))
+}

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -84,7 +84,11 @@ func compactVerdict(output string) storage.Verdict {
 	if !IsValidCompactOutput(output) {
 		return storage.VerdictUnknown
 	}
-	if reportsNoRemainingFindings(strings.ToLower(output)) {
+	lower := strings.ToLower(output)
+	if hasActionableCompactFinding(output, lower) {
+		return storage.VerdictFail
+	}
+	if reportsNoRemainingFindings(lower) {
 		return storage.VerdictPass
 	}
 	return storage.VerdictFail

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
 )
 
 // CompactMetadata stores source job IDs for a compact job
@@ -77,6 +78,16 @@ func IsValidCompactOutput(output string) bool {
 	}
 
 	return !reportsRemainingFindingsWithoutDetails(output)
+}
+
+func compactVerdict(output string) storage.Verdict {
+	if !IsValidCompactOutput(output) {
+		return storage.VerdictUnknown
+	}
+	if reportsNoRemainingFindings(strings.ToLower(output)) {
+		return storage.VerdictPass
+	}
+	return storage.VerdictFail
 }
 
 var (

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -97,7 +97,6 @@ func compactVerdict(output string) storage.Verdict {
 var (
 	compactFileLinePattern        = regexp.MustCompile(`(?i)\b[\w./-]+\.(go|py|js|ts|tsx|jsx|java|rb|rs|c|cc|cpp|h|hpp|cs|php|swift|kt|m|mm|sql|yaml|yml|json|toml|md):\d+\b`)
 	compactPositiveRemainingCount = regexp.MustCompile(`\b[1-9]\d* (?:verified )?findings? remains?\b`)
-	compactFindingHeadingPattern  = regexp.MustCompile(`(?im)^#{1,6}\s*(review findings|verified findings|findings)\b`)
 	compactSeverityHeadingPattern = regexp.MustCompile(`(?im)^#{1,6}\s*(?:\*\*)?\s*(critical|high|medium|low)\b`)
 )
 
@@ -183,8 +182,7 @@ func hasActionableCompactFinding(output, lower string) bool {
 		return true
 	}
 
-	return compactFindingHeadingPattern.MatchString(output) &&
-		compactSeverityHeadingPattern.MatchString(output) &&
+	return compactSeverityHeadingPattern.MatchString(output) &&
 		compactFileLinePattern.MatchString(output)
 }
 

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -61,9 +61,11 @@ func IsValidCompactOutput(output string) bool {
 		return false
 	}
 
-	// Reject placeholder output from agents that ran but produced no
-	// review content (auth errors, empty responses, etc.).
-	if output == "No review output generated" {
+	// Reject output from agents that ran but never reviewed anything: the
+	// empty-output placeholder, or a response saying the diff could not be
+	// read. Completing such a job would mark its source reviews as compacted
+	// with nothing verified.
+	if storage.IsUnreadableInput(output) {
 		return false
 	}
 

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -61,11 +61,9 @@ func IsValidCompactOutput(output string) bool {
 		return false
 	}
 
-	// Reject output from agents that ran but never reviewed anything: the
-	// empty-output placeholder, or a response saying the diff could not be
-	// read. Completing such a job would mark its source reviews as compacted
-	// with nothing verified.
-	if storage.IsUnreadableInput(output) {
+	// Output that is not a review at all (empty, or an unreadable diff)
+	// never satisfies the compact contract either.
+	if storage.ClassifyOutput(output) != storage.OutputReviewed {
 		return false
 	}
 

--- a/internal/daemon/compact.go
+++ b/internal/daemon/compact.go
@@ -91,6 +91,9 @@ func compactVerdict(output string) storage.Verdict {
 	if reportsNoRemainingFindings(lower) {
 		return storage.VerdictPass
 	}
+	if verdict := storage.ParseVerdict(output); verdict != storage.VerdictUnknown {
+		return verdict
+	}
 	return storage.VerdictFail
 }
 

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -237,6 +237,36 @@ func TestCleanCompactOutputsParseAsPassVerdicts(t *testing.T) {
 	}
 }
 
+func TestCompactVerdict(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   storage.Verdict
+	}{
+		{
+			name:   "clean",
+			output: "No findings remain.",
+			want:   storage.VerdictPass,
+		},
+		{
+			name:   "findings",
+			output: "## Critical Issues\n\n1. SQL injection in main.go:42",
+			want:   storage.VerdictFail,
+		},
+		{
+			name:   "invalid",
+			output: "Error: failed to read review output",
+			want:   storage.VerdictUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, compactVerdict(tt.output))
+		})
+	}
+}
+
 func TestCompactMetadataPath(t *testing.T) {
 	tmpDir := setupTestEnv(t)
 

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -257,9 +257,7 @@ func TestCompactVerdict(t *testing.T) {
 			name: "listed finding overrides clean statement",
 			output: `No findings remain.
 
-## Review Findings
-
-### High
+## Critical Issues
 
 1. SQL injection in main.go:42`,
 			want: storage.VerdictFail,

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -254,6 +254,17 @@ func TestCompactVerdict(t *testing.T) {
 			want:   storage.VerdictFail,
 		},
 		{
+			name: "listed finding overrides clean statement",
+			output: `No findings remain.
+
+## Review Findings
+
+### High
+
+1. SQL injection in main.go:42`,
+			want: storage.VerdictFail,
+		},
+		{
 			name:   "invalid",
 			output: "Error: failed to read review output",
 			want:   storage.VerdictUnknown,

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -249,6 +249,11 @@ func TestCompactVerdict(t *testing.T) {
 			want:   storage.VerdictPass,
 		},
 		{
+			name:   "explicit pass verdict",
+			output: "Verdict: PASS",
+			want:   storage.VerdictPass,
+		},
+		{
 			name:   "findings",
 			output: "## Critical Issues\n\n1. SQL injection in main.go:42",
 			want:   storage.VerdictFail,

--- a/internal/daemon/compact_test.go
+++ b/internal/daemon/compact_test.go
@@ -237,6 +237,13 @@ func TestCleanCompactOutputsParseAsPassVerdicts(t *testing.T) {
 	}
 }
 
+func TestIsValidCompactOutputRejectsUnreadableInput(t *testing.T) {
+	assert := assert.New(t)
+	assert.False(IsValidCompactOutput("No review output generated"))
+	assert.False(IsValidCompactOutput("I am unable to read the diff file because it is ignored by configured ignore patterns."))
+	assert.True(IsValidCompactOutput("No findings remain."))
+}
+
 func TestCompactVerdict(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -59,6 +60,7 @@ func (wp *WorkerPool) processSynthesisJob(
 		wp.completeSynthesisContext(workerID, job, synthesisResult{
 			agentName: job.Agent,
 			output:    reviewpkg.FormatAllFailedComment(results, headOf(job.GitRef)),
+			verdict:   storage.VerdictFail,
 		})
 	case 1:
 		// Exactly one member produced output — pass it through verbatim and
@@ -143,7 +145,7 @@ func (wp *WorkerPool) synthesizeSucceededResults(
 		return
 	}
 	prompt := reviewpkg.BuildSynthesisPrompt(succeeded, job.MinSeverity)
-	out, resolvedAgent, capturedSession, runErr := wp.runSynthesisAgent(
+	doc, resolvedAgent, capturedSession, runErr := wp.runSynthesisAgent(
 		ctx, workerID, job, prompt,
 	)
 	if runErr != nil {
@@ -153,7 +155,8 @@ func (wp *WorkerPool) synthesizeSucceededResults(
 	wp.completeSynthesisContext(workerID, job, synthesisResult{
 		agentName:       resolvedAgent,
 		prompt:          prompt,
-		output:          out,
+		output:          doc.Markdown,
+		verdict:         doc.Verdict,
 		capturedSession: capturedSession,
 		captureUsage:    true,
 	})
@@ -324,14 +327,14 @@ func (wp *WorkerPool) completeSynthesisLocked(
 // so the caller stores nothing.
 func (wp *WorkerPool) runSynthesisAgent(
 	ctx context.Context, workerID string, job *storage.ReviewJob, prompt string,
-) (string, string, string, error) {
+) (reviewpkg.SynthesisDocument, string, string, error) {
 	if err := wp.db.SaveJobPrompt(job.ID, prompt); err != nil {
 		log.Printf("[%s] Error saving synthesis prompt for job %d: %v", workerID, job.ID, err)
 	}
 
 	a, agentName, err := wp.configureSynthesisAgentContext(ctx, workerID, job)
 	if err != nil {
-		return "", "", "", err
+		return reviewpkg.SynthesisDocument{}, "", "", err
 	}
 
 	wp.broadcaster.Broadcast(Event{
@@ -365,13 +368,18 @@ func (wp *WorkerPool) runSynthesisAgent(
 	})
 	agentOutput = sessionWriter
 
-	var output string
-	if synthAgent, ok := a.(agent.SynthesisAgent); ok {
+	var raw json.RawMessage
+	if schemaAgent, ok := a.(agent.SchemaAgent); ok {
+		wp.markAgentInvoked(workerID, job, a)
+		raw, err = schemaAgent.ClassifyWithSchema(
+			ctx, "", "", prompt, reviewpkg.SynthesisSchema, agentOutput,
+		)
+	} else if synthAgent, ok := a.(agent.SynthesisAgent); ok {
 		// No pre-agent gate on this path; mark immediately before the agent runs
 		// to keep the "set only when an agent actually runs" invariant adjacent
 		// to the call.
 		wp.markAgentInvoked(workerID, job, a)
-		output, err = synthAgent.Synthesize(ctx, prompt, agentOutput)
+		raw, err = synthAgent.Synthesize(ctx, prompt, agentOutput)
 	} else {
 		// Verify findings against the reviewed checkout: a panel enqueued from a
 		// linked worktree must synthesize against that worktree, and CI panels
@@ -383,12 +391,14 @@ func (wp *WorkerPool) runSynthesisAgent(
 		}
 		if checkoutErr != nil {
 			wp.failOrRetryContext(ctx, workerID, job, agentName, fmt.Sprintf("prepare checkout: %v", checkoutErr))
-			return "", agentName, "", checkoutErr
+			return reviewpkg.SynthesisDocument{}, agentName, "", checkoutErr
 		}
 		// Checkout succeeded and the agent is about to run; mark it invoked only
 		// now so a checkout failure above is never miscounted as an agent run.
 		wp.markAgentInvoked(workerID, job, a)
+		var output string
 		output, err = a.Review(ctx, checkout.agentRepoPath, job.GitRef, prompt, agentOutput)
+		raw = json.RawMessage(output)
 	}
 	sessionWriter.Flush()
 	if sessionID := sessionWriter.SessionID(); sessionID != "" {
@@ -399,19 +409,24 @@ func (wp *WorkerPool) runSynthesisAgent(
 	if err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			if wp.handleUpdateInterruption(ctx, workerID, job) {
-				return "", agentName, "", errSynthesisCanceled
+				return reviewpkg.SynthesisDocument{}, agentName, "", errSynthesisCanceled
 			}
 			// A user cancellation is already terminal. Don't fail it.
 			log.Printf("[%s] Synthesis job %d canceled during agent run", workerID, job.ID)
-			return "", agentName, "", errSynthesisCanceled
+			return reviewpkg.SynthesisDocument{}, agentName, "", errSynthesisCanceled
 		}
 		wp.failOrRetryAgentContext(ctx, workerID, job, agentName, fmt.Sprintf("agent: %v", err))
-		return "", agentName, "", err
+		return reviewpkg.SynthesisDocument{}, agentName, "", err
 	}
 	if wp.handleUpdateInterruption(ctx, workerID, job) {
-		return "", agentName, "", errSynthesisCanceled
+		return reviewpkg.SynthesisDocument{}, agentName, "", errSynthesisCanceled
 	}
-	return output, agentName, sessionWriter.SessionID(), nil
+	doc, err := reviewpkg.DecodeSynthesisDocument(raw)
+	if err != nil {
+		wp.failOrRetryAgentContext(ctx, workerID, job, agentName, fmt.Sprintf("agent: %v", err))
+		return reviewpkg.SynthesisDocument{}, agentName, sessionWriter.SessionID(), err
+	}
+	return doc, agentName, sessionWriter.SessionID(), nil
 }
 
 // configureSynthesisAgent resolves and configures the read-only synthesis agent,

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -145,19 +146,24 @@ func (wp *WorkerPool) synthesizeSucceededResults(
 	}
 	prompt := reviewpkg.BuildSynthesisPrompt(succeeded, job.MinSeverity)
 	doc, resolvedAgent, capturedSession, runErr := wp.runSynthesisAgent(
-		ctx, workerID, job, prompt,
+		ctx, workerID, job, succeeded, prompt,
 	)
 	if runErr != nil {
 		// runSynthesisAgent already handled the failure/cancel.
 		return
 	}
+	structured, err := json.Marshal(doc)
+	if err != nil {
+		log.Printf("[%s] Error encoding synthesis document for job %d: %v", workerID, job.ID, err)
+	}
 	wp.completeSynthesisContext(workerID, job, synthesisResult{
-		agentName:       resolvedAgent,
-		prompt:          prompt,
-		output:          doc.Markdown,
-		verdict:         doc.Verdict,
-		capturedSession: capturedSession,
-		captureUsage:    true,
+		agentName:        resolvedAgent,
+		prompt:           prompt,
+		output:           doc.Markdown(),
+		verdict:          reviewpkg.SynthesisVerdict(doc),
+		structuredOutput: structured,
+		capturedSession:  capturedSession,
+		captureUsage:     true,
 	})
 }
 
@@ -238,12 +244,13 @@ func (wp *WorkerPool) failSynthesisWithoutReviewLocked(
 // capture must happen after the terminal write but before the completion
 // broadcast so a CI cost footer never renders an unpriced synthesis row.
 type synthesisResult struct {
-	agentName       string
-	prompt          string
-	output          string
-	verdict         storage.Verdict
-	capturedSession string
-	captureUsage    bool
+	agentName        string
+	prompt           string
+	output           string
+	verdict          storage.Verdict
+	structuredOutput json.RawMessage
+	capturedSession  string
+	captureUsage     bool
 }
 
 // completeSynthesisContext stores the synthesis review, guards against the
@@ -266,6 +273,7 @@ func (wp *WorkerPool) completeSynthesisLocked(
 		completeErr = wp.db.CompleteJobResult(
 			job.ID, agentName, prompt, storage.ReviewCompletion{
 				Output: output, Verdict: res.verdict,
+				StructuredOutput: res.structuredOutput,
 			},
 		)
 	} else {
@@ -325,7 +333,8 @@ func (wp *WorkerPool) completeSynthesisLocked(
 // after routing through failOrRetryAgent; cancel returns errSynthesisCanceled
 // so the caller stores nothing.
 func (wp *WorkerPool) runSynthesisAgent(
-	ctx context.Context, workerID string, job *storage.ReviewJob, prompt string,
+	ctx context.Context, workerID string, job *storage.ReviewJob,
+	reviews []reviewpkg.ReviewResult, prompt string,
 ) (reviewpkg.SynthesisDocument, string, string, error) {
 	if err := wp.db.SaveJobPrompt(job.ID, prompt); err != nil {
 		log.Printf("[%s] Error saving synthesis prompt for job %d: %v", workerID, job.ID, err)
@@ -367,7 +376,7 @@ func (wp *WorkerPool) runSynthesisAgent(
 	})
 	agentOutput = sessionWriter
 
-	doc, err := reviewpkg.RunSynthesisAgent(ctx, a, prompt, agentOutput, reviewpkg.SynthesisHooks{
+	doc, err := reviewpkg.RunSynthesisAgent(ctx, a, reviews, prompt, job.MinSeverity, agentOutput, reviewpkg.SynthesisHooks{
 		// Mark the agent invoked only once it is about to run, so a checkout
 		// failure below is never miscounted as an agent run.
 		BeforeInvoke: func() { wp.markAgentInvoked(workerID, job, a) },

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -182,9 +182,17 @@ func headOf(gitRef string) string {
 func filterSucceeded(results []reviewpkg.ReviewResult) []reviewpkg.ReviewResult {
 	out := make([]reviewpkg.ReviewResult, 0, len(results))
 	for _, r := range results {
-		if reviewpkg.IsSubstantiveOutput(r) {
-			out = append(out, r)
+		if !reviewpkg.IsSubstantiveOutput(r) {
+			continue
 		}
+		// A member whose stored verdict is unset and whose output carries no
+		// verdict never reviewed the code (for example an unreadable diff);
+		// it must not feed synthesis as if it had.
+		if r.Verdict == storage.VerdictUnknown &&
+			storage.ParseVerdict(r.Output) == storage.VerdictUnknown {
+			continue
+		}
+		out = append(out, r)
 	}
 	return out
 }

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -182,15 +182,9 @@ func headOf(gitRef string) string {
 func filterSucceeded(results []reviewpkg.ReviewResult) []reviewpkg.ReviewResult {
 	out := make([]reviewpkg.ReviewResult, 0, len(results))
 	for _, r := range results {
-		if !reviewpkg.IsSubstantiveOutput(r) {
-			continue
+		if reviewpkg.IsSubstantiveOutput(r) {
+			out = append(out, r)
 		}
-		// A member whose output is not a review (empty, or an unreadable
-		// diff) must not feed synthesis as if it had reviewed the code.
-		if storage.ClassifyOutput(r.Output) != storage.OutputReviewed {
-			continue
-		}
-		out = append(out, r)
 	}
 	return out
 }
@@ -423,6 +417,14 @@ func (wp *WorkerPool) runSynthesisAgent(
 			// A user cancellation is already terminal. Don't fail it.
 			log.Printf("[%s] Synthesis job %d canceled during agent run", workerID, job.ID)
 			return reviewpkg.SynthesisDocument{}, agentName, "", errSynthesisCanceled
+		}
+		if noVerdict, ok := errors.AsType[*reviewpkg.NoVerdictError](err); ok {
+			// Same code and same failover as a review that produced no
+			// verdict: retrying the same agent cannot change the outcome.
+			wp.failoverOrFailNonRetryableAgentContext(
+				ctx, workerID, job, agentName, reviewpkg.NoVerdictMessage(noVerdict),
+			)
+			return reviewpkg.SynthesisDocument{}, agentName, sessionWriter.SessionID(), err
 		}
 		wp.failOrRetryAgentContext(ctx, workerID, job, agentName, fmt.Sprintf("agent: %v", err))
 		return reviewpkg.SynthesisDocument{}, agentName, sessionWriter.SessionID(), err

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -185,11 +185,9 @@ func filterSucceeded(results []reviewpkg.ReviewResult) []reviewpkg.ReviewResult 
 		if !reviewpkg.IsSubstantiveOutput(r) {
 			continue
 		}
-		// A member whose stored verdict is unset and whose output carries no
-		// verdict never reviewed the code (for example an unreadable diff);
-		// it must not feed synthesis as if it had.
-		if r.Verdict == storage.VerdictUnknown &&
-			storage.ParseVerdict(r.Output) == storage.VerdictUnknown {
+		// A member whose output is not a review (empty, or an unreadable
+		// diff) must not feed synthesis as if it had reviewed the code.
+		if storage.ClassifyOutput(r.Output) != storage.OutputReviewed {
 			continue
 		}
 		out = append(out, r)

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -368,38 +367,23 @@ func (wp *WorkerPool) runSynthesisAgent(
 	})
 	agentOutput = sessionWriter
 
-	var raw json.RawMessage
-	if schemaAgent, ok := a.(agent.SchemaAgent); ok {
-		wp.markAgentInvoked(workerID, job, a)
-		raw, err = schemaAgent.ClassifyWithSchema(
-			ctx, "", "", prompt, reviewpkg.SynthesisSchema, agentOutput,
-		)
-	} else if synthAgent, ok := a.(agent.SynthesisAgent); ok {
-		// No pre-agent gate on this path; mark immediately before the agent runs
-		// to keep the "set only when an agent actually runs" invariant adjacent
-		// to the call.
-		wp.markAgentInvoked(workerID, job, a)
-		raw, err = synthAgent.Synthesize(ctx, prompt, agentOutput)
-	} else {
+	doc, err := reviewpkg.RunSynthesisAgent(ctx, a, prompt, agentOutput, reviewpkg.SynthesisHooks{
+		// Mark the agent invoked only once it is about to run, so a checkout
+		// failure below is never miscounted as an agent run.
+		BeforeInvoke: func() { wp.markAgentInvoked(workerID, job, a) },
 		// Verify findings against the reviewed checkout: a panel enqueued from a
 		// linked worktree must synthesize against that worktree, and CI panels
 		// get a detached checkout at the reviewed head instead of the stale
 		// shared clone.
-		checkout, checkoutErr := wp.prepareJobCheckout(ctx, workerID, job)
-		if checkout.cleanup != nil {
-			defer checkout.cleanup()
-		}
-		if checkoutErr != nil {
-			wp.failOrRetryContext(ctx, workerID, job, agentName, fmt.Sprintf("prepare checkout: %v", checkoutErr))
-			return reviewpkg.SynthesisDocument{}, agentName, "", checkoutErr
-		}
-		// Checkout succeeded and the agent is about to run; mark it invoked only
-		// now so a checkout failure above is never miscounted as an agent run.
-		wp.markAgentInvoked(workerID, job, a)
-		var output string
-		output, err = a.Review(ctx, checkout.agentRepoPath, job.GitRef, prompt, agentOutput)
-		raw = json.RawMessage(output)
-	}
+		Checkout: func() (reviewpkg.SynthesisCheckout, error) {
+			checkout, err := wp.prepareJobCheckout(ctx, workerID, job)
+			return reviewpkg.SynthesisCheckout{
+				RepoPath: checkout.agentRepoPath,
+				GitRef:   job.GitRef,
+				Cleanup:  checkout.cleanup,
+			}, err
+		},
+	})
 	sessionWriter.Flush()
 	if sessionID := sessionWriter.SessionID(); sessionID != "" {
 		if saveErr := wp.db.SaveJobSessionID(job.ID, workerID, sessionID); saveErr != nil {
@@ -407,6 +391,10 @@ func (wp *WorkerPool) runSynthesisAgent(
 		}
 	}
 	if err != nil {
+		if checkoutErr, ok := errors.AsType[*reviewpkg.SynthesisCheckoutError](err); ok {
+			wp.failOrRetryContext(ctx, workerID, job, agentName, checkoutErr.Error())
+			return reviewpkg.SynthesisDocument{}, agentName, "", checkoutErr.Err
+		}
 		if errors.Is(ctx.Err(), context.Canceled) {
 			if wp.handleUpdateInterruption(ctx, workerID, job) {
 				return reviewpkg.SynthesisDocument{}, agentName, "", errSynthesisCanceled
@@ -416,15 +404,10 @@ func (wp *WorkerPool) runSynthesisAgent(
 			return reviewpkg.SynthesisDocument{}, agentName, "", errSynthesisCanceled
 		}
 		wp.failOrRetryAgentContext(ctx, workerID, job, agentName, fmt.Sprintf("agent: %v", err))
-		return reviewpkg.SynthesisDocument{}, agentName, "", err
+		return reviewpkg.SynthesisDocument{}, agentName, sessionWriter.SessionID(), err
 	}
 	if wp.handleUpdateInterruption(ctx, workerID, job) {
 		return reviewpkg.SynthesisDocument{}, agentName, "", errSynthesisCanceled
-	}
-	doc, err := reviewpkg.DecodeSynthesisDocument(raw)
-	if err != nil {
-		wp.failOrRetryAgentContext(ctx, workerID, job, agentName, fmt.Sprintf("agent: %v", err))
-		return reviewpkg.SynthesisDocument{}, agentName, sessionWriter.SessionID(), err
 	}
 	return doc, agentName, sessionWriter.SessionID(), nil
 }

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -288,7 +288,13 @@ func (wp *WorkerPool) completeSynthesisLocked(
 		completeErr = wp.db.CompleteJob(job.ID, agentName, prompt, output)
 	}
 	if completeErr != nil {
+		// Leaving the job running would strand the panel with no comment.
+		// Route the storage failure through the ordinary retry/fail path.
 		log.Printf("[%s] Error storing synthesis review for job %d: %v", workerID, job.ID, completeErr)
+		wp.failOrRetryInnerLocked(
+			workerID, job, agentName,
+			fmt.Sprintf("store synthesis review: %v", completeErr), false, nil,
+		)
 		return
 	}
 

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -180,7 +180,13 @@ func TestRunSynthesisAgentMarksInvokedOnlyWhenAgentRuns(t *testing.T) {
 	t.Run("successful synthesis run is counted", func(t *testing.T) {
 		tc := newWorkerTestContext(t, 1)
 		const synthAgent = "synth-runs-ok"
-		registerPassingAgent(t, synthAgent)
+		agent.Register(&agent.FakeAgent{
+			NameStr: synthAgent,
+			ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
+				return `{"schema_version":1,"verdict":"pass","markdown":"No issues found."}`, nil
+			},
+		})
+		t.Cleanup(func() { agent.Unregister(synthAgent) })
 
 		_, _, synth := enqueuePanelRun(t, tc, "runs-ok-panel", []memberSpec{
 			{name: "m0", agent: "test"},
@@ -216,17 +222,17 @@ func (a *synthesisEntrypointTestAgent) Review(context.Context, string, string, s
 	return "", fmt.Errorf("review entrypoint should not be used for synthesis")
 }
 
-func (a *synthesisEntrypointTestAgent) Synthesize(ctx context.Context, prompt string, output io.Writer) (string, error) {
+func (a *synthesisEntrypointTestAgent) Synthesize(ctx context.Context, prompt string, output io.Writer) (json.RawMessage, error) {
 	a.synthPrompt = prompt
 	if output != nil && a.streamLine != "" {
 		if _, err := io.WriteString(output, a.streamLine+"\n"); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 	if a.result != "" {
-		return a.result, nil
+		return json.RawMessage(a.result), nil
 	}
-	return "## Review Findings\n\n- **Severity**: Medium\n- **Location**: file.go:1\n- **Problem**: combined\n- **Fix**: fix", nil
+	return json.RawMessage(`{"schema_version":1,"verdict":"fail","markdown":"## Review Findings\n\n- **Severity**: Medium\n- **Location**: file.go:1\n- **Problem**: combined\n- **Fix**: fix"}`), nil
 }
 
 func (a *synthesisEntrypointTestAgent) WithReasoning(agent.ReasoningLevel) agent.Agent { return a }
@@ -613,7 +619,7 @@ func TestSynthesisSingleSuccessWithMinSeverityUsesFilterPrompt(t *testing.T) {
 
 	synthAgent := &synthesisEntrypointTestAgent{
 		name:   "panel-single-minsev-synth",
-		result: "No Medium, High, or Critical findings remain.",
+		result: `{"schema_version":1,"verdict":"pass","markdown":"No Medium, High, or Critical findings remain."}`,
 	}
 	agent.Register(synthAgent)
 	t.Cleanup(func() { agent.Unregister(synthAgent.name) })
@@ -796,9 +802,39 @@ func TestSynthesisUsesSynthesisEntrypoint(t *testing.T) {
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
 	assert.Contains(review.Output, "combined")
+	require.NotNil(t, review.VerdictBool)
+	assert.Equal(0, *review.VerdictBool)
 	assert.False(synthAgent.reviewCalled, "synthesis must not use the code-review entrypoint")
 	assert.Contains(synthAgent.synthPrompt, "Review #1")
 	assert.NotContains(synthAgent.synthPrompt, "Review the code changes in commit")
+}
+
+func TestSynthesisInvalidJSONRetriesWithoutStoringReview(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
+
+	const memberAgent = "panel-invalid-json-member"
+	registerPassingAgent(t, memberAgent)
+	synthAgent := &synthesisEntrypointTestAgent{
+		name:   "panel-invalid-json-synth",
+		result: "Markdown without structured synthesis JSON.",
+	}
+	agent.Register(synthAgent)
+	t.Cleanup(func() { agent.Unregister(synthAgent.name) })
+
+	runUUID, members, synth := enqueuePanelRun(t, tc, "invalid-json-panel", []memberSpec{
+		{name: "m0", agent: memberAgent},
+		{name: "m1", agent: memberAgent},
+	})
+	setSynthesisAgent(t, tc, runUUID, synthAgent.name)
+	completeMember(t, tc, members[0].ID, memberAgent, "**Verdict**: FAIL\n\nFinding A")
+	completeMember(t, tc, members[1].ID, memberAgent, "**Verdict**: FAIL\n\nFinding B")
+
+	claimed := releaseAndClaimSynthesis(t, tc, runUUID)
+	tc.Pool.processSynthesisJob(context.Background(), testWorkerID, claimed)
+
+	tc.assertJobStatus(t, synth.ID, storage.JobStatusQueued)
+	_, err := tc.DB.GetReviewByJobID(synth.ID)
+	require.Error(t, err)
 }
 
 func TestSynthesisCapturesTokenUsage(t *testing.T) {
@@ -935,7 +971,7 @@ func TestSynthesisMultiVerifyDedupe(t *testing.T) {
 		NameStr: synthAgent,
 		ReviewFn: func(_ context.Context, _, _, prompt string, _ io.Writer) (string, error) {
 			captured = prompt
-			return "## Combined\nConsolidated finding.", nil
+			return `{"schema_version":1,"verdict":"fail","markdown":"## Combined\nConsolidated finding."}`, nil
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(synthAgent) })
@@ -1142,7 +1178,7 @@ func TestSynthesisRunsAgainstWorktree(t *testing.T) {
 		NameStr: synthAgent,
 		ReviewFn: func(_ context.Context, repoPath, _, _ string, _ io.Writer) (string, error) {
 			capturedPath = repoPath
-			return "## Combined\nDone.", nil
+			return `{"schema_version":1,"verdict":"pass","markdown":"## Combined\nDone."}`, nil
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(synthAgent) })

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 	"uuid"
@@ -1252,4 +1253,37 @@ func TestSynthesisStoresFindingWithoutLocation(t *testing.T) {
 	assert.NotContains(review.Output, "**Location:**")
 	require.NotNil(t, review.VerdictBool)
 	assert.Equal(0, *review.VerdictBool)
+}
+
+func TestSynthesisNoVerdictOutputFailsWithoutRetry(t *testing.T) {
+	assert := assert.New(t)
+	tc := newWorkerTestContext(t, 1)
+
+	const memberAgent = "panel-noverdict-member"
+	registerPassingAgent(t, memberAgent)
+
+	const synthAgent = "synth-noverdict"
+	agent.Register(&agent.FakeAgent{
+		NameStr: synthAgent,
+		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
+			return "I am unable to read the diff file because it is ignored by configured ignore patterns.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(synthAgent) })
+
+	runUUID, members, _ := enqueuePanelRun(t, tc, "noverdict-panel", []memberSpec{
+		{name: "m0", agent: memberAgent},
+		{name: "m1", agent: memberAgent},
+	})
+	setSynthesisAgent(t, tc, runUUID, synthAgent)
+	completeMember(t, tc, members[0].ID, memberAgent, "Finding A")
+	completeMember(t, tc, members[1].ID, memberAgent, "Finding B")
+
+	synth := releaseAndClaimSynthesis(t, tc, runUUID)
+	tc.Pool.processSynthesisJob(context.Background(), testWorkerID, synth)
+
+	updated := tc.assertJobStatus(t, synth.ID, storage.JobStatusFailed)
+	assert.True(strings.HasPrefix(updated.Error, reviewpkg.NoVerdictErrorPrefix), updated.Error)
+	assert.Contains(updated.Error, "unable to read the diff file")
+	assert.Equal(0, updated.RetryCount, "no-verdict synthesis output must not burn same-agent retries")
 }

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -1217,3 +1217,39 @@ func TestSynthesisRunsAgainstWorktree(t *testing.T) {
 	assert.Equal(worktreePath, capturedPath,
 		"synthesis agent must run against the reviewed worktree, not the main repo")
 }
+
+func TestSynthesisStoresFindingWithoutLocation(t *testing.T) {
+	assert := assert.New(t)
+	tc := newWorkerTestContext(t, 1)
+
+	const memberAgent = "panel-null-location-member"
+	registerPassingAgent(t, memberAgent)
+
+	const synthAgent = "synth-null-location"
+	agent.Register(&agent.FakeAgent{
+		NameStr: synthAgent,
+		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
+			return `{"schema_version":1,"summary":"One finding without a location.","findings":[{"severity":"medium","problem":"Missing test","fix":"Add one","location":null,"sources":[1]}]}`, nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(synthAgent) })
+
+	runUUID, members, _ := enqueuePanelRun(t, tc, "null-location-panel", []memberSpec{
+		{name: "m0", agent: memberAgent},
+		{name: "m1", agent: memberAgent},
+	})
+	setSynthesisAgent(t, tc, runUUID, synthAgent)
+	completeMember(t, tc, members[0].ID, memberAgent, "Finding A")
+	completeMember(t, tc, members[1].ID, memberAgent, "Finding B")
+
+	synth := releaseAndClaimSynthesis(t, tc, runUUID)
+	tc.Pool.processSynthesisJob(context.Background(), testWorkerID, synth)
+
+	tc.assertJobStatus(t, synth.ID, storage.JobStatusDone)
+	review, err := tc.DB.GetReviewByJobID(synth.ID)
+	require.NoError(t, err)
+	assert.Contains(review.Output, "Missing test")
+	assert.NotContains(review.Output, "**Location:**")
+	require.NotNil(t, review.VerdictBool)
+	assert.Equal(0, *review.VerdictBool)
+}

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -167,7 +167,7 @@ func TestRunSynthesisAgentMarksInvokedOnlyWhenAgentRuns(t *testing.T) {
 		job, err := tc.DB.GetJobByID(synth.ID)
 		require.NoError(t, err)
 
-		_, _, _, runErr := tc.Pool.runSynthesisAgent(context.Background(), testWorkerID, job, "prompt")
+		_, _, _, runErr := tc.Pool.runSynthesisAgent(context.Background(), testWorkerID, job, nil, "prompt")
 		require.Error(t, runErr, "checkout must fail before the agent runs")
 
 		failed, err := tc.DB.GetJobByID(synth.ID)
@@ -183,7 +183,7 @@ func TestRunSynthesisAgentMarksInvokedOnlyWhenAgentRuns(t *testing.T) {
 		agent.Register(&agent.FakeAgent{
 			NameStr: synthAgent,
 			ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
-				return `{"schema_version":1,"verdict":"pass","markdown":"No issues found."}`, nil
+				return `{"schema_version":1,"summary":"No issues found.","findings":[]}`, nil
 			},
 		})
 		t.Cleanup(func() { agent.Unregister(synthAgent) })
@@ -199,7 +199,7 @@ func TestRunSynthesisAgentMarksInvokedOnlyWhenAgentRuns(t *testing.T) {
 		job, err := tc.DB.GetJobByID(synth.ID)
 		require.NoError(t, err)
 
-		_, _, _, runErr := tc.Pool.runSynthesisAgent(context.Background(), testWorkerID, job, "prompt")
+		_, _, _, runErr := tc.Pool.runSynthesisAgent(context.Background(), testWorkerID, job, nil, "prompt")
 		require.NoError(t, runErr)
 		assert.True(t, jobAgentInvoked(t, tc, synth.ID),
 			"a synthesis agent that actually runs must be marked agent_invoked")
@@ -232,7 +232,7 @@ func (a *synthesisEntrypointTestAgent) Synthesize(ctx context.Context, prompt st
 	if a.result != "" {
 		return json.RawMessage(a.result), nil
 	}
-	return json.RawMessage(`{"schema_version":1,"verdict":"fail","markdown":"## Review Findings\n\n- **Severity**: Medium\n- **Location**: file.go:1\n- **Problem**: combined\n- **Fix**: fix"}`), nil
+	return json.RawMessage(`{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
 }
 
 func (a *synthesisEntrypointTestAgent) WithReasoning(agent.ReasoningLevel) agent.Agent { return a }
@@ -619,7 +619,7 @@ func TestSynthesisSingleSuccessWithMinSeverityUsesFilterPrompt(t *testing.T) {
 
 	synthAgent := &synthesisEntrypointTestAgent{
 		name:   "panel-single-minsev-synth",
-		result: `{"schema_version":1,"verdict":"pass","markdown":"No Medium, High, or Critical findings remain."}`,
+		result: `{"schema_version":1,"summary":"No Medium, High, or Critical findings remain.","findings":[]}`,
 	}
 	agent.Register(synthAgent)
 	t.Cleanup(func() { agent.Unregister(synthAgent.name) })
@@ -644,7 +644,7 @@ func TestSynthesisSingleSuccessWithMinSeverityUsesFilterPrompt(t *testing.T) {
 	tc.assertJobStatus(t, synth.ID, storage.JobStatusDone)
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
-	assert.Equal("No Medium, High, or Critical findings remain.", review.Output)
+	assert.Contains(review.Output, "No Medium, High, or Critical findings remain.")
 	assert.Equal(synthAgent.name, review.Agent)
 	assert.False(synthAgent.reviewCalled, "synthesis must use the synthesis entrypoint")
 	assert.Contains(synthAgent.synthPrompt, "### Review 1")
@@ -971,7 +971,7 @@ func TestSynthesisMultiVerifyDedupe(t *testing.T) {
 		NameStr: synthAgent,
 		ReviewFn: func(_ context.Context, _, _, prompt string, _ io.Writer) (string, error) {
 			captured = prompt
-			return `{"schema_version":1,"verdict":"fail","markdown":"## Combined\nConsolidated finding."}`, nil
+			return `{"schema_version":1,"summary":"Combined","findings":[{"severity":"high","problem":"Consolidated finding.","fix":"Fix it.","location":"alpha.go:1","sources":[1,2]}]}`, nil
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(synthAgent) })
@@ -993,7 +993,8 @@ func TestSynthesisMultiVerifyDedupe(t *testing.T) {
 	tc.assertJobStatus(t, synth.ID, storage.JobStatusDone)
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
-	assert.Equal("## Combined\nConsolidated finding.", review.Output)
+	assert.Contains(review.Output, "Consolidated finding.")
+	assert.Contains(review.Output, "**Reported by:** "+memberAgent)
 
 	assert.Contains(captured, "Do not call tools or run commands")
 	assert.Contains(captured, "Only combine the input review results according to these rules")
@@ -1178,7 +1179,7 @@ func TestSynthesisRunsAgainstWorktree(t *testing.T) {
 		NameStr: synthAgent,
 		ReviewFn: func(_ context.Context, repoPath, _, _ string, _ io.Writer) (string, error) {
 			capturedPath = repoPath
-			return `{"schema_version":1,"verdict":"pass","markdown":"## Combined\nDone."}`, nil
+			return `{"schema_version":1,"summary":"Done.","findings":[]}`, nil
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(synthAgent) })

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -138,8 +138,8 @@ func TestFilterSucceededRejectsUnreadableDiffWithoutVerdict(t *testing.T) {
 		{Status: reviewpkg.ResultDone, Output: "- High: nil deref in a.go:1"},
 	}
 
-	assert.Equal(t, results[1:], filterSucceeded(results),
-		"a done member with no stored verdict and unreadable output never reviewed the code")
+	assert.Equal(t, results[2:], filterSucceeded(results),
+		"a done member with unreadable output never reviewed the code, whatever verdict was stored")
 }
 
 // jobAgentInvoked reads the raw agent_invoked cost-eligibility marker for a job.

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -130,6 +130,18 @@ func TestFilterSucceededRejectsEmptyOutputPlaceholder(t *testing.T) {
 	assert.Equal(t, results[1:], filterSucceeded(results))
 }
 
+func TestFilterSucceededRejectsUnreadableDiffWithoutVerdict(t *testing.T) {
+	const unreadable = "I am unable to read the diff file because it is ignored by configured ignore patterns."
+	results := []reviewpkg.ReviewResult{
+		{Status: reviewpkg.ResultDone, Output: unreadable},
+		{Status: reviewpkg.ResultDone, Output: unreadable, Verdict: storage.VerdictFail},
+		{Status: reviewpkg.ResultDone, Output: "- High: nil deref in a.go:1"},
+	}
+
+	assert.Equal(t, results[1:], filterSucceeded(results),
+		"a done member with no stored verdict and unreadable output never reviewed the code")
+}
+
 // jobAgentInvoked reads the raw agent_invoked cost-eligibility marker for a job.
 func jobAgentInvoked(t *testing.T, tc *workerTestContext, jobID int64) bool {
 	t.Helper()

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1148,13 +1148,22 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// (prompt size, worktree creation) have passed.
 	wp.markAgentInvoked(workerID, job, a)
 
-	// Run the review
+	// Run the agent. Tasks, insights, and fixes are free-form work rather than
+	// reviews, so their output does not need a pass/fail verdict. Actual reviews
+	// and compact jobs keep the verdict-bearing review contract.
 	log.Printf("[%s] Running %s %sreview (job %d)...",
 		workerID, agentName, rtTag, job.ID)
-	agentReview, err := review.RunAgentReview(
-		ctx, a, reviewRepoPath, job.GitRef, reviewPrompt, job.ReviewType,
-		effectiveMinSeverity, agentOutput,
-	)
+	var agentReview review.ReviewResult
+	if job.IsTaskJob() || job.IsFixJob() {
+		agentReview.Output, err = a.Review(
+			ctx, reviewRepoPath, job.GitRef, reviewPrompt, agentOutput,
+		)
+	} else {
+		agentReview, err = review.RunAgentReview(
+			ctx, a, reviewRepoPath, job.GitRef, reviewPrompt, job.ReviewType,
+			effectiveMinSeverity, agentOutput,
+		)
+	}
 	output := agentReview.Output
 	sessionWriter.Flush()
 	if sessionID := sessionWriter.SessionID(); sessionID != "" {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1158,8 +1158,12 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		agentReview.Output, err = a.Review(
 			ctx, reviewRepoPath, job.GitRef, reviewPrompt, agentOutput,
 		)
-		if job.JobType == storage.JobTypeCompact {
-			agentReview.Verdict = compactVerdict(agentReview.Output)
+		if job.JobType == storage.JobTypeCompact && err == nil {
+			if noVerdict := review.NoVerdict(agentReview.Output); noVerdict != nil {
+				err = noVerdict
+			} else {
+				agentReview.Verdict = compactVerdict(agentReview.Output)
+			}
 		}
 	} else {
 		agentReview, err = review.RunAgentReview(

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1431,6 +1431,16 @@ func (wp *WorkerPool) failOrRetryAgentExecutionContext(
 	agentName string,
 	executionErr error,
 ) {
+	// A review that ran but produced no verdict (typically an unreadable
+	// diff) is deterministic for that agent: retrying it wastes runs. Fail
+	// over to the backup agent at once, or fail with the agent output kept
+	// in the stored error so the reason stays inspectable.
+	if noVerdict, ok := errors.AsType[*review.NoVerdictError](executionErr); ok {
+		wp.failoverOrFailNonRetryableAgentContext(
+			ctx, workerID, job, agentName, review.NoVerdictMessage(noVerdict),
+		)
+		return
+	}
 	errorMsg := fmt.Sprintf("agent: %v", executionErr)
 	classification, attached := agent.LimitClassificationFromError(executionErr)
 	if !attached {

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1148,16 +1148,19 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 	// (prompt size, worktree creation) have passed.
 	wp.markAgentInvoked(workerID, job, a)
 
-	// Run the agent. Tasks, insights, and fixes are free-form work rather than
-	// reviews, so their output does not need a pass/fail verdict. Actual reviews
-	// and compact jobs keep the verdict-bearing review contract.
+	// Run the agent. Tasks, insights, fixes, and compact jobs use their stored
+	// prompts directly. Compact derives its verdict from the compact response
+	// contract instead of the ordinary review-text parser.
 	log.Printf("[%s] Running %s %sreview (job %d)...",
 		workerID, agentName, rtTag, job.ID)
 	var agentReview review.ReviewResult
-	if job.IsTaskJob() || job.IsFixJob() {
+	if job.IsTaskJob() || job.IsFixJob() || job.JobType == storage.JobTypeCompact {
 		agentReview.Output, err = a.Review(
 			ctx, reviewRepoPath, job.GitRef, reviewPrompt, agentOutput,
 		)
+		if job.JobType == storage.JobTypeCompact {
+			agentReview.Verdict = compactVerdict(agentReview.Output)
+		}
 	} else {
 		agentReview, err = review.RunAgentReview(
 			ctx, a, reviewRepoPath, job.GitRef, reviewPrompt, job.ReviewType,
@@ -1251,7 +1254,7 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 				log.Printf("[%s] Error storing fix review: %v", workerID, err)
 				return
 			}
-		} else if job.IsReviewJob() &&
+		} else if (job.IsReviewJob() || job.JobType == storage.JobTypeCompact) &&
 			agentReview.Verdict != storage.VerdictUnknown {
 			if err := wp.db.CompleteJobResult(
 				job.ID, agentName, reviewPrompt, storage.ReviewCompletion{

--- a/internal/daemon/worker_coverage_test.go
+++ b/internal/daemon/worker_coverage_test.go
@@ -51,10 +51,12 @@ func TestReviewFileCoverageForCommittedInputs(t *testing.T) {
 
 func TestProcessJobStoresCoverageWithoutChangingPrompt(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
+	// Empty output is not a review and fails the job, so the fixture must
+	// return a real (clean) review for a row to be stored.
 	baseline := &agent.FakeAgent{
-		NameStr: "empty-review",
+		NameStr: "clean-review",
 		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
-			return "", nil
+			return "No issues found.", nil
 		},
 	}
 	agent.Register(baseline)
@@ -85,7 +87,8 @@ func TestProcessJobStoresCoverageWithoutChangingPrompt(t *testing.T) {
 	require.NotNil(t, review.FileCoverage)
 	assert.Equal(t, 1, *review.FileCoverage.Reviewed)
 	assert.Equal(t, 0, *review.FileCoverage.Excluded)
-	assert.Nil(t, review.VerdictBool)
+	require.NotNil(t, review.VerdictBool)
+	assert.Equal(t, 1, *review.VerdictBool)
 	assert.Equal(t, "medium", review.Job.MinSeverity)
 	assert.Equal(t, independent.Prompt, review.Prompt)
 

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2208,6 +2208,39 @@ func TestProcessJob_OversizedFinalPromptFailsBeforeAnyAgent(t *testing.T) {
 	assert.Contains(t, updated.Error, "prompt exceeds size limit before agent submission")
 }
 
+func TestProcessJob_TaskAllowsFreeFormOutputWithUnknownVerdict(t *testing.T) {
+	const agentName = "task-free-form"
+	agent.Register(&agent.FakeAgent{
+		NameStr: agentName,
+		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
+			return "Task completed successfully.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	tc := newWorkerTestContext(t, 1)
+	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+		RepoID: tc.Repo.ID, GitRef: "run:free-form", Agent: agentName,
+		Prompt: "Do the task", JobType: storage.JobTypeTask,
+	})
+	require.NoError(t, err)
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+
+	tc.Pool.processJob(testWorkerID, claimed)
+	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	reviewRow, err := tc.DB.GetReviewByJobID(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Task completed successfully.", reviewRow.Output)
+
+	var verdict sql.NullInt64
+	require.NoError(t, tc.DB.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID,
+	).Scan(&verdict))
+	assert.False(t, verdict.Valid)
+}
+
 func TestProcessJob_NonzeroAgentExitFailsPromptly(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("synthetic agent uses a POSIX shell")

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -369,6 +369,29 @@ func TestWorkerStoresFilteredStructuredCustomReview(t *testing.T) {
 	assert.Equal(t, 0, *stored.VerdictBool)
 }
 
+func TestWorkerDoesNotCompleteReviewWithoutVerdict(t *testing.T) {
+	const agentName = "unreadable-diff-test"
+	agent.Register(&agent.FakeAgent{
+		NameStr: agentName,
+		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
+			return "I am unable to read the diff file because it is ignored by configured ignore patterns.", nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	tc := newWorkerTestContext(t, 1)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, agentName)
+	job = tc.exhaustRetries(t, job, testWorkerID, agentName)
+
+	tc.Pool.processJob(testWorkerID, job)
+
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
+	assert.Contains(t, updated.Error, "review produced no recognizable verdict")
+	_, err := tc.DB.GetReviewByJobID(job.ID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+}
+
 func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	agentName := "structured-review-config-severity-test"

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -369,27 +369,54 @@ func TestWorkerStoresFilteredStructuredCustomReview(t *testing.T) {
 	assert.Equal(t, 0, *stored.VerdictBool)
 }
 
-func TestWorkerDoesNotCompleteReviewWithoutVerdict(t *testing.T) {
-	const agentName = "unreadable-diff-test"
+func registerUnreadableDiffAgent(t *testing.T, name string) {
+	t.Helper()
 	agent.Register(&agent.FakeAgent{
-		NameStr: agentName,
+		NameStr: name,
 		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
 			return "I am unable to read the diff file because it is ignored by configured ignore patterns.", nil
 		},
 	})
-	t.Cleanup(func() { agent.Unregister(agentName) })
+	t.Cleanup(func() { agent.Unregister(name) })
+}
+
+func TestWorkerFailsReviewWithoutVerdictKeepingOutput(t *testing.T) {
+	const agentName = "unreadable-diff-test"
+	registerUnreadableDiffAgent(t, agentName)
 
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)
 	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, agentName)
-	job = tc.exhaustRetries(t, job, testWorkerID, agentName)
 
 	tc.Pool.processJob(testWorkerID, job)
 
+	assert := assert.New(t)
 	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
-	assert.Contains(t, updated.Error, "review produced no recognizable verdict")
+	assert.True(strings.HasPrefix(updated.Error, review.NoVerdictErrorPrefix), updated.Error)
+	assert.Contains(updated.Error, "review produced no recognizable verdict")
+	assert.Contains(updated.Error, "unable to read the diff file")
+	assert.Equal(0, updated.RetryCount, "no-verdict output must not burn same-agent retries")
 	_, err := tc.DB.GetReviewByJobID(job.ID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func TestWorkerFailsOverReviewWithoutVerdictWithoutRetry(t *testing.T) {
+	const agentName = "unreadable-diff-failover-test"
+	registerUnreadableDiffAgent(t, agentName)
+
+	tc := newWorkerTestContext(t, 1)
+	cfg := config.DefaultConfig()
+	cfg.DefaultBackupAgent = "test"
+	tc.reconfigurePool(cfg)
+	sha := testutil.GetHeadSHA(t, tc.TmpDir)
+	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, agentName)
+
+	tc.Pool.processJob(testWorkerID, job)
+
+	assert := assert.New(t)
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusQueued)
+	assert.Equal("test", updated.Agent)
+	assert.Equal(0, updated.RetryCount)
 }
 
 func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -3788,6 +3788,46 @@ func TestAutoClosePassingReviews(t *testing.T) {
 	})
 }
 
+func TestProcessCompactJobStoresCompactVerdict(t *testing.T) {
+	setupTestEnv(t)
+	tc := newWorkerTestContext(t, 1)
+	const agentName = "compact-verdict-agent"
+	const output = "## Critical Issues\n\n1. SQL injection in main.go:42"
+
+	agent.Register(&agent.FakeAgent{
+		NameStr: agentName,
+		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
+			return output, nil
+		},
+	})
+	t.Cleanup(func() { agent.Unregister(agentName) })
+
+	job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+		RepoID:  tc.Repo.ID,
+		GitRef:  "main",
+		Agent:   agentName,
+		JobType: storage.JobTypeCompact,
+		Prompt:  "Consolidate the open review findings.",
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		compactMetadataPath(job.ID), []byte(`{"source_job_ids":[]}`), 0o600,
+	))
+
+	claimed, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.Equal(t, job.ID, claimed.ID)
+	tc.Pool.processJob(testWorkerID, claimed)
+
+	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+	var verdict sql.NullInt64
+	require.NoError(t, tc.DB.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID,
+	).Scan(&verdict))
+	require.True(t, verdict.Valid)
+	assert.Equal(t, int64(0), verdict.Int64)
+}
+
 func TestProcessJob_MinSeverityCascade(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -180,7 +180,7 @@ func TestRunBatch(t *testing.T) {
 			agents:      []string{"test"},
 			reviewTypes: []string{"security"},
 			registry: map[string]agent.Agent{
-				"test": &mockAgent{name: "test", output: "looks good"},
+				"test": &mockAgent{name: "test", output: "No issues found. looks good."},
 			},
 			checks: []resultCheck{
 				{agent: "test", reviewType: "security", status: ResultDone, outContain: "looks good"},
@@ -191,7 +191,7 @@ func TestRunBatch(t *testing.T) {
 			agents:      []string{"test"},
 			reviewTypes: []string{"security", "default"},
 			registry: map[string]agent.Agent{
-				"test": &mockAgent{name: "test", output: "ok"},
+				"test": &mockAgent{name: "test", output: "No issues found."},
 			},
 			checks: []resultCheck{
 				{agent: "test", reviewType: "security", status: ResultDone},
@@ -518,7 +518,7 @@ func TestRunBatch_WorkflowModelResolution(t *testing.T) {
 		AgentRegistry: map[string]agent.Agent{
 			"model-test-agent": &mockAgent{
 				name:   "model-test-agent",
-				output: "ok",
+				output: "No issues found.",
 			},
 		},
 	}
@@ -624,7 +624,7 @@ func writeFakeCodex(t *testing.T) (cmdPath string, argsPath string) {
 		"#!/bin/sh",
 		"case \"$*\" in *--help*) echo 'usage --sandbox --ignore-user-config'; exit 0;; esac",
 		fmt.Sprintf("echo \"$@\" > %q", argsPath),
-		"echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"ok\"}}'",
+		"echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"No issues found.\"}}'",
 	}, "\n") + "\n"
 
 	cmdPath = filepath.Join(dir, "codex")
@@ -643,7 +643,7 @@ func (p *promptCapture) Review(
 	_ context.Context, _, _, prompt string, _ io.Writer,
 ) (string, error) {
 	p.lastPrompt = prompt
-	return "ok", nil
+	return "No issues found.", nil
 }
 
 func (p *promptCapture) WithReasoning(
@@ -680,7 +680,7 @@ func TestRunBatch_BackupKeepsOwnModelWhenBackupModelUnset(t *testing.T) {
 			// the configured preferred agent name distinct.
 			"primary-agent": &mockAgent{
 				name:   "backup-agent",
-				output: "ok",
+				output: "No issues found.",
 			},
 		},
 	}
@@ -714,7 +714,7 @@ func TestRunBatchIgnoresMalformedRepoConfig(t *testing.T) {
 		AgentRegistry: map[string]agent.Agent{
 			"batch-agent": &mockAgent{
 				name:   "batch-agent",
-				output: "ok",
+				output: "No issues found.",
 			},
 		},
 	}

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -192,6 +192,47 @@ func UnavailableError(msg string) string {
 	return UnavailableErrorPrefix + msg
 }
 
+// NoVerdictErrorPrefix is prepended to the stored job error when a built-in
+// review ran to completion but its output carried no recognizable verdict,
+// typically because the agent could not read the diff. Consumers can select
+// these rows to separate "never reviewed" from genuine agent failures.
+const NoVerdictErrorPrefix = "no-verdict: "
+
+// noVerdictOutputLimit caps the agent output preserved in the job error so a
+// runaway response cannot bloat the row.
+const noVerdictOutputLimit = 4000
+
+// NoVerdictError reports that a built-in review completed without a
+// recognizable verdict. Output holds the agent's response so the reason can
+// be inspected after the job fails.
+type NoVerdictError struct {
+	Output string
+}
+
+func (e *NoVerdictError) Error() string {
+	return "review produced no recognizable verdict"
+}
+
+// NoVerdictMessage renders the stored job error for a NoVerdictError: the
+// prefix, the reason, and the agent output that lacked a verdict.
+func NoVerdictMessage(err *NoVerdictError) string {
+	output := strings.TrimSpace(err.Output)
+	if len(output) > noVerdictOutputLimit {
+		output = output[:noVerdictOutputLimit] + "\n[truncated]"
+	}
+	if output == "" {
+		return NoVerdictErrorPrefix + err.Error() + " (empty output)"
+	}
+	return NoVerdictErrorPrefix + err.Error() + "\n\n" + output
+}
+
+// IsNoVerdictFailure reports whether a review failed because its output had
+// no recognizable verdict.
+func IsNoVerdictFailure(r ReviewResult) bool {
+	return r.Status == ResultFailed &&
+		strings.HasPrefix(r.Error, NoVerdictErrorPrefix)
+}
+
 // TimeoutErrorPrefix is prepended to error messages when a batch job
 // is canceled because the batch exceeded its timeout and results were
 // posted with the available reviews.

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -80,8 +80,6 @@ const (
 	ResultSkipped = "skipped"
 )
 
-const noReviewOutputPlaceholder = "No review output generated"
-
 // HasSubstantiveOutput reports whether any completed review produced
 // agent-authored output. Failed and skipped results never qualify, even when
 // they carry diagnostic text, and neither does the placeholder returned by
@@ -93,9 +91,8 @@ func HasSubstantiveOutput(results []ReviewResult) bool {
 // IsSubstantiveOutput reports whether one completed review produced
 // agent-authored output.
 func IsSubstantiveOutput(result ReviewResult) bool {
-	output := strings.TrimSpace(result.Output)
 	return result.Status == ResultDone &&
-		output != "" && output != noReviewOutputPlaceholder
+		storage.ClassifyOutput(result.Output) == storage.OutputReviewed
 }
 
 // MaxCommentLen is the maximum length for a GitHub PR comment.

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -192,25 +192,38 @@ func UnavailableError(msg string) string {
 	return UnavailableErrorPrefix + msg
 }
 
-// NoVerdictErrorPrefix is prepended to the stored job error when a built-in
-// review ran to completion but its output carried no recognizable verdict,
-// typically because the agent could not read the diff. Consumers can select
-// these rows to separate "never reviewed" from genuine agent failures.
+// NoVerdictErrorPrefix is the stored job error code for an agent that ran to
+// completion without producing a review (empty output, or an unreadable
+// diff). It sits beside QuotaErrorPrefix, OutageErrorPrefix, and the others
+// so consumers can separate "never reviewed" from genuine agent failures.
 const NoVerdictErrorPrefix = "no-verdict: "
 
 // noVerdictOutputLimit caps the agent output preserved in the job error so a
 // runaway response cannot bloat the row.
 const noVerdictOutputLimit = 4000
 
-// NoVerdictError reports that a built-in review completed without a
-// recognizable verdict. Output holds the agent's response so the reason can
-// be inspected after the job fails.
+// NoVerdictError reports that an agent ran to completion but its output is
+// not a review. Kind says why and Output holds the agent's response so the
+// reason can be inspected after the job fails.
 type NoVerdictError struct {
+	Kind   storage.OutputKind
 	Output string
 }
 
 func (e *NoVerdictError) Error() string {
-	return "review produced no recognizable verdict"
+	return "review produced no recognizable verdict (" + e.Kind.String() + ")"
+}
+
+// NoVerdict is the one boundary check for fresh agent output. It returns a
+// NoVerdictError when the output is not a review, and nil otherwise. Every
+// path that runs an agent for a verdict (review, compact, synthesis) calls
+// it so the job fails with the same code and the same preserved output.
+func NoVerdict(output string) *NoVerdictError {
+	kind := storage.ClassifyOutput(output)
+	if kind == storage.OutputReviewed {
+		return nil
+	}
+	return &NoVerdictError{Kind: kind, Output: output}
 }
 
 // NoVerdictMessage renders the stored job error for a NoVerdictError: the
@@ -221,7 +234,7 @@ func NoVerdictMessage(err *NoVerdictError) string {
 		output = output[:noVerdictOutputLimit] + "\n[truncated]"
 	}
 	if output == "" {
-		return NoVerdictErrorPrefix + err.Error() + " (empty output)"
+		return NoVerdictErrorPrefix + err.Error()
 	}
 	return NoVerdictErrorPrefix + err.Error() + "\n\n" + output
 }

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -3,6 +3,7 @@ package review
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -26,8 +27,9 @@ func RunAgentReview(
 			return ReviewResult{}, err
 		}
 		result := ReviewResult{Output: output}
-		if output != "" {
-			result.Verdict = storage.ParseVerdict(output)
+		result.Verdict = storage.ParseVerdict(output)
+		if result.Verdict == storage.VerdictUnknown {
+			return result, errors.New("review produced no recognizable verdict")
 		}
 		return result, nil
 	}

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -26,10 +26,10 @@ func RunAgentReview(
 			return ReviewResult{}, err
 		}
 		result := ReviewResult{Output: output}
-		result.Verdict = storage.ParseVerdict(output)
-		if result.Verdict == storage.VerdictUnknown {
-			return result, &NoVerdictError{Output: output}
+		if noVerdict := NoVerdict(output); noVerdict != nil {
+			return result, noVerdict
 		}
+		result.Verdict = storage.ParseVerdict(output)
 		return result, nil
 	}
 

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -3,7 +3,6 @@ package review
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
@@ -29,7 +28,7 @@ func RunAgentReview(
 		result := ReviewResult{Output: output}
 		result.Verdict = storage.ParseVerdict(output)
 		if result.Verdict == storage.VerdictUnknown {
-			return result, errors.New("review produced no recognizable verdict")
+			return result, &NoVerdictError{Output: output}
 		}
 		return result, nil
 	}

--- a/internal/review/runner_test.go
+++ b/internal/review/runner_test.go
@@ -54,3 +54,16 @@ func TestRunAgentReviewDerivesBuiltInVerdict(t *testing.T) {
 	assert.Equal(t, "No issues found.", got.Output)
 	assert.Equal(t, storage.VerdictPass, got.Verdict)
 }
+
+func TestRunAgentReviewRejectsOutputWithoutVerdict(t *testing.T) {
+	const output = "I am unable to read the diff file because it is ignored by configured ignore patterns."
+	a := &mockAgent{name: "prose", output: output}
+
+	got, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "", nil,
+	)
+	require.EqualError(t, err, "review produced no recognizable verdict")
+	assert.Equal(t, output, got.Output)
+	assert.Equal(t, storage.VerdictUnknown, got.Verdict)
+}

--- a/internal/review/runner_test.go
+++ b/internal/review/runner_test.go
@@ -84,17 +84,26 @@ func TestRunAgentReviewKeepsProseFindings(t *testing.T) {
 func TestNoVerdictMessage(t *testing.T) {
 	assert := assert.New(t)
 
-	msg := NoVerdictMessage(&NoVerdictError{Output: "  I am unable to read the diff.\n"})
+	unreadable := NoVerdict("  I am unable to read the diff.\n")
+	require.NotNil(t, unreadable)
+	assert.Equal(storage.OutputUnreadableInput, unreadable.Kind)
+	msg := NoVerdictMessage(unreadable)
 	assert.True(strings.HasPrefix(msg, NoVerdictErrorPrefix))
-	assert.Contains(msg, "review produced no recognizable verdict")
+	assert.Contains(msg, "review produced no recognizable verdict (unreadable input)")
 	assert.Contains(msg, "I am unable to read the diff.")
 	assert.False(strings.HasSuffix(msg, "\n"))
 
-	assert.Contains(NoVerdictMessage(&NoVerdictError{}), "(empty output)")
+	empty := NoVerdict("No review output generated")
+	require.NotNil(t, empty)
+	assert.Equal(storage.OutputEmpty, empty.Kind)
+	assert.Contains(NoVerdictMessage(empty), "(empty output)")
 
-	long := NoVerdictMessage(&NoVerdictError{Output: strings.Repeat("x", noVerdictOutputLimit+50)})
+	assert.Nil(NoVerdict("No issues found."))
+	assert.Nil(NoVerdict("The code has issues."))
+
+	long := NoVerdictMessage(&NoVerdictError{Kind: storage.OutputUnreadableInput, Output: "cannot read the diff " + strings.Repeat("x", noVerdictOutputLimit+50)})
 	assert.Contains(long, "[truncated]")
-	assert.Less(len(long), noVerdictOutputLimit+100)
+	assert.Less(len(long), noVerdictOutputLimit+120)
 
 	assert.True(IsNoVerdictFailure(ReviewResult{Status: ResultFailed, Error: msg}))
 	assert.False(IsNoVerdictFailure(ReviewResult{Status: ResultFailed, Error: "agent: boom"}))

--- a/internal/review/runner_test.go
+++ b/internal/review/runner_test.go
@@ -63,7 +63,39 @@ func TestRunAgentReviewRejectsOutputWithoutVerdict(t *testing.T) {
 		context.Background(), a, t.TempDir(), "HEAD", "prompt",
 		"default", "", nil,
 	)
-	require.EqualError(t, err, "review produced no recognizable verdict")
+	var noVerdict *NoVerdictError
+	require.ErrorAs(t, err, &noVerdict)
+	assert.Equal(t, output, noVerdict.Output)
 	assert.Equal(t, output, got.Output)
 	assert.Equal(t, storage.VerdictUnknown, got.Verdict)
+}
+
+func TestRunAgentReviewKeepsProseFindings(t *testing.T) {
+	a := &mockAgent{name: "prose", output: "The retry loop never terminates when the queue is empty."}
+
+	got, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "", nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, storage.VerdictFail, got.Verdict)
+}
+
+func TestNoVerdictMessage(t *testing.T) {
+	assert := assert.New(t)
+
+	msg := NoVerdictMessage(&NoVerdictError{Output: "  I am unable to read the diff.\n"})
+	assert.True(strings.HasPrefix(msg, NoVerdictErrorPrefix))
+	assert.Contains(msg, "review produced no recognizable verdict")
+	assert.Contains(msg, "I am unable to read the diff.")
+	assert.False(strings.HasSuffix(msg, "\n"))
+
+	assert.Contains(NoVerdictMessage(&NoVerdictError{}), "(empty output)")
+
+	long := NoVerdictMessage(&NoVerdictError{Output: strings.Repeat("x", noVerdictOutputLimit+50)})
+	assert.Contains(long, "[truncated]")
+	assert.Less(len(long), noVerdictOutputLimit+100)
+
+	assert.True(IsNoVerdictFailure(ReviewResult{Status: ResultFailed, Error: msg}))
+	assert.False(IsNoVerdictFailure(ReviewResult{Status: ResultFailed, Error: "agent: boom"}))
 }

--- a/internal/review/synthesis.go
+++ b/internal/review/synthesis.go
@@ -1,11 +1,90 @@
 package review
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	gitrepo "go.kenn.io/kit/git/repo"
+
+	"go.kenn.io/roborev/internal/storage"
 )
+
+const SynthesisSchemaVersion = 1
+
+var SynthesisSchema = json.RawMessage(`{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "verdict", "markdown"],
+  "properties": {
+    "schema_version": {"type": "integer", "const": 1},
+    "verdict": {"type": "string", "enum": ["pass", "fail"]},
+    "markdown": {"type": "string", "minLength": 1}
+  }
+}`)
+
+// SynthesisDocument is the structured result returned by a synthesis agent.
+// Markdown remains the user-facing comment body while Verdict is carried as
+// data instead of being inferred from prose.
+type SynthesisDocument struct {
+	SchemaVersion int             `json:"schema_version"`
+	Verdict       storage.Verdict `json:"verdict"`
+	Markdown      string          `json:"markdown"`
+}
+
+// DecodeSynthesisDocument validates one complete synthesis JSON document.
+func DecodeSynthesisDocument(raw json.RawMessage) (SynthesisDocument, error) {
+	var wire struct {
+		SchemaVersion int    `json:"schema_version"`
+		Verdict       string `json:"verdict"`
+		Markdown      string `json:"markdown"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&wire); err != nil {
+		return SynthesisDocument{}, fmt.Errorf("decode synthesis output: %w", err)
+	}
+	if err := ensureJSONEOF(dec); err != nil {
+		return SynthesisDocument{}, err
+	}
+	if wire.SchemaVersion != SynthesisSchemaVersion {
+		return SynthesisDocument{}, fmt.Errorf(
+			"unsupported synthesis schema version %d", wire.SchemaVersion,
+		)
+	}
+	var verdict storage.Verdict
+	switch wire.Verdict {
+	case "pass":
+		verdict = storage.VerdictPass
+	case "fail":
+		verdict = storage.VerdictFail
+	default:
+		return SynthesisDocument{}, fmt.Errorf(
+			"invalid synthesis verdict %q", wire.Verdict,
+		)
+	}
+	if strings.TrimSpace(wire.Markdown) == "" {
+		return SynthesisDocument{}, fmt.Errorf("synthesis markdown is empty")
+	}
+	return SynthesisDocument{
+		SchemaVersion: wire.SchemaVersion,
+		Verdict:       verdict,
+		Markdown:      wire.Markdown,
+	}, nil
+}
+
+func ensureJSONEOF(dec *json.Decoder) error {
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("decode synthesis output: multiple JSON values")
+		}
+		return fmt.Errorf("decode synthesis output: %w", err)
+	}
+	return nil
+}
 
 // severityAbove maps a minimum severity to the instruction
 // describing which levels to include in synthesis output.
@@ -48,15 +127,20 @@ func BuildSynthesisPrompt(
 	var b strings.Builder
 	b.WriteString(
 		"You are combining multiple code review outputs " +
-			"into a single GitHub PR comment.\nRules:\n" +
+			"into a single GitHub PR comment.\n" +
+			"Return exactly one JSON object with this shape and no code fence: " +
+			`{"schema_version":1,"verdict":"pass|fail","markdown":"..."}` + "\n" +
+			"Put the complete GitHub-flavored Markdown comment body in `markdown`. " +
+			"Set `verdict` to `fail` if the included findings require changes, " +
+			"otherwise set it to `pass`.\nRules:\n" +
 			"- Do not call tools or run commands\n" +
 			"- Only combine the input review results according to these rules\n" +
 			"- Deduplicate findings reported by multiple reviewers\n" +
 			"- Organize by severity (Critical > High > Medium > Low)\n" +
 			"- Preserve file/line references\n" +
 			"- If all reviewers agree code is clean, say so concisely\n" +
-			"- Start with a one-line summary verdict\n" +
-			"- Use markdown formatting\n" +
+			"- Start the `markdown` value with a one-line summary\n" +
+			"- Use markdown formatting inside `markdown`\n" +
 			"- No preamble about yourself\n")
 
 	if instruction, ok := severityAbove[minSeverity]; ok {

--- a/internal/review/synthesis.go
+++ b/internal/review/synthesis.go
@@ -1,89 +1,65 @@
 package review
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 
 	gitrepo "go.kenn.io/kit/git/repo"
 
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/structuredreview"
 )
 
-const SynthesisSchemaVersion = 1
-
-var SynthesisSchema = json.RawMessage(`{
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["schema_version", "verdict", "markdown"],
-  "properties": {
-    "schema_version": {"type": "integer", "const": 1},
-    "verdict": {"type": "string", "enum": ["pass", "fail"]},
-    "markdown": {"type": "string", "minLength": 1}
-  }
-}`)
+// SynthesisSchema is the structured review schema with one addition: every
+// finding cites the input review numbers that reported it.
+var SynthesisSchema = structuredreview.SourcedSchema
 
 // SynthesisDocument is the structured result returned by a synthesis agent.
-// Markdown remains the user-facing comment body while Verdict is carried as
-// data instead of being inferred from prose.
-type SynthesisDocument struct {
-	SchemaVersion int             `json:"schema_version"`
-	Verdict       storage.Verdict `json:"verdict"`
-	Markdown      string          `json:"markdown"`
-}
+// It has the same shape as a single structured review, so the verdict derives
+// from the findings instead of being asserted separately, and each finding
+// keeps the reviews it came from.
+type SynthesisDocument = structuredreview.Document
 
-// DecodeSynthesisDocument validates one complete synthesis JSON document.
-func DecodeSynthesisDocument(raw json.RawMessage) (SynthesisDocument, error) {
-	var wire struct {
-		SchemaVersion int    `json:"schema_version"`
-		Verdict       string `json:"verdict"`
-		Markdown      string `json:"markdown"`
-	}
-	dec := json.NewDecoder(bytes.NewReader(raw))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&wire); err != nil {
+// DecodeSynthesisDocument validates one complete synthesis JSON document
+// against the input reviews it combined and attaches reviewer labels so the
+// rendered Markdown can say where each finding came from.
+func DecodeSynthesisDocument(raw json.RawMessage, reviews []ReviewResult) (SynthesisDocument, error) {
+	doc, err := structuredreview.Decode(raw)
+	if err != nil {
 		return SynthesisDocument{}, fmt.Errorf("decode synthesis output: %w", err)
 	}
-	if err := ensureJSONEOF(dec); err != nil {
-		return SynthesisDocument{}, err
+	if err := doc.RequireSources(len(reviews)); err != nil {
+		return SynthesisDocument{}, fmt.Errorf("decode synthesis output: %w", err)
 	}
-	if wire.SchemaVersion != SynthesisSchemaVersion {
-		return SynthesisDocument{}, fmt.Errorf(
-			"unsupported synthesis schema version %d", wire.SchemaVersion,
-		)
-	}
-	var verdict storage.Verdict
-	switch wire.Verdict {
-	case "pass":
-		verdict = storage.VerdictPass
-	case "fail":
-		verdict = storage.VerdictFail
-	default:
-		return SynthesisDocument{}, fmt.Errorf(
-			"invalid synthesis verdict %q", wire.Verdict,
-		)
-	}
-	if strings.TrimSpace(wire.Markdown) == "" {
-		return SynthesisDocument{}, fmt.Errorf("synthesis markdown is empty")
-	}
-	return SynthesisDocument{
-		SchemaVersion: wire.SchemaVersion,
-		Verdict:       verdict,
-		Markdown:      wire.Markdown,
-	}, nil
+	doc.SourceLabels = SynthesisSourceLabels(reviews)
+	return doc, nil
 }
 
-func ensureJSONEOF(dec *json.Decoder) error {
-	var extra any
-	if err := dec.Decode(&extra); err != io.EOF {
-		if err == nil {
-			return fmt.Errorf("decode synthesis output: multiple JSON values")
+// SynthesisVerdict is the canonical verdict of a synthesis document: pass when
+// no finding survived the severity threshold, otherwise fail.
+func SynthesisVerdict(doc SynthesisDocument) storage.Verdict {
+	return storage.VerdictFromPassed(doc.Passed())
+}
+
+// SynthesisSourceLabels names each input review for readers: the agent, plus
+// the review type when it is not the default review. The prompt itself keeps
+// reviewers anonymous as "Review N" so the synthesizer weighs findings on
+// their merits; the labels are applied only when rendering.
+func SynthesisSourceLabels(reviews []ReviewResult) []string {
+	labels := make([]string, len(reviews))
+	for i, r := range reviews {
+		label := strings.TrimSpace(r.Agent)
+		if label == "" {
+			label = fmt.Sprintf("review %d", i+1)
 		}
-		return fmt.Errorf("decode synthesis output: %w", err)
+		if rt := strings.TrimSpace(r.ReviewType); rt != "" && !config.IsDefaultReviewType(rt) {
+			label += " (" + rt + ")"
+		}
+		labels[i] = label
 	}
-	return nil
+	return labels
 }
 
 // severityAbove maps a minimum severity to the instruction
@@ -129,18 +105,17 @@ func BuildSynthesisPrompt(
 		"You are combining multiple code review outputs " +
 			"into a single GitHub PR comment.\n" +
 			"Return exactly one JSON object with this shape and no code fence: " +
-			`{"schema_version":1,"verdict":"pass|fail","markdown":"..."}` + "\n" +
-			"Put the complete GitHub-flavored Markdown comment body in `markdown`. " +
-			"Set `verdict` to `fail` if the included findings require changes, " +
-			"otherwise set it to `pass`.\nRules:\n" +
+			`{"schema_version":1,"summary":"...","findings":[{"severity":"critical|high|medium|low","problem":"...","fix":"...","location":"file:line or null","sources":[1]}]}` + "\n" +
+			"Put a one-line overall summary in `summary`. " +
+			"List every finding that requires changes in `findings`; " +
+			"return an empty `findings` array if the reviewers agree the code is clean.\n" +
+			"In `sources`, list the numbers of the reviews below (### Review N) " +
+			"that reported the finding.\nRules:\n" +
 			"- Do not call tools or run commands\n" +
 			"- Only combine the input review results according to these rules\n" +
-			"- Deduplicate findings reported by multiple reviewers\n" +
-			"- Organize by severity (Critical > High > Medium > Low)\n" +
-			"- Preserve file/line references\n" +
-			"- If all reviewers agree code is clean, say so concisely\n" +
-			"- Start the `markdown` value with a one-line summary\n" +
-			"- Use markdown formatting inside `markdown`\n" +
+			"- Deduplicate findings reported by multiple reviewers and cite every source\n" +
+			"- Order findings by severity (Critical > High > Medium > Low)\n" +
+			"- Preserve file/line references in `location`\n" +
 			"- No preamble about yourself\n")
 
 	if instruction, ok := severityAbove[minSeverity]; ok {

--- a/internal/review/synthesis_dispatch.go
+++ b/internal/review/synthesis_dispatch.go
@@ -108,6 +108,9 @@ func RunSynthesisAgent(
 	if err != nil {
 		return SynthesisDocument{}, err
 	}
+	if noVerdict := NoVerdict(string(raw)); noVerdict != nil {
+		return SynthesisDocument{}, noVerdict
+	}
 	doc, err := DecodeSynthesisDocument(raw, reviews)
 	if err != nil {
 		return SynthesisDocument{}, err

--- a/internal/review/synthesis_dispatch.go
+++ b/internal/review/synthesis_dispatch.go
@@ -38,13 +38,16 @@ type SynthesisHooks struct {
 }
 
 // RunSynthesisAgent sends the synthesis prompt to the most capable interface
-// the agent implements and decodes the schema-validated document. Schema and
-// synthesis agents run without a checkout; plain review agents run against
-// the checkout returned by hooks.Checkout.
+// the agent implements, decodes the schema-validated document against the
+// reviews it combined, and drops findings below minSeverity so the threshold
+// holds even if the agent ignored the instruction. Schema and synthesis agents
+// run without a checkout; plain review agents run against the checkout
+// returned by hooks.Checkout.
 func RunSynthesisAgent(
 	ctx context.Context,
 	a agent.Agent,
-	prompt string,
+	reviews []ReviewResult,
+	prompt, minSeverity string,
 	out io.Writer,
 	hooks SynthesisHooks,
 ) (SynthesisDocument, error) {
@@ -82,5 +85,9 @@ func RunSynthesisAgent(
 	if err != nil {
 		return SynthesisDocument{}, err
 	}
-	return DecodeSynthesisDocument(raw)
+	doc, err := DecodeSynthesisDocument(raw, reviews)
+	if err != nil {
+		return SynthesisDocument{}, err
+	}
+	return doc.Filter(minSeverity), nil
 }

--- a/internal/review/synthesis_dispatch.go
+++ b/internal/review/synthesis_dispatch.go
@@ -1,0 +1,86 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"go.kenn.io/roborev/internal/agent"
+)
+
+// SynthesisCheckout is the reviewed checkout a plain review agent needs to
+// verify findings. Cleanup may be nil.
+type SynthesisCheckout struct {
+	RepoPath string
+	GitRef   string
+	Cleanup  func()
+}
+
+// SynthesisCheckoutError wraps a failure to prepare the checkout for the
+// plain review fallback so callers can retry it as infrastructure rather than
+// as an agent error.
+type SynthesisCheckoutError struct {
+	Err error
+}
+
+func (e *SynthesisCheckoutError) Error() string { return "prepare checkout: " + e.Err.Error() }
+func (e *SynthesisCheckoutError) Unwrap() error { return e.Err }
+
+// SynthesisHooks lets a caller observe the dispatch without duplicating it.
+type SynthesisHooks struct {
+	// BeforeInvoke runs once, immediately before the agent is called. The
+	// daemon uses it to record that an agent actually ran, so it must fire
+	// after any checkout preparation that could still fail.
+	BeforeInvoke func()
+	// Checkout resolves where a plain review agent runs. It is called only
+	// when the agent implements neither SchemaAgent nor SynthesisAgent.
+	Checkout func() (SynthesisCheckout, error)
+}
+
+// RunSynthesisAgent sends the synthesis prompt to the most capable interface
+// the agent implements and decodes the schema-validated document. Schema and
+// synthesis agents run without a checkout; plain review agents run against
+// the checkout returned by hooks.Checkout.
+func RunSynthesisAgent(
+	ctx context.Context,
+	a agent.Agent,
+	prompt string,
+	out io.Writer,
+	hooks SynthesisHooks,
+) (SynthesisDocument, error) {
+	invoke := func() {
+		if hooks.BeforeInvoke != nil {
+			hooks.BeforeInvoke()
+		}
+	}
+
+	var raw json.RawMessage
+	var err error
+	switch sa := a.(type) {
+	case agent.SchemaAgent:
+		invoke()
+		raw, err = sa.ClassifyWithSchema(ctx, "", "", prompt, SynthesisSchema, out)
+	case agent.SynthesisAgent:
+		invoke()
+		raw, err = sa.Synthesize(ctx, prompt, out)
+	default:
+		var checkout SynthesisCheckout
+		if hooks.Checkout != nil {
+			checkout, err = hooks.Checkout()
+			if checkout.Cleanup != nil {
+				defer checkout.Cleanup()
+			}
+			if err != nil {
+				return SynthesisDocument{}, &SynthesisCheckoutError{Err: err}
+			}
+		}
+		invoke()
+		var output string
+		output, err = a.Review(ctx, checkout.RepoPath, checkout.GitRef, prompt, out)
+		raw = json.RawMessage(output)
+	}
+	if err != nil {
+		return SynthesisDocument{}, err
+	}
+	return DecodeSynthesisDocument(raw)
+}

--- a/internal/review/synthesis_dispatch.go
+++ b/internal/review/synthesis_dispatch.go
@@ -40,9 +40,9 @@ type SynthesisHooks struct {
 // RunSynthesisAgent sends the synthesis prompt to the most capable interface
 // the agent implements, decodes the schema-validated document against the
 // reviews it combined, and drops findings below minSeverity so the threshold
-// holds even if the agent ignored the instruction. Schema and synthesis agents
-// run without a checkout; plain review agents run against the checkout
-// returned by hooks.Checkout.
+// holds even if the agent ignored the instruction. Classifier and synthesis
+// agents run without a checkout; schema-constrained and plain review agents
+// run against the checkout returned by hooks.Checkout.
 func RunSynthesisAgent(
 	ctx context.Context,
 	a agent.Agent,
@@ -57,25 +57,48 @@ func RunSynthesisAgent(
 		}
 	}
 
+	resolveCheckout := func() (SynthesisCheckout, error) {
+		if hooks.Checkout == nil {
+			return SynthesisCheckout{}, nil
+		}
+		checkout, err := hooks.Checkout()
+		if err != nil {
+			if checkout.Cleanup != nil {
+				checkout.Cleanup()
+			}
+			return SynthesisCheckout{}, &SynthesisCheckoutError{Err: err}
+		}
+		return checkout, nil
+	}
+
 	var raw json.RawMessage
 	var err error
 	switch sa := a.(type) {
 	case agent.SchemaAgent:
 		invoke()
 		raw, err = sa.ClassifyWithSchema(ctx, "", "", prompt, SynthesisSchema, out)
+	case agent.StructuredReviewAgent:
+		// Codex and similar agents constrain review output to a schema but
+		// expose no classifier entry point.
+		checkout, cerr := resolveCheckout()
+		if cerr != nil {
+			return SynthesisDocument{}, cerr
+		}
+		if checkout.Cleanup != nil {
+			defer checkout.Cleanup()
+		}
+		invoke()
+		raw, err = sa.ReviewWithSchema(ctx, checkout.RepoPath, checkout.GitRef, prompt, SynthesisSchema, out)
 	case agent.SynthesisAgent:
 		invoke()
 		raw, err = sa.Synthesize(ctx, prompt, out)
 	default:
-		var checkout SynthesisCheckout
-		if hooks.Checkout != nil {
-			checkout, err = hooks.Checkout()
-			if checkout.Cleanup != nil {
-				defer checkout.Cleanup()
-			}
-			if err != nil {
-				return SynthesisDocument{}, &SynthesisCheckoutError{Err: err}
-			}
+		checkout, cerr := resolveCheckout()
+		if cerr != nil {
+			return SynthesisDocument{}, cerr
+		}
+		if checkout.Cleanup != nil {
+			defer checkout.Cleanup()
 		}
 		invoke()
 		var output string

--- a/internal/review/synthesis_test.go
+++ b/internal/review/synthesis_test.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testenv"
 )
 
@@ -146,6 +148,7 @@ func TestBuildSynthesisPrompt_Basic(t *testing.T) {
 
 	assertContainsAll(t, prompt, []string{
 		"combining multiple code review outputs",
+		`{"schema_version":1,"verdict":"pass|fail","markdown":"..."}`,
 		"Do not call tools or run commands",
 		"Only combine the input review results according to these rules",
 		"### Review 1",
@@ -157,6 +160,32 @@ func TestBuildSynthesisPrompt_Basic(t *testing.T) {
 	assert.NotContains(t, prompt, "Type=")
 	assert.NotContains(t, prompt, "Verify each finding")
 	assert.NotContains(t, prompt, "current codebase")
+}
+
+func TestDecodeSynthesisDocument(t *testing.T) {
+	doc, err := DecodeSynthesisDocument(json.RawMessage(
+		`{"schema_version":1,"verdict":"fail","markdown":"Finding"}`,
+	))
+	require.NoError(t, err)
+	assert.Equal(t, storage.VerdictFail, doc.Verdict)
+	assert.Equal(t, "Finding", doc.Markdown)
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "malformed", raw: `not json`},
+		{name: "unknown verdict", raw: `{"schema_version":1,"verdict":"unknown","markdown":"Finding"}`},
+		{name: "empty markdown", raw: `{"schema_version":1,"verdict":"pass","markdown":" "}`},
+		{name: "unknown field", raw: `{"schema_version":1,"verdict":"pass","markdown":"Clean","extra":true}`},
+		{name: "multiple values", raw: `{"schema_version":1,"verdict":"pass","markdown":"Clean"} {}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecodeSynthesisDocument(json.RawMessage(tt.raw))
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestBuildSynthesisPrompt_UsesNeutralReviewerLabels(t *testing.T) {

--- a/internal/review/synthesis_test.go
+++ b/internal/review/synthesis_test.go
@@ -210,6 +210,22 @@ func TestDecodeSynthesisDocument(t *testing.T) {
 	}
 }
 
+func TestSynthesisDocumentRoundTripsNullLocation(t *testing.T) {
+	doc, err := DecodeSynthesisDocument(json.RawMessage(
+		`{"schema_version":1,"summary":"S","findings":[{"severity":"low","problem":"P","fix":"F","location":null,"sources":[1]}]}`,
+	), []ReviewResult{{Agent: "codex"}})
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(doc)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"location":null`)
+	assert.NotContains(t, string(encoded), "source_labels")
+
+	again, err := DecodeStructuredReview(encoded)
+	require.NoError(t, err, "the stored document must satisfy the storage validator")
+	assert.Equal(t, doc.Findings, again.Findings)
+}
+
 func TestSynthesisSourceLabels(t *testing.T) {
 	labels := SynthesisSourceLabels([]ReviewResult{
 		{Agent: "codex"},

--- a/internal/review/synthesis_test.go
+++ b/internal/review/synthesis_test.go
@@ -148,7 +148,8 @@ func TestBuildSynthesisPrompt_Basic(t *testing.T) {
 
 	assertContainsAll(t, prompt, []string{
 		"combining multiple code review outputs",
-		`{"schema_version":1,"verdict":"pass|fail","markdown":"..."}`,
+		`"sources":[1]`,
+		"### Review N",
 		"Do not call tools or run commands",
 		"Only combine the input review results according to these rules",
 		"### Review 1",
@@ -163,29 +164,60 @@ func TestBuildSynthesisPrompt_Basic(t *testing.T) {
 }
 
 func TestDecodeSynthesisDocument(t *testing.T) {
+	assert := assert.New(t)
+	reviews := []ReviewResult{
+		{Agent: "codex", ReviewType: "default"},
+		{Agent: "gemini", ReviewType: "security"},
+	}
+
 	doc, err := DecodeSynthesisDocument(json.RawMessage(
-		`{"schema_version":1,"verdict":"fail","markdown":"Finding"}`,
-	))
+		`{"schema_version":1,"summary":"One shared finding.","findings":[
+		  {"severity":"high","problem":"Leak","fix":"Close it","location":"a.go:1","sources":[2,1,2]}
+		]}`,
+	), reviews)
 	require.NoError(t, err)
-	assert.Equal(t, storage.VerdictFail, doc.Verdict)
-	assert.Equal(t, "Finding", doc.Markdown)
+	assert.Equal(storage.VerdictFail, SynthesisVerdict(doc))
+	assert.Equal([]string{"codex", "gemini (security)"}, doc.SourceLabels)
+	md := doc.Markdown()
+	assert.Contains(md, "One shared finding.")
+	assert.Contains(md, "**Reported by:** gemini (security), codex")
+
+	clean, err := DecodeSynthesisDocument(json.RawMessage(
+		`{"schema_version":1,"summary":"Clean.","findings":[]}`,
+	), reviews)
+	require.NoError(t, err)
+	assert.Equal(storage.VerdictPass, SynthesisVerdict(clean))
+	assert.NotContains(clean.Markdown(), "Reported by")
 
 	tests := []struct {
 		name string
 		raw  string
 	}{
 		{name: "malformed", raw: `not json`},
-		{name: "unknown verdict", raw: `{"schema_version":1,"verdict":"unknown","markdown":"Finding"}`},
-		{name: "empty markdown", raw: `{"schema_version":1,"verdict":"pass","markdown":" "}`},
-		{name: "unknown field", raw: `{"schema_version":1,"verdict":"pass","markdown":"Clean","extra":true}`},
-		{name: "multiple values", raw: `{"schema_version":1,"verdict":"pass","markdown":"Clean"} {}`},
+		{name: "legacy verdict shape", raw: `{"schema_version":1,"verdict":"pass","markdown":"Clean"}`},
+		{name: "empty summary", raw: `{"schema_version":1,"summary":" ","findings":[]}`},
+		{name: "missing sources", raw: `{"schema_version":1,"summary":"S","findings":[{"severity":"low","problem":"P","fix":"F","location":null}]}`},
+		{name: "empty sources", raw: `{"schema_version":1,"summary":"S","findings":[{"severity":"low","problem":"P","fix":"F","location":null,"sources":[]}]}`},
+		{name: "source out of range", raw: `{"schema_version":1,"summary":"S","findings":[{"severity":"low","problem":"P","fix":"F","location":null,"sources":[3]}]}`},
+		{name: "unknown field", raw: `{"schema_version":1,"summary":"S","findings":[],"extra":true}`},
+		{name: "multiple values", raw: `{"schema_version":1,"summary":"S","findings":[]} {}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := DecodeSynthesisDocument(json.RawMessage(tt.raw))
+			_, err := DecodeSynthesisDocument(json.RawMessage(tt.raw), reviews)
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestSynthesisSourceLabels(t *testing.T) {
+	labels := SynthesisSourceLabels([]ReviewResult{
+		{Agent: "codex"},
+		{Agent: "claude-code", ReviewType: "review"},
+		{Agent: "gemini", ReviewType: "design"},
+		{},
+	})
+	assert.Equal(t, []string{"codex", "claude-code", "gemini (design)", "review 4"}, labels)
 }
 
 func TestBuildSynthesisPrompt_UsesNeutralReviewerLabels(t *testing.T) {

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -154,17 +155,27 @@ func runSynthesis(
 		ctx, 5*time.Minute)
 	defer cancel()
 
-	var output string
-	if sa, ok := synthAgent.(agent.SynthesisAgent); ok {
-		output, err = sa.Synthesize(synthCtx, synthPrompt, nil)
+	var raw json.RawMessage
+	if sa, ok := synthAgent.(agent.SchemaAgent); ok {
+		raw, err = sa.ClassifyWithSchema(
+			synthCtx, "", "", synthPrompt, SynthesisSchema, nil,
+		)
+	} else if sa, ok := synthAgent.(agent.SynthesisAgent); ok {
+		raw, err = sa.Synthesize(synthCtx, synthPrompt, nil)
 	} else {
+		var output string
 		output, err = synthAgent.Review(
 			synthCtx, opts.RepoPath, opts.GitRef, synthPrompt, nil)
+		raw = json.RawMessage(output)
 	}
+	if err != nil {
+		return "", fmt.Errorf("synthesis review: %w", err)
+	}
+	doc, err := DecodeSynthesisDocument(raw)
 	if err != nil {
 		return "", fmt.Errorf("synthesis review: %w", err)
 	}
 
 	return FormatSynthesizedComment(
-		output, results, opts.HeadSHA), nil
+		doc.Markdown, results, opts.HeadSHA), nil
 }

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -2,7 +2,6 @@ package review
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -155,23 +154,11 @@ func runSynthesis(
 		ctx, 5*time.Minute)
 	defer cancel()
 
-	var raw json.RawMessage
-	if sa, ok := synthAgent.(agent.SchemaAgent); ok {
-		raw, err = sa.ClassifyWithSchema(
-			synthCtx, "", "", synthPrompt, SynthesisSchema, nil,
-		)
-	} else if sa, ok := synthAgent.(agent.SynthesisAgent); ok {
-		raw, err = sa.Synthesize(synthCtx, synthPrompt, nil)
-	} else {
-		var output string
-		output, err = synthAgent.Review(
-			synthCtx, opts.RepoPath, opts.GitRef, synthPrompt, nil)
-		raw = json.RawMessage(output)
-	}
-	if err != nil {
-		return "", fmt.Errorf("synthesis review: %w", err)
-	}
-	doc, err := DecodeSynthesisDocument(raw)
+	doc, err := RunSynthesisAgent(synthCtx, synthAgent, synthPrompt, nil, SynthesisHooks{
+		Checkout: func() (SynthesisCheckout, error) {
+			return SynthesisCheckout{RepoPath: opts.RepoPath, GitRef: opts.GitRef}, nil
+		},
+	})
 	if err != nil {
 		return "", fmt.Errorf("synthesis review: %w", err)
 	}

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -154,7 +154,7 @@ func runSynthesis(
 		ctx, 5*time.Minute)
 	defer cancel()
 
-	doc, err := RunSynthesisAgent(synthCtx, synthAgent, synthPrompt, nil, SynthesisHooks{
+	doc, err := RunSynthesisAgent(synthCtx, synthAgent, results, synthPrompt, opts.MinSeverity, nil, SynthesisHooks{
 		Checkout: func() (SynthesisCheckout, error) {
 			return SynthesisCheckout{RepoPath: opts.RepoPath, GitRef: opts.GitRef}, nil
 		},
@@ -164,5 +164,5 @@ func runSynthesis(
 	}
 
 	return FormatSynthesizedComment(
-		doc.Markdown, results, opts.HeadSHA), nil
+		doc.Markdown(), results, opts.HeadSHA), nil
 }

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"testing"
@@ -65,7 +66,7 @@ func (a *capturingAgent) Review(
 	_ context.Context, _, gitRef, _ string, _ io.Writer,
 ) (string, error) {
 	a.capturedGitRef = gitRef
-	return "synthesized output", nil
+	return `{"schema_version":1,"verdict":"fail","markdown":"synthesized output"}`, nil
 }
 func (a *capturingAgent) CommandLine() string { return "capture" }
 
@@ -91,11 +92,29 @@ func (a *synthesisEntrypointAgent) Review(
 
 func (a *synthesisEntrypointAgent) Synthesize(
 	_ context.Context, prompt string, _ io.Writer,
-) (string, error) {
+) (json.RawMessage, error) {
 	a.synthPrompt = prompt
-	return "synthesized output", nil
+	return json.RawMessage(`{"schema_version":1,"verdict":"fail","markdown":"synthesized output"}`), nil
 }
 func (a *synthesisEntrypointAgent) CommandLine() string { return "synthesis-entrypoint" }
+
+type invalidSynthesisAgent struct {
+	commonMockAgent
+}
+
+func newInvalidSynthesisAgent() *invalidSynthesisAgent {
+	a := &invalidSynthesisAgent{}
+	a.self = a
+	return a
+}
+
+func (a *invalidSynthesisAgent) Name() string { return "invalid-synthesis" }
+func (a *invalidSynthesisAgent) Review(
+	context.Context, string, string, string, io.Writer,
+) (string, error) {
+	return "Markdown without structured synthesis JSON.", nil
+}
+func (a *invalidSynthesisAgent) CommandLine() string { return a.Name() }
 
 func TestSynthesize_Formatting(t *testing.T) {
 	tests := []struct {
@@ -329,6 +348,24 @@ func TestSynthesize_MultipleResults_FallsBackToRaw(t *testing.T) {
 	assert.NotContains(t, comment, "codex —")
 	assert.NotContains(t, comment, "security")
 	assert.NotContains(t, comment, "design")
+}
+
+func TestSynthesize_InvalidJSONFallsBackToRaw(t *testing.T) {
+	ag := newInvalidSynthesisAgent()
+	agent.Register(ag)
+	t.Cleanup(func() { agent.Unregister(ag.Name()) })
+
+	results := []ReviewResult{
+		{Status: ResultDone, Output: "Finding A"},
+		{Status: ResultDone, Output: "Finding B"},
+	}
+	comment, err := Synthesize(context.Background(), results, SynthesizeOpts{
+		Agent: ag.Name(), HeadSHA: "def456789012",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, comment, "Synthesis unavailable")
+	assert.Contains(t, comment, "Finding A")
+	assert.Contains(t, comment, "Finding B")
 }
 
 func TestSynthesize_MixedSuccessAndFailure(t *testing.T) {

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -66,7 +66,7 @@ func (a *capturingAgent) Review(
 	_ context.Context, _, gitRef, _ string, _ io.Writer,
 ) (string, error) {
 	a.capturedGitRef = gitRef
-	return `{"schema_version":1,"verdict":"fail","markdown":"synthesized output"}`, nil
+	return `{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`, nil
 }
 func (a *capturingAgent) CommandLine() string { return "capture" }
 
@@ -94,7 +94,7 @@ func (a *synthesisEntrypointAgent) Synthesize(
 	_ context.Context, prompt string, _ io.Writer,
 ) (json.RawMessage, error) {
 	a.synthPrompt = prompt
-	return json.RawMessage(`{"schema_version":1,"verdict":"fail","markdown":"synthesized output"}`), nil
+	return json.RawMessage(`{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
 }
 func (a *synthesisEntrypointAgent) CommandLine() string { return "synthesis-entrypoint" }
 

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -98,6 +98,55 @@ func (a *synthesisEntrypointAgent) Synthesize(
 }
 func (a *synthesisEntrypointAgent) CommandLine() string { return "synthesis-entrypoint" }
 
+type structuredSynthesisAgent struct {
+	commonMockAgent
+	schema       json.RawMessage
+	repoPath     string
+	reviewCalled bool
+}
+
+func newStructuredSynthesisAgent() *structuredSynthesisAgent {
+	a := &structuredSynthesisAgent{}
+	a.self = a
+	return a
+}
+
+func (a *structuredSynthesisAgent) Name() string { return "structured-synthesis" }
+func (a *structuredSynthesisAgent) Review(
+	context.Context, string, string, string, io.Writer,
+) (string, error) {
+	a.reviewCalled = true
+	return "", errors.New("plain review must not be used when ReviewWithSchema exists")
+}
+
+func (a *structuredSynthesisAgent) ReviewWithSchema(
+	_ context.Context, repoPath, _, _ string, schema json.RawMessage, _ io.Writer,
+) (json.RawMessage, error) {
+	a.schema = schema
+	a.repoPath = repoPath
+	return json.RawMessage(`{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
+}
+func (a *structuredSynthesisAgent) CommandLine() string { return a.Name() }
+
+func TestRunSynthesisAgentPrefersSchemaReviewOverPlainReview(t *testing.T) {
+	a := newStructuredSynthesisAgent()
+	reviews := []ReviewResult{{Agent: "codex", Status: ResultDone, Output: "Found issue A"}}
+	cleaned := false
+
+	doc, err := RunSynthesisAgent(context.Background(), a, reviews, "prompt", "", nil, SynthesisHooks{
+		Checkout: func() (SynthesisCheckout, error) {
+			return SynthesisCheckout{RepoPath: "/repo", GitRef: "HEAD", Cleanup: func() { cleaned = true }}, nil
+		},
+	})
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.False(a.reviewCalled)
+	assert.JSONEq(string(SynthesisSchema), string(a.schema))
+	assert.Equal("/repo", a.repoPath, "schema review runs against the reviewed checkout")
+	assert.True(cleaned, "checkout cleanup must run after the agent")
+	assert.Equal([]int{1}, doc.Findings[0].Sources)
+}
+
 type invalidSynthesisAgent struct {
 	commonMockAgent
 }

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -93,6 +93,21 @@ func TestCompleteJobResultStoresCanonicalReview(t *testing.T) {
 	assert.JSONEq(t, string(structured), storedStructured)
 }
 
+func TestCompleteJobUnknownOutputLeavesVerdictNull(t *testing.T) {
+	env := setupJobEnv(t, "/tmp/unknown-verdict", "unknown123")
+	claimJob(t, env.db, "worker-1")
+
+	require.NoError(t, env.db.CompleteJob(
+		env.job.ID, "codex", "prompt", "Task completed successfully.",
+	))
+
+	var verdict sql.NullInt64
+	require.NoError(t, env.db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, env.job.ID,
+	).Scan(&verdict))
+	assert.False(t, verdict.Valid)
+}
+
 func TestCompleteJobResultRejectsInvalidStructuredOutput(t *testing.T) {
 	tests := []struct {
 		name string
@@ -2472,4 +2487,24 @@ func TestCompleteFixJobEmptyOutputLeavesVerdictNull(t *testing.T) {
 	var vb sql.NullInt64
 	require.NoError(t, db.QueryRow(`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID).Scan(&vb))
 	assert.False(t, vb.Valid, "empty output must not store a verdict")
+}
+
+func TestCompleteFixJobUnknownOutputLeavesVerdictNull(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	repo := createRepo(t, db, "/tmp/fix-unknown-output-repo")
+	commit := createCommit(t, db, repo.ID, "fix456")
+	job := enqueueJob(t, db, repo.ID, commit.ID, "fix456")
+	claimJob(t, db, "w1")
+
+	require.NoError(t, db.CompleteFixJob(
+		job.ID, "codex", "p", "Applied the requested change.", "patch content",
+	))
+
+	var verdict sql.NullInt64
+	require.NoError(t, db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID,
+	).Scan(&verdict))
+	assert.False(t, verdict.Valid)
 }

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -106,6 +106,9 @@ func TestCompleteJobUnknownOutputLeavesVerdictNull(t *testing.T) {
 		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, env.job.ID,
 	).Scan(&verdict))
 	assert.False(t, verdict.Valid)
+	reviewRow, err := env.db.GetReviewByJobID(env.job.ID)
+	require.NoError(t, err)
+	assert.Nil(t, reviewRow.Job.Verdict)
 }
 
 func TestCompleteJobResultRejectsInvalidStructuredOutput(t *testing.T) {

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -93,12 +93,32 @@ func TestCompleteJobResultStoresCanonicalReview(t *testing.T) {
 	assert.JSONEq(t, string(structured), storedStructured)
 }
 
-func TestCompleteJobUnknownOutputLeavesVerdictNull(t *testing.T) {
+func TestCompleteJobTaskOutputLeavesVerdictNull(t *testing.T) {
+	db := openTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	repo := createRepo(t, db, "/tmp/task-verdict")
+
+	job, err := db.EnqueueJob(EnqueueOpts{
+		RepoID: repo.ID, GitRef: "prompt", Agent: "test",
+		Prompt: "count the exported symbols", JobType: JobTypeTask,
+	})
+	require.NoError(t, err)
+	claimJob(t, db, "worker-1")
+	require.NoError(t, db.CompleteJob(job.ID, "test", "prompt", "The code has issues."))
+
+	var verdict sql.NullInt64
+	require.NoError(t, db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID,
+	).Scan(&verdict))
+	assert.False(t, verdict.Valid, "task output must not carry a parsed verdict")
+}
+
+func TestCompleteJobUnreadableOutputLeavesVerdictNull(t *testing.T) {
 	env := setupJobEnv(t, "/tmp/unknown-verdict", "unknown123")
 	claimJob(t, env.db, "worker-1")
 
 	require.NoError(t, env.db.CompleteJob(
-		env.job.ID, "codex", "prompt", "Task completed successfully.",
+		env.job.ID, "codex", "prompt", "I am unable to read the diff file because it is ignored by configured ignore patterns.",
 	))
 
 	var verdict sql.NullInt64
@@ -2502,7 +2522,7 @@ func TestCompleteFixJobUnknownOutputLeavesVerdictNull(t *testing.T) {
 	claimJob(t, db, "w1")
 
 	require.NoError(t, db.CompleteFixJob(
-		job.ID, "codex", "p", "Applied the requested change.", "patch content",
+		job.ID, "codex", "p", "I am unable to read the diff file because it is ignored by configured ignore patterns.", "patch content",
 	))
 
 	var verdict sql.NullInt64

--- a/internal/storage/export_test.go
+++ b/internal/storage/export_test.go
@@ -531,7 +531,12 @@ func TestExportReviewsCapsContent(t *testing.T) {
 	commit := createCommit(t, db, repo.ID, "cccccccccccccccccccccccccccccccccccccccc")
 	job := enqueueJob(t, db, repo.ID, commit.ID, commit.SHA)
 	claimJob(t, db, "w1")
-	require.NoError(t, db.CompleteJob(job.ID, "codex", "prompt", strings.Repeat("x", exportContentMaxBytes+100)))
+	require.NoError(t, db.CompleteJobResult(
+		job.ID, "codex", "prompt", ReviewCompletion{
+			Output:  strings.Repeat("x", exportContentMaxBytes+100),
+			Verdict: VerdictFail,
+		},
+	))
 
 	page, err := db.ExportReviews(ExportReviewsOptions{Profile: ExportProfileContent, Limit: 10})
 	require.NoError(t, err)

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1108,7 +1108,9 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 	// review output exists and skip reading the output column.
 	var verdictBoolVal any
 	if finalOutput != "" {
-		verdictBoolVal = verdictToBool(ParseVerdict(finalOutput))
+		if verdict := ParseVerdict(finalOutput); verdict != VerdictUnknown {
+			verdictBoolVal = verdictToBool(verdict)
+		}
 	}
 	_, err = conn.ExecContext(ctx,
 		`INSERT INTO reviews (job_id, agent, prompt, output, verdict_bool, uuid, updated_by_machine_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1225,7 +1227,9 @@ func (db *DB) completeJob(
 	if completion.Verdict != VerdictUnknown {
 		verdictBoolVal = verdictToBool(completion.Verdict)
 	} else if finalOutput != "" {
-		verdictBoolVal = verdictToBool(ParseVerdict(finalOutput))
+		if verdict := ParseVerdict(finalOutput); verdict != VerdictUnknown {
+			verdictBoolVal = verdictToBool(verdict)
+		}
 	}
 	coverage := NormalizeReviewFileCoverage(completion.FileCoverage)
 	var reviewedFileCount, excludedFileCount any

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1075,9 +1075,10 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 		}
 	}()
 
-	// Fetch output_prefix from job (if any)
+	// Fetch output_prefix and job_type from job (if any)
 	var outputPrefix sql.NullString
-	err = conn.QueryRowContext(ctx, `SELECT output_prefix FROM review_jobs WHERE id = ?`, jobID).Scan(&outputPrefix)
+	var jobType string
+	err = conn.QueryRowContext(ctx, `SELECT output_prefix, job_type FROM review_jobs WHERE id = ?`, jobID).Scan(&outputPrefix, &jobType)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
@@ -1106,12 +1107,7 @@ func (db *DB) CompleteFixJob(jobID int64, agent, prompt, output, patch string) e
 	// Only store a verdict for non-empty output, matching CompleteJob:
 	// listings treat a non-NULL verdict_bool as proof that a non-empty
 	// review output exists and skip reading the output column.
-	var verdictBoolVal any
-	if finalOutput != "" {
-		if verdict := ParseVerdict(finalOutput); verdict != VerdictUnknown {
-			verdictBoolVal = verdictToBool(verdict)
-		}
-	}
+	verdictBoolVal := verdictBoolFromOutput(finalOutput)
 	_, err = conn.ExecContext(ctx,
 		`INSERT INTO reviews (job_id, agent, prompt, output, verdict_bool, uuid, updated_by_machine_id, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		jobID, agent, prompt, finalOutput, verdictBoolVal, reviewUUID, machineID, now)
@@ -1188,9 +1184,10 @@ func (db *DB) completeJob(
 		}
 	}()
 
-	// Fetch output_prefix from job (if any)
+	// Fetch output_prefix and job_type from job (if any)
 	var outputPrefix sql.NullString
-	err = conn.QueryRowContext(ctx, `SELECT output_prefix FROM review_jobs WHERE id = ?`, jobID).Scan(&outputPrefix)
+	var jobType string
+	err = conn.QueryRowContext(ctx, `SELECT output_prefix, job_type FROM review_jobs WHERE id = ?`, jobID).Scan(&outputPrefix, &jobType)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
@@ -1222,14 +1219,13 @@ func (db *DB) completeJob(
 		return nil
 	}
 
-	// Insert review with sync columns
+	// Insert review with sync columns. Task and insights output is free-form
+	// prose, so it never carries a parsed verdict.
 	var verdictBoolVal any
 	if completion.Verdict != VerdictUnknown {
 		verdictBoolVal = verdictToBool(completion.Verdict)
-	} else if finalOutput != "" {
-		if verdict := ParseVerdict(finalOutput); verdict != VerdictUnknown {
-			verdictBoolVal = verdictToBool(verdict)
-		}
+	} else if jobType != JobTypeTask && jobType != JobTypeInsights {
+		verdictBoolVal = verdictBoolFromOutput(finalOutput)
 	}
 	coverage := NormalizeReviewFileCoverage(completion.FileCoverage)
 	var reviewedFileCount, excludedFileCount any

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1224,7 +1224,7 @@ func (db *DB) completeJob(
 	var verdictBoolVal any
 	if completion.Verdict != VerdictUnknown {
 		verdictBoolVal = verdictToBool(completion.Verdict)
-	} else if jobType != JobTypeTask && jobType != JobTypeInsights {
+	} else if !isFreeFormJobType(jobType) {
 		verdictBoolVal = verdictBoolFromOutput(finalOutput)
 	}
 	coverage := NormalizeReviewFileCoverage(completion.FileCoverage)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -834,12 +834,12 @@ const pgUpsertReviewSQL = `
 			updated_by_machine_id, created_at, updated_at
 		) VALUES ($1, $2, $3, $4, $5, $6,
 			CASE WHEN EXISTS (SELECT 1 FROM review_jobs j WHERE j.uuid = $2 AND j.job_type IN ('task', 'insights'))
-				THEN NULL ELSE $7 END,
+				THEN NULL ELSE $7::boolean END,
 			$8, $9, $10, $11, $12, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			closed = EXCLUDED.closed,
 			verdict_bool = CASE
-				WHEN $13 THEN NULL
+				WHEN $13::boolean THEN NULL
 				WHEN EXISTS (SELECT 1 FROM review_jobs j WHERE j.uuid = EXCLUDED.job_uuid AND j.job_type IN ('task', 'insights')) THEN NULL
 				ELSE COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool) END,
 			structured_output = COALESCE(EXCLUDED.structured_output, reviews.structured_output),

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -815,24 +815,42 @@ func (p *PgPool) UpsertJob(ctx context.Context, j SyncableJob, pgRepoID int64, p
 
 // UpsertReview inserts or updates a review in PostgreSQL
 func (p *PgPool) UpsertReview(ctx context.Context, r SyncableReview) error {
-	_, err := p.pool.Exec(ctx, `
+	verdictBool, noReview := syncedReviewVerdict(r)
+	_, err := p.pool.Exec(ctx, pgUpsertReviewSQL,
+		r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
+		verdictBool, nullJSON(r.StructuredOutput), r.ReviewedFileCount, r.ExcludedFileCount,
+		r.UpdatedByMachineID, r.CreatedAt, noReview)
+	return err
+}
+
+// pgUpsertReviewSQL merges a pushed review. A NULL verdict normally keeps the
+// central value so an older sender cannot wipe one, but output that is not a
+// review ($13) must end unrated even if a legacy verdict was stored before.
+const pgUpsertReviewSQL = `
 		INSERT INTO reviews (
 			uuid, job_uuid, agent, prompt, output, closed,
 			verdict_bool, structured_output, reviewed_file_count, excluded_file_count,
 			updated_by_machine_id, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, clock_timestamp())
+		) VALUES ($1, $2, $3, $4, $5, $6,
+			$7,
+			$8, $9, $10, $11, $12, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			closed = EXCLUDED.closed,
-			verdict_bool = COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool),
+			verdict_bool = CASE WHEN $13 THEN NULL ELSE COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool) END,
 			structured_output = COALESCE(EXCLUDED.structured_output, reviews.structured_output),
 			reviewed_file_count = COALESCE(EXCLUDED.reviewed_file_count, reviews.reviewed_file_count),
 			excluded_file_count = COALESCE(EXCLUDED.excluded_file_count, reviews.excluded_file_count),
 			updated_by_machine_id = EXCLUDED.updated_by_machine_id,
 			updated_at = clock_timestamp()
-	`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
-		r.VerdictBool, nullJSON(r.StructuredOutput), r.ReviewedFileCount, r.ExcludedFileCount,
-		r.UpdatedByMachineID, r.CreatedAt)
-	return err
+`
+
+// syncedReviewVerdict returns the verdict to store for a pushed review and
+// whether its output is not a review at all, mirroring the SQLite pull path.
+func syncedReviewVerdict(r SyncableReview) (*bool, bool) {
+	if ClassifyOutput(r.Output) != OutputReviewed {
+		return nil, true
+	}
+	return r.VerdictBool, false
 }
 
 func (p *PgPool) UpsertExperimentDefinition(ctx context.Context, definition SyncableExperimentDefinition) error {
@@ -1331,23 +1349,11 @@ func (p *PgPool) BatchUpsertReviews(ctx context.Context, reviews []SyncableRevie
 
 	batch := &pgx.Batch{}
 	for _, r := range reviews {
-		batch.Queue(`
-			INSERT INTO reviews (
-				uuid, job_uuid, agent, prompt, output, closed,
-				verdict_bool, structured_output, reviewed_file_count, excluded_file_count,
-				updated_by_machine_id, created_at, updated_at
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, clock_timestamp())
-			ON CONFLICT (uuid) DO UPDATE SET
-				closed = EXCLUDED.closed,
-				verdict_bool = COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool),
-				structured_output = COALESCE(EXCLUDED.structured_output, reviews.structured_output),
-				reviewed_file_count = COALESCE(EXCLUDED.reviewed_file_count, reviews.reviewed_file_count),
-				excluded_file_count = COALESCE(EXCLUDED.excluded_file_count, reviews.excluded_file_count),
-				updated_by_machine_id = EXCLUDED.updated_by_machine_id,
-				updated_at = clock_timestamp()
-		`, r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
-			r.VerdictBool, nullJSON(r.StructuredOutput), r.ReviewedFileCount, r.ExcludedFileCount,
-			r.UpdatedByMachineID, r.CreatedAt)
+		verdictBool, noReview := syncedReviewVerdict(r)
+		batch.Queue(pgUpsertReviewSQL,
+			r.UUID, r.JobUUID, r.Agent, r.Prompt, r.Output, r.Closed,
+			verdictBool, nullJSON(r.StructuredOutput), r.ReviewedFileCount, r.ExcludedFileCount,
+			r.UpdatedByMachineID, r.CreatedAt, noReview)
 	}
 
 	br := p.pool.SendBatch(ctx, batch)

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -824,19 +824,24 @@ func (p *PgPool) UpsertReview(ctx context.Context, r SyncableReview) error {
 }
 
 // pgUpsertReviewSQL merges a pushed review. A NULL verdict normally keeps the
-// central value so an older sender cannot wipe one, but output that is not a
-// review ($13) must end unrated even if a legacy verdict was stored before.
+// central value so an older sender cannot wipe one. Two cases must end
+// unrated even if a legacy verdict was stored before: output that is not a
+// review ($13), and free-form task or insights jobs, looked up by job type.
 const pgUpsertReviewSQL = `
 		INSERT INTO reviews (
 			uuid, job_uuid, agent, prompt, output, closed,
 			verdict_bool, structured_output, reviewed_file_count, excluded_file_count,
 			updated_by_machine_id, created_at, updated_at
 		) VALUES ($1, $2, $3, $4, $5, $6,
-			$7,
+			CASE WHEN EXISTS (SELECT 1 FROM review_jobs j WHERE j.uuid = $2 AND j.job_type IN ('task', 'insights'))
+				THEN NULL ELSE $7 END,
 			$8, $9, $10, $11, $12, clock_timestamp())
 		ON CONFLICT (uuid) DO UPDATE SET
 			closed = EXCLUDED.closed,
-			verdict_bool = CASE WHEN $13 THEN NULL ELSE COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool) END,
+			verdict_bool = CASE
+				WHEN $13 THEN NULL
+				WHEN EXISTS (SELECT 1 FROM review_jobs j WHERE j.uuid = EXCLUDED.job_uuid AND j.job_type IN ('task', 'insights')) THEN NULL
+				ELSE COALESCE(EXCLUDED.verdict_bool, reviews.verdict_bool) END,
 			structured_output = COALESCE(EXCLUDED.structured_output, reviews.structured_output),
 			reviewed_file_count = COALESCE(EXCLUDED.reviewed_file_count, reviews.reviewed_file_count),
 			excluded_file_count = COALESCE(EXCLUDED.excluded_file_count, reviews.excluded_file_count),

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -569,6 +569,19 @@ func TestGetRepoStats(t *testing.T) {
 		assert.Equal(t, 2, stats.OpenReviews)
 	})
 
+	t.Run("unknown verdict is not counted as failed", func(t *testing.T) {
+		db, repo := setupDBAndRepo(t, "stats-unknown-verdict")
+		commit := createCommit(t, db, repo.ID, "stats-unknown-sha")
+		job := enqueueJob(t, db, repo.ID, commit.ID, commit.SHA)
+		completeTestJob(t, db, job.ID, "Review completed without a verdict.")
+
+		stats, err := db.GetRepoStats(repo.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 0, stats.PassedReviews)
+		assert.Equal(t, 0, stats.FailedReviews)
+		assert.Equal(t, 1, stats.OpenReviews)
+	})
+
 	t.Run("closed reviews counted", func(t *testing.T) {
 		db, repo := setupDBAndRepo(t, "stats-addressed-test")
 		commit1 := createCommit(t, db, repo.ID, "stats-sha1")

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -984,7 +984,7 @@ func TestVerdictSuppressionForPromptJobs(t *testing.T) {
 
 		claimJob(t, db, "worker-1")
 		// Output that should be parsed as FAIL
-		db.CompleteJob(jobID, "codex", "prompt", "Found issues:\n1. Bug found")
+		db.CompleteJob(jobID, "codex", "prompt", "**Verdict**: FAIL\n\n1. Bug found")
 
 		// Fetch via ListJobs and check verdict IS computed (because commit_id is not NULL)
 		jobs, _ := db.ListJobs("", repo.RootPath, 100, 0)

--- a/internal/storage/repos_test.go
+++ b/internal/storage/repos_test.go
@@ -573,7 +573,7 @@ func TestGetRepoStats(t *testing.T) {
 		db, repo := setupDBAndRepo(t, "stats-unknown-verdict")
 		commit := createCommit(t, db, repo.ID, "stats-unknown-sha")
 		job := enqueueJob(t, db, repo.ID, commit.ID, commit.SHA)
-		completeTestJob(t, db, job.ID, "Review completed without a verdict.")
+		completeTestJob(t, db, job.ID, "I am unable to read the diff file because it is ignored by configured ignore patterns.")
 
 		stats, err := db.GetRepoStats(repo.ID)
 		require.NoError(t, err)

--- a/internal/storage/summary.go
+++ b/internal/storage/summary.go
@@ -530,9 +530,13 @@ func (db *DB) BackfillVerdictBool() (int, error) {
 		if err := rows.Scan(&id, &output); err != nil {
 			return 0, err
 		}
+		verdict := ParseVerdict(output)
+		if verdict == VerdictUnknown {
+			continue
+		}
 		updates = append(updates, pending{
 			id:      id,
-			verdict: verdictToBool(ParseVerdict(output)),
+			verdict: verdictToBool(verdict),
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/storage/summary.go
+++ b/internal/storage/summary.go
@@ -617,11 +617,11 @@ func percentile(values []float64, p float64) float64 {
 }
 
 // clearUnreadableVerdicts nulls verdict_bool on rows that an older parser
-// recorded as a verdict but that ParseVerdict now classifies as unreadable
-// input. The SQL LIKE prefilter keeps the per-startup scan cheap; the Go
-// parser makes the final call so a labelled finding is never cleared.
+// recorded as a verdict but that ClassifyOutput now says were never reviewed.
+// The SQL LIKE prefilter keeps the per-startup scan cheap; the Go parser
+// makes the final call so a labelled finding is never cleared.
 func (db *DB) clearUnreadableVerdicts() (int64, error) {
-	where, args := UnreadableInputLikeClauses("output")
+	where, args := NoReviewLikeClauses("output")
 	rows, err := db.Query(`SELECT id, output FROM reviews WHERE verdict_bool IS NOT NULL AND (`+where+`)`, args...)
 	if err != nil {
 		return 0, err

--- a/internal/storage/summary.go
+++ b/internal/storage/summary.go
@@ -516,11 +516,30 @@ func (db *DB) BackfillVerdictBool() (int, error) {
 	}
 	clearedCount += unreadable
 
+	// Task and insights output is free-form prose and never carries a
+	// verdict. Clear any verdict an older release parsed out of it, and keep
+	// those rows out of the re-parse below so a restart cannot add one back.
+	freeForm, err := db.Exec(`
+		UPDATE reviews SET verdict_bool = NULL
+		WHERE verdict_bool IS NOT NULL
+		  AND job_id IN (SELECT id FROM review_jobs WHERE job_type IN (?, ?))
+	`, JobTypeTask, JobTypeInsights)
+	if err != nil {
+		return 0, err
+	}
+	freeFormCount, err := freeForm.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	clearedCount += freeFormCount
+
 	rows, err := db.Query(`
 		SELECT rv.id, rv.output
 		FROM reviews rv
+		JOIN review_jobs j ON j.id = rv.job_id
 		WHERE rv.verdict_bool IS NULL AND rv.output != ''
-	`)
+		  AND j.job_type NOT IN (?, ?)
+	`, JobTypeTask, JobTypeInsights)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/storage/summary.go
+++ b/internal/storage/summary.go
@@ -498,7 +498,9 @@ func summaryFailures(q querier, where string, args []any) (FailureStats, error) 
 // but a NULL verdict_bool, and clears verdict_bool on empty-output rows
 // (written by older CompleteFixJob versions). Listings rely on a non-NULL
 // verdict_bool implying a non-empty output so they can skip reading the
-// output column. Returns the number of rows updated.
+// output column. It also clears verdict_bool on rows whose output says the
+// agent never read its diff; older parsers recorded those as failed reviews.
+// Returns the number of rows updated.
 func (db *DB) BackfillVerdictBool() (int, error) {
 	cleared, err := db.Exec(`UPDATE reviews SET verdict_bool = NULL WHERE verdict_bool IS NOT NULL AND output = ''`)
 	if err != nil {
@@ -508,6 +510,11 @@ func (db *DB) BackfillVerdictBool() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	unreadable, err := db.clearUnreadableVerdicts()
+	if err != nil {
+		return 0, err
+	}
+	clearedCount += unreadable
 
 	rows, err := db.Query(`
 		SELECT rv.id, rv.output
@@ -607,4 +614,46 @@ func percentile(values []float64, p float64) float64 {
 	}
 	frac := rank - float64(lower)
 	return values[lower] + frac*(values[upper]-values[lower])
+}
+
+// clearUnreadableVerdicts nulls verdict_bool on rows that an older parser
+// recorded as a verdict but that ParseVerdict now classifies as unreadable
+// input. The SQL LIKE prefilter keeps the per-startup scan cheap; the Go
+// parser makes the final call so a labelled finding is never cleared.
+func (db *DB) clearUnreadableVerdicts() (int64, error) {
+	where, args := UnreadableInputLikeClauses("output")
+	rows, err := db.Query(`SELECT id, output FROM reviews WHERE verdict_bool IS NOT NULL AND (`+where+`)`, args...)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		var output string
+		if err := rows.Scan(&id, &output); err != nil {
+			return 0, err
+		}
+		if ParseVerdict(output) == VerdictUnknown {
+			ids = append(ids, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	var cleared int64
+	for _, id := range ids {
+		res, err := db.Exec(`UPDATE reviews SET verdict_bool = NULL WHERE id = ?`, id)
+		if err != nil {
+			return 0, err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return 0, err
+		}
+		cleared += n
+	}
+	return cleared, nil
 }

--- a/internal/storage/summary_test.go
+++ b/internal/storage/summary_test.go
@@ -440,6 +440,10 @@ func TestBackfillVerdictBool(t *testing.T) {
 	claimJob(t, db, "w1")
 	require.NoError(t, db.CompleteJob(j2.ID, "codex", "p", "- High — Bug"))
 
+	j3 := enqueueJob(t, db, repo.ID, commit.ID, "abc123")
+	claimJob(t, db, "w1")
+	require.NoError(t, db.CompleteJob(j3.ID, "codex", "p", "Review completed without a verdict."))
+
 	// Simulate legacy rows by nullifying verdict_bool
 	_, err := db.Exec(`UPDATE reviews SET verdict_bool = NULL`)
 	require.NoError(t, err)
@@ -460,6 +464,12 @@ func TestBackfillVerdictBool(t *testing.T) {
 	assert.Equal(t, 2, s.Verdicts.Total)
 	assert.Equal(t, 1, s.Verdicts.Passed)
 	assert.Equal(t, 1, s.Verdicts.Failed)
+
+	var unknownVerdict sql.NullInt64
+	require.NoError(t, db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, j3.ID,
+	).Scan(&unknownVerdict))
+	assert.False(t, unknownVerdict.Valid, "unknown verdict must remain NULL")
 
 	// Running again is a no-op
 	count, err = db.BackfillVerdictBool()

--- a/internal/storage/summary_test.go
+++ b/internal/storage/summary_test.go
@@ -484,6 +484,35 @@ func TestBackfillVerdictBool(t *testing.T) {
 // Older CompleteFixJob stored verdict_bool even for empty outputs. Listings
 // rely on non-NULL verdict_bool implying a non-empty output, so the startup
 // backfill pass must clear those legacy rows.
+func TestBackfillVerdictBoolSkipsFreeFormJobs(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+	repo := createRepo(t, db, "/tmp/backfill-freeform-repo")
+
+	job, err := db.EnqueueJob(EnqueueOpts{
+		RepoID: repo.ID, GitRef: "prompt", Agent: "test",
+		Prompt: "summarize the module", JobType: JobTypeTask,
+	})
+	require.NoError(t, err)
+	claimJob(t, db, "w1")
+	require.NoError(t, db.CompleteJob(job.ID, "test", "prompt", "The code has issues."))
+	// An older release parsed a verdict out of this prose.
+	_, err = db.Exec(`UPDATE reviews SET verdict_bool = 0 WHERE job_id = ?`, job.ID)
+	require.NoError(t, err)
+
+	count, err := db.BackfillVerdictBool()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "the legacy task verdict is cleared")
+
+	var verdict sql.NullInt64
+	require.NoError(t, db.QueryRow(`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID).Scan(&verdict))
+	assert.False(t, verdict.Valid, "task output must not be re-parsed into a verdict")
+
+	count, err = db.BackfillVerdictBool()
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "a second run is a no-op")
+}
+
 func TestBackfillVerdictBoolClearsEmptyOutputVerdicts(t *testing.T) {
 	db := openTestDB(t)
 	defer db.Close()

--- a/internal/storage/summary_test.go
+++ b/internal/storage/summary_test.go
@@ -442,21 +442,25 @@ func TestBackfillVerdictBool(t *testing.T) {
 
 	j3 := enqueueJob(t, db, repo.ID, commit.ID, "abc123")
 	claimJob(t, db, "w1")
-	require.NoError(t, db.CompleteJob(j3.ID, "codex", "p", "Review completed without a verdict."))
+	require.NoError(t, db.CompleteJob(j3.ID, "codex", "p", "I am unable to read the diff file because it is ignored by configured ignore patterns."))
 
 	// Simulate legacy rows by nullifying verdict_bool
 	_, err := db.Exec(`UPDATE reviews SET verdict_bool = NULL`)
 	require.NoError(t, err)
+	// Older parsers recorded unreadable-diff output as a failed review.
+	_, err = db.Exec(`UPDATE reviews SET verdict_bool = 0 WHERE job_id = ?`, j3.ID)
+	require.NoError(t, err)
 
-	// Verify summary sees nothing before backfill
+	// Before backfill the summary sees only the bogus fail on the unreadable row
 	s, err := db.GetSummary(SummaryOptions{Since: time.Now().Add(-1 * time.Hour)})
 	require.NoError(t, err)
-	assert.Equal(t, 0, s.Verdicts.Total)
+	assert.Equal(t, 1, s.Verdicts.Total)
+	assert.Equal(t, 1, s.Verdicts.Failed)
 
-	// Backfill
+	// Backfill: two legacy rows gain a verdict, one unreadable row loses its bogus fail
 	count, err := db.BackfillVerdictBool()
 	require.NoError(t, err)
-	assert.Equal(t, 2, count)
+	assert.Equal(t, 3, count)
 
 	// Verify summary now sees the verdicts
 	s, err = db.GetSummary(SummaryOptions{Since: time.Now().Add(-1 * time.Hour)})

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -897,10 +897,8 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 		if *r.VerdictBool {
 			verdictBool = 1
 		}
-	} else if r.Output != "" {
-		if verdict := ParseVerdict(r.Output); verdict != VerdictUnknown {
-			verdictBool = verdictToBool(verdict)
-		}
+	} else {
+		verdictBool = verdictBoolFromOutput(r.Output)
 	}
 	_, err = db.Exec(`
 		INSERT INTO reviews (

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -891,13 +891,16 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
+	// A remote machine on an older release may have stored a verdict for
+	// output that never reviewed the code (an unreadable diff). Do not
+	// re-import that verdict; the row stays unrated here as it would locally.
 	var verdictBool any
-	if r.VerdictBool != nil {
+	if r.VerdictBool != nil && !IsUnreadableInput(r.Output) {
 		verdictBool = 0
 		if *r.VerdictBool {
 			verdictBool = 1
 		}
-	} else {
+	} else if r.VerdictBool == nil {
 		verdictBool = verdictBoolFromOutput(r.Output)
 	}
 	_, err = db.Exec(`

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -899,7 +899,7 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 	// one. Unreadable output is the exception: that row must end unrated
 	// even if a legacy verdict was stored before.
 	var verdictBool any
-	unreadable := IsUnreadableInput(r.Output)
+	unreadable := ClassifyOutput(r.Output) != OutputReviewed
 	if r.VerdictBool != nil && !unreadable {
 		verdictBool = 0
 		if *r.VerdictBool {

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -881,7 +881,8 @@ func (db *DB) UpsertPulledJob(j PulledJob, repoID int64, commitID *int64) error 
 func (db *DB) UpsertPulledReview(r PulledReview) error {
 	// First, find the job_id by uuid
 	var jobID int64
-	err := db.QueryRow(`SELECT id FROM review_jobs WHERE uuid = ?`, r.JobUUID).Scan(&jobID)
+	var jobType string
+	err := db.QueryRow(`SELECT id, job_type FROM review_jobs WHERE uuid = ?`, r.JobUUID).Scan(&jobID, &jobType)
 	if errors.Is(err, sql.ErrNoRows) {
 		// Job doesn't exist locally - skip this review (orphaned)
 		return nil
@@ -896,20 +897,21 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 	// re-import that verdict; the row stays unrated here as it would locally.
 	// A NULL verdict normally keeps the local value on conflict, so an older
 	// sender that never sends verdict_bool cannot wipe a locally computed
-	// one. Unreadable output is the exception: that row must end unrated
-	// even if a legacy verdict was stored before.
+	// one. Two cases are the exception and must end unrated even if a legacy
+	// verdict was stored before: output that is not a review, and free-form
+	// task or insights output, which never carries a verdict locally either.
 	var verdictBool any
-	unreadable := ClassifyOutput(r.Output) != OutputReviewed
-	if r.VerdictBool != nil && !unreadable {
+	noVerdict := ClassifyOutput(r.Output) != OutputReviewed || isFreeFormJobType(jobType)
+	if r.VerdictBool != nil && !noVerdict {
 		verdictBool = 0
 		if *r.VerdictBool {
 			verdictBool = 1
 		}
-	} else if r.VerdictBool == nil {
+	} else if r.VerdictBool == nil && !noVerdict {
 		verdictBool = verdictBoolFromOutput(r.Output)
 	}
 	verdictOnConflict := "COALESCE(excluded.verdict_bool, reviews.verdict_bool)"
-	if unreadable {
+	if noVerdict {
 		verdictOnConflict = "NULL"
 	}
 	_, err = db.Exec(`
@@ -938,7 +940,8 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 func (db *DB) UpsertPulledResponse(r PulledResponse) error {
 	// First, find the job_id by uuid
 	var jobID int64
-	err := db.QueryRow(`SELECT id FROM review_jobs WHERE uuid = ?`, r.JobUUID).Scan(&jobID)
+	var jobType string
+	err := db.QueryRow(`SELECT id, job_type FROM review_jobs WHERE uuid = ?`, r.JobUUID).Scan(&jobID, &jobType)
 	if errors.Is(err, sql.ErrNoRows) {
 		// Job doesn't exist locally - skip this response (orphaned)
 		return nil

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -894,14 +894,23 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 	// A remote machine on an older release may have stored a verdict for
 	// output that never reviewed the code (an unreadable diff). Do not
 	// re-import that verdict; the row stays unrated here as it would locally.
+	// A NULL verdict normally keeps the local value on conflict, so an older
+	// sender that never sends verdict_bool cannot wipe a locally computed
+	// one. Unreadable output is the exception: that row must end unrated
+	// even if a legacy verdict was stored before.
 	var verdictBool any
-	if r.VerdictBool != nil && !IsUnreadableInput(r.Output) {
+	unreadable := IsUnreadableInput(r.Output)
+	if r.VerdictBool != nil && !unreadable {
 		verdictBool = 0
 		if *r.VerdictBool {
 			verdictBool = 1
 		}
 	} else if r.VerdictBool == nil {
 		verdictBool = verdictBoolFromOutput(r.Output)
+	}
+	verdictOnConflict := "COALESCE(excluded.verdict_bool, reviews.verdict_bool)"
+	if unreadable {
+		verdictOnConflict = "NULL"
 	}
 	_, err = db.Exec(`
 		INSERT INTO reviews (
@@ -911,7 +920,7 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(uuid) DO UPDATE SET
 			closed = excluded.closed,
-			verdict_bool = COALESCE(excluded.verdict_bool, reviews.verdict_bool),
+			verdict_bool = `+verdictOnConflict+`,
 			structured_output = COALESCE(excluded.structured_output, reviews.structured_output),
 			reviewed_file_count = COALESCE(excluded.reviewed_file_count, reviews.reviewed_file_count),
 			excluded_file_count = COALESCE(excluded.excluded_file_count, reviews.excluded_file_count),

--- a/internal/storage/sync.go
+++ b/internal/storage/sync.go
@@ -898,7 +898,9 @@ func (db *DB) UpsertPulledReview(r PulledReview) error {
 			verdictBool = 1
 		}
 	} else if r.Output != "" {
-		verdictBool = verdictToBool(ParseVerdict(r.Output))
+		if verdict := ParseVerdict(r.Output); verdict != VerdictUnknown {
+			verdictBool = verdictToBool(verdict)
+		}
 	}
 	_, err = db.Exec(`
 		INSERT INTO reviews (

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -595,6 +595,28 @@ func TestUpsertPulledReviewUsesStoredVerdict(t *testing.T) {
 	assert.Equal(t, VerdictFail, review.Verdict())
 }
 
+func TestUpsertPulledReviewLeavesUnknownVerdictUnset(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createPendingJob("unknown-review-verdict")
+
+	require.NoError(t, h.db.UpsertPulledReview(PulledReview{
+		UUID:               testUUID("unknown-review-verdict"),
+		JobUUID:            *job.UUID,
+		Agent:              "test",
+		Prompt:             "prompt",
+		Output:             "Review completed without a verdict.",
+		UpdatedByMachineID: testUUID("unknown-review-machine"),
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}))
+
+	var verdict sql.NullInt64
+	require.NoError(t, h.db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID,
+	).Scan(&verdict))
+	assert.False(t, verdict.Valid, "unknown verdict must remain NULL")
+}
+
 // TestGetCommentsToSync_RequiresJobSynced verifies that responses are only
 // returned when their parent job has been synced (j.synced_at IS NOT NULL).
 func TestGetCommentsToSync_RequiresJobSynced(t *testing.T) {

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -839,3 +839,25 @@ func TestSyncedReviewVerdictDropsVerdictOnNonReviewOutput(t *testing.T) {
 	assert.True(noReview)
 	assert.Nil(verdict)
 }
+
+func TestUpsertPulledReviewLeavesTaskOutputUnrated(t *testing.T) {
+	h := newSyncTestHelper(t)
+	repo := createRepo(t, h.db, "/tmp/sync-task-repo")
+	job, err := h.db.EnqueueJob(EnqueueOpts{
+		RepoID: repo.ID, GitRef: "prompt", Agent: "test",
+		Prompt: "summarize", JobType: JobTypeTask,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, job.UUID)
+
+	require.NoError(t, h.db.UpsertPulledReview(PulledReview{
+		UUID: testUUID("task-pulled-review"), JobUUID: *job.UUID,
+		Agent: "test", Prompt: "prompt", Output: "Task done. No issues found.",
+		VerdictBool: new(true), UpdatedByMachineID: testUUID("task-machine"),
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}))
+
+	var verdict sql.NullInt64
+	require.NoError(t, h.db.QueryRow(`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID).Scan(&verdict))
+	assert.False(t, verdict.Valid, "task output must stay unrated on pull, as it does locally")
+}

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -604,7 +604,7 @@ func TestUpsertPulledReviewLeavesUnknownVerdictUnset(t *testing.T) {
 		JobUUID:            *job.UUID,
 		Agent:              "test",
 		Prompt:             "prompt",
-		Output:             "Review completed without a verdict.",
+		Output:             "I am unable to read the diff file because it is ignored by configured ignore patterns.",
 		UpdatedByMachineID: testUUID("unknown-review-machine"),
 		CreatedAt:          time.Now(),
 		UpdatedAt:          time.Now(),

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -618,6 +618,38 @@ func TestUpsertPulledReviewDropsVerdictOnUnreadableOutput(t *testing.T) {
 	assert.False(t, verdict.Valid, "a remote fail verdict on unreadable output must not be imported")
 }
 
+func TestUpsertPulledReviewClearsLegacyVerdictOnUnreadableUpdate(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createPendingJob("unreadable-pulled-conflict")
+	const unreadable = "I am unable to read the diff file because it is ignored by configured ignore patterns."
+	first := time.Now().Add(-time.Minute)
+
+	// A legacy row stored the unreadable output with a fail verdict.
+	require.NoError(t, h.db.UpsertPulledReview(PulledReview{
+		UUID: testUUID("unreadable-pulled-conflict"), JobUUID: *job.UUID,
+		Agent: "test", Prompt: "prompt", Output: "- High: placeholder finding",
+		VerdictBool: new(false), UpdatedByMachineID: testUUID("legacy-machine"),
+		CreatedAt: first, UpdatedAt: first,
+	}))
+	_, err := h.db.Exec(`UPDATE reviews SET output = ?, verdict_bool = 0 WHERE uuid = ?`,
+		unreadable, testUUID("unreadable-pulled-conflict"))
+	require.NoError(t, err)
+
+	// A newer version of the same review arrives with the unreadable output.
+	require.NoError(t, h.db.UpsertPulledReview(PulledReview{
+		UUID: testUUID("unreadable-pulled-conflict"), JobUUID: *job.UUID,
+		Agent: "test", Prompt: "prompt", Output: unreadable,
+		VerdictBool: new(false), UpdatedByMachineID: testUUID("legacy-machine"),
+		CreatedAt: first, UpdatedAt: time.Now(),
+	}))
+
+	var verdict sql.NullInt64
+	require.NoError(t, h.db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID,
+	).Scan(&verdict))
+	assert.False(t, verdict.Valid, "conflict update must clear a legacy verdict on unreadable output")
+}
+
 func TestUpsertPulledReviewLeavesUnknownVerdictUnset(t *testing.T) {
 	h := newSyncTestHelper(t)
 	job := h.createPendingJob("unknown-review-verdict")

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -595,6 +595,29 @@ func TestUpsertPulledReviewUsesStoredVerdict(t *testing.T) {
 	assert.Equal(t, VerdictFail, review.Verdict())
 }
 
+func TestUpsertPulledReviewDropsVerdictOnUnreadableOutput(t *testing.T) {
+	h := newSyncTestHelper(t)
+	job := h.createPendingJob("unreadable-pulled-verdict")
+
+	require.NoError(t, h.db.UpsertPulledReview(PulledReview{
+		UUID:               testUUID("unreadable-pulled-verdict"),
+		JobUUID:            *job.UUID,
+		Agent:              "test",
+		Prompt:             "prompt",
+		Output:             "I am unable to read the diff file because it is ignored by configured ignore patterns.",
+		VerdictBool:        new(false),
+		UpdatedByMachineID: testUUID("unreadable-pulled-machine"),
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}))
+
+	var verdict sql.NullInt64
+	require.NoError(t, h.db.QueryRow(
+		`SELECT verdict_bool FROM reviews WHERE job_id = ?`, job.ID,
+	).Scan(&verdict))
+	assert.False(t, verdict.Valid, "a remote fail verdict on unreadable output must not be imported")
+}
+
 func TestUpsertPulledReviewLeavesUnknownVerdictUnset(t *testing.T) {
 	h := newSyncTestHelper(t)
 	job := h.createPendingJob("unknown-review-verdict")

--- a/internal/storage/sync_ordering_test.go
+++ b/internal/storage/sync_ordering_test.go
@@ -820,3 +820,22 @@ func TestSyncOrder_FullWorkflow(t *testing.T) {
 
 	assert.Len(t, responses, 3)
 }
+
+func TestSyncedReviewVerdictDropsVerdictOnNonReviewOutput(t *testing.T) {
+	assert := assert.New(t)
+	fail := false
+
+	verdict, noReview := syncedReviewVerdict(SyncableReview{Output: "- High: bug in a.go:1", VerdictBool: &fail})
+	assert.False(noReview)
+	assert.Equal(&fail, verdict)
+
+	verdict, noReview = syncedReviewVerdict(SyncableReview{
+		Output: "I am unable to read the diff file because it is ignored by configured ignore patterns.", VerdictBool: &fail,
+	})
+	assert.True(noReview)
+	assert.Nil(verdict)
+
+	verdict, noReview = syncedReviewVerdict(SyncableReview{Output: "No review output generated", VerdictBool: &fail})
+	assert.True(noReview)
+	assert.Nil(verdict)
+}

--- a/internal/storage/sync_test_helpers_test.go
+++ b/internal/storage/sync_test_helpers_test.go
@@ -59,7 +59,11 @@ func (h *syncTestHelper) createCompletedJob(sha string) *ReviewJob {
 	require.NoError(h.t, err, "Failed to claim job")
 	require.NotNil(h.t, claimed, "ClaimJob returned nil job")
 	require.Equal(h.t, job.ID, claimed.ID, "Claimed wrong job")
-	err = h.db.CompleteJob(job.ID, "test", "prompt", "output")
+	err = h.db.CompleteJobResult(
+		job.ID, "test", "prompt", ReviewCompletion{
+			Output: "output", Verdict: VerdictFail,
+		},
+	)
 	require.NoError(h.t, err, "Failed to complete job")
 	return job
 }

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -80,6 +80,9 @@ func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, h
 		return
 	}
 	verdict := verdictFromBoolOrParse(verdictBool, output)
+	if verdict == VerdictUnknown {
+		return
+	}
 	value := string(verdict)
 	job.Verdict = &value
 }

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -84,7 +84,8 @@ func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, h
 	job.Verdict = &value
 }
 
-// ParseVerdict extracts P (pass) or F (fail) from review output.
+// ParseVerdict extracts P (pass) or F (fail) from review output. Output without
+// a clear verdict signal returns VerdictUnknown.
 // It intentionally uses a small set of deterministic signals:
 // clear severity/findings markers mean fail, and clear pass phrases mean pass.
 // We do not try to interpret narrative caveats after "No issues found." because
@@ -106,6 +107,7 @@ func ParseVerdict(output string) Verdict {
 		return VerdictPass
 	}
 
+	sawFail := strings.Contains(output, config.SeverityThresholdMarker)
 	for line := range strings.SplitSeq(output, "\n") {
 		normalized := normalizeVerdictLine(line)
 		// Historical reviews sometimes include a stale "Verdict: Fail" header
@@ -117,12 +119,17 @@ func ParseVerdict(output string) Verdict {
 		if isNoFindingVerdictLine(normalized) {
 			return VerdictPass
 		}
-		if !hasPassPrefix(normalized) {
-			continue
+		if hasPassPrefix(normalized) {
+			return VerdictPass
 		}
-		return VerdictPass
+		if isExplicitVerdictValue(normalized, "fail") {
+			sawFail = true
+		}
 	}
-	return VerdictFail
+	if sawFail {
+		return VerdictFail
+	}
+	return VerdictUnknown
 }
 
 func normalizeVerdictLine(line string) string {

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -140,6 +140,11 @@ func ClassifyOutput(output string) OutputKind {
 	if trimmed == "" || trimmed == NoReviewOutputPlaceholder {
 		return OutputEmpty
 	}
+	// A severity-labelled finding is a real review even if the agent also
+	// says part of the input was unreadable.
+	if hasSeverityLabel(trimmed) {
+		return OutputReviewed
+	}
 	lower := strings.ReplaceAll(strings.ToLower(trimmed), "\u2019", "'")
 	for _, phrase := range unreadableInputPhrases {
 		if strings.Contains(lower, phrase) {
@@ -185,16 +190,14 @@ func verdictBoolFromOutput(output string) any {
 // too chatty or mixes process narration with findings, that should be fixed in
 // the review prompt rather than by adding more verdict heuristics here.
 func ParseVerdict(output string) Verdict {
-	// First check for severity labels which indicate actual findings
-	// These appear as "- Medium —", "* Low:", "Critical -", etc.
-	// A labelled finding is a real review even if part of the input was
-	// unreadable, so this check runs before the output classification.
-	if hasSeverityLabel(output) {
-		return VerdictFail
-	}
-
 	if ClassifyOutput(output) != OutputReviewed {
 		return VerdictUnknown
+	}
+
+	// Severity labels indicate actual findings. They appear as
+	// "- Medium —", "* Low:", "Critical -", etc.
+	if hasSeverityLabel(output) {
+		return VerdictFail
 	}
 
 	// Marker signals pass ONLY when it stands alone. A loose

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -168,6 +168,12 @@ func NoReviewLikeClauses(column string) (string, []any) {
 	return strings.Join(clauses, " OR "), args
 }
 
+// isFreeFormJobType reports whether a job's output is free-form prose that
+// never carries a verdict (task and insights jobs).
+func isFreeFormJobType(jobType string) bool {
+	return jobType == JobTypeTask || jobType == JobTypeInsights
+}
+
 // verdictBoolFromOutput returns the verdict_bool column value for review
 // output: 1 or 0 for a parsed verdict, nil (SQL NULL) when the output carries
 // no verdict.

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -87,19 +87,84 @@ func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, h
 	job.Verdict = &value
 }
 
-// ParseVerdict extracts P (pass) or F (fail) from review output. Output without
-// a clear verdict signal returns VerdictUnknown.
+// unreadableInputPhrases are deterministic signals that the agent never saw
+// the diff it was asked to review. Output containing one of these and no
+// severity-labelled finding is not a review at all, so it must not record a
+// verdict even when the agent appends a reflexive "No issues found."
+var unreadableInputPhrases = []string{
+	"unable to read the diff",
+	"unable to access the diff",
+	"cannot read the diff",
+	"can't read the diff",
+	"could not read the diff",
+	"couldn't read the diff",
+	"failed to read the diff",
+	"no diff was provided",
+	"ignored by configured ignore patterns",
+}
+
+// IsUnreadableInput reports whether review output says the agent could not
+// read its input diff.
+func IsUnreadableInput(output string) bool {
+	lower := strings.ToLower(output)
+	lower = strings.ReplaceAll(lower, "\u2019", "'")
+	for _, phrase := range unreadableInputPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// UnreadableInputLikeClauses returns SQL predicates, one per unreadable-input
+// phrase, that prefilter review rows whose lower-cased output may match
+// IsUnreadableInput. The caller ANDs them under an OR and binds args in order.
+func UnreadableInputLikeClauses(column string) (string, []any) {
+	clauses := make([]string, 0, len(unreadableInputPhrases))
+	args := make([]any, 0, len(unreadableInputPhrases))
+	for _, phrase := range unreadableInputPhrases {
+		clauses = append(clauses, "lower("+column+") LIKE '%' || ? || '%'")
+		args = append(args, phrase)
+	}
+	return strings.Join(clauses, " OR "), args
+}
+
+// verdictBoolFromOutput returns the verdict_bool column value for review
+// output: 1 or 0 for a parsed verdict, nil (SQL NULL) when the output carries
+// no verdict.
+func verdictBoolFromOutput(output string) any {
+	verdict := ParseVerdict(output)
+	if verdict == VerdictUnknown {
+		return nil
+	}
+	return verdictToBool(verdict)
+}
+
+// ParseVerdict extracts P (pass) or F (fail) from review output. Empty output
+// and output that says the diff could not be read return VerdictUnknown so the
+// caller can treat the job as never reviewed instead of clean or failed.
 // It intentionally uses a small set of deterministic signals:
 // clear severity/findings markers mean fail, and clear pass phrases mean pass.
+// Anything else defaults to fail so prose findings without labels are kept.
 // We do not try to interpret narrative caveats after "No issues found." because
 // that quickly turns into a brittle natural-language parser. If agent output is
 // too chatty or mixes process narration with findings, that should be fixed in
 // the review prompt rather than by adding more verdict heuristics here.
 func ParseVerdict(output string) Verdict {
+	if strings.TrimSpace(output) == "" {
+		return VerdictUnknown
+	}
+
 	// First check for severity labels which indicate actual findings
 	// These appear as "- Medium —", "* Low:", "Critical -", etc.
+	// A labelled finding is a real review even if part of the input was
+	// unreadable, so this check runs before the unreadable-input check.
 	if hasSeverityLabel(output) {
 		return VerdictFail
+	}
+
+	if IsUnreadableInput(output) {
+		return VerdictUnknown
 	}
 
 	// Marker signals pass ONLY when it stands alone. A loose
@@ -110,7 +175,6 @@ func ParseVerdict(output string) Verdict {
 		return VerdictPass
 	}
 
-	sawFail := strings.Contains(output, config.SeverityThresholdMarker)
 	for line := range strings.SplitSeq(output, "\n") {
 		normalized := normalizeVerdictLine(line)
 		// Historical reviews sometimes include a stale "Verdict: Fail" header
@@ -125,14 +189,8 @@ func ParseVerdict(output string) Verdict {
 		if hasPassPrefix(normalized) {
 			return VerdictPass
 		}
-		if isExplicitVerdictValue(normalized, "fail") {
-			sawFail = true
-		}
 	}
-	if sawFail {
-		return VerdictFail
-	}
-	return VerdictUnknown
+	return VerdictFail
 }
 
 func normalizeVerdictLine(line string) string {

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -87,14 +87,40 @@ func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, h
 	job.Verdict = &value
 }
 
-// unreadableInputPhrases are deterministic signals that the agent never
-// produced a review: it could not see the diff, or it printed nothing. Output containing one of these and no
-// severity-labelled finding is not a review at all, so it must not record a
-// verdict even when the agent appends a reflexive "No issues found."
+// OutputKind classifies agent output before any verdict is parsed from it.
+// Only OutputReviewed carries a verdict; the other kinds mean no review
+// happened, whatever the text says afterwards.
+type OutputKind int
+
+const (
+	// OutputReviewed is ordinary review text; parse it for a verdict.
+	OutputReviewed OutputKind = iota
+	// OutputEmpty means the agent produced nothing: blank output, or the fixed
+	// placeholder every adapter returns when the process printed nothing.
+	OutputEmpty
+	// OutputUnreadableInput means the agent said it could not read its diff.
+	OutputUnreadableInput
+)
+
+func (k OutputKind) String() string {
+	switch k {
+	case OutputEmpty:
+		return "empty output"
+	case OutputUnreadableInput:
+		return "unreadable input"
+	default:
+		return "reviewed"
+	}
+}
+
+// NoReviewOutputPlaceholder is the text agent adapters return when the agent
+// process printed nothing at all.
+const NoReviewOutputPlaceholder = "No review output generated"
+
+// unreadableInputPhrases are deterministic signals that the agent never saw
+// the diff it was asked to review. They win over any pass phrase that
+// follows, such as a reflexive "No issues found."
 var unreadableInputPhrases = []string{
-	// Every agent adapter returns this fixed text when the process printed
-	// nothing at all; it is an empty review, not a finding.
-	"no review output generated",
 	"unable to read the diff",
 	"unable to access the diff",
 	"cannot read the diff",
@@ -106,26 +132,31 @@ var unreadableInputPhrases = []string{
 	"ignored by configured ignore patterns",
 }
 
-// IsUnreadableInput reports whether review output says the agent could not
-// read its input diff.
-func IsUnreadableInput(output string) bool {
-	lower := strings.ToLower(output)
-	lower = strings.ReplaceAll(lower, "\u2019", "'")
+// ClassifyOutput is the single place that decides whether agent output is a
+// review at all. Every path that turns output into a verdict, whether fresh
+// from an agent or already stored, asks this function.
+func ClassifyOutput(output string) OutputKind {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" || trimmed == NoReviewOutputPlaceholder {
+		return OutputEmpty
+	}
+	lower := strings.ReplaceAll(strings.ToLower(trimmed), "\u2019", "'")
 	for _, phrase := range unreadableInputPhrases {
 		if strings.Contains(lower, phrase) {
-			return true
+			return OutputUnreadableInput
 		}
 	}
-	return false
+	return OutputReviewed
 }
 
-// UnreadableInputLikeClauses returns SQL predicates, one per unreadable-input
-// phrase, that prefilter review rows whose lower-cased output may match
-// IsUnreadableInput. The caller ANDs them under an OR and binds args in order.
-func UnreadableInputLikeClauses(column string) (string, []any) {
-	clauses := make([]string, 0, len(unreadableInputPhrases))
-	args := make([]any, 0, len(unreadableInputPhrases))
-	for _, phrase := range unreadableInputPhrases {
+// NoReviewLikeClauses returns SQL predicates that prefilter review rows whose
+// output may classify as anything other than OutputReviewed. The caller ORs
+// them and binds args in order; ClassifyOutput makes the final call.
+func NoReviewLikeClauses(column string) (string, []any) {
+	phrases := append([]string{strings.ToLower(NoReviewOutputPlaceholder)}, unreadableInputPhrases...)
+	clauses := make([]string, 0, len(phrases))
+	args := make([]any, 0, len(phrases))
+	for _, phrase := range phrases {
 		clauses = append(clauses, "lower("+column+") LIKE '%' || ? || '%'")
 		args = append(args, phrase)
 	}
@@ -143,8 +174,8 @@ func verdictBoolFromOutput(output string) any {
 	return verdictToBool(verdict)
 }
 
-// ParseVerdict extracts P (pass) or F (fail) from review output. Empty output
-// and output that says the diff could not be read return VerdictUnknown so the
+// ParseVerdict extracts P (pass) or F (fail) from review output. Output that
+// ClassifyOutput does not consider a review returns VerdictUnknown so the
 // caller can treat the job as never reviewed instead of clean or failed.
 // It intentionally uses a small set of deterministic signals:
 // clear severity/findings markers mean fail, and clear pass phrases mean pass.
@@ -154,19 +185,15 @@ func verdictBoolFromOutput(output string) any {
 // too chatty or mixes process narration with findings, that should be fixed in
 // the review prompt rather than by adding more verdict heuristics here.
 func ParseVerdict(output string) Verdict {
-	if strings.TrimSpace(output) == "" {
-		return VerdictUnknown
-	}
-
 	// First check for severity labels which indicate actual findings
 	// These appear as "- Medium —", "* Low:", "Critical -", etc.
 	// A labelled finding is a real review even if part of the input was
-	// unreadable, so this check runs before the unreadable-input check.
+	// unreadable, so this check runs before the output classification.
 	if hasSeverityLabel(output) {
 		return VerdictFail
 	}
 
-	if IsUnreadableInput(output) {
+	if ClassifyOutput(output) != OutputReviewed {
 		return VerdictUnknown
 	}
 

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -87,11 +87,14 @@ func applyJobVerdict(job *ReviewJob, verdictBool sql.NullInt64, output string, h
 	job.Verdict = &value
 }
 
-// unreadableInputPhrases are deterministic signals that the agent never saw
-// the diff it was asked to review. Output containing one of these and no
+// unreadableInputPhrases are deterministic signals that the agent never
+// produced a review: it could not see the diff, or it printed nothing. Output containing one of these and no
 // severity-labelled finding is not a review at all, so it must not record a
 // verdict even when the agent appends a reflexive "No issues found."
 var unreadableInputPhrases = []string{
+	// Every agent adapter returns this fixed text when the process printed
+	// nothing at all; it is an empty review, not a finding.
+	"no review output generated",
 	"unable to read the diff",
 	"unable to access the diff",
 	"cannot read the diff",

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -608,26 +608,40 @@ var verdictTests = []verdictTestCase{
 		want: VerdictPass,
 	},
 
-	// Failures should come from clear structured findings or from the absence of a
-	// clear pass phrase. We intentionally avoid sentence-level caveat parsing.
+	// Output without a clear pass or fail signal did not produce a review verdict.
 	{
-		name:   "FailFallback/empty output",
+		name:   "Unknown/empty output",
 		output: "",
-		want:   VerdictFail,
+		want:   VerdictUnknown,
 	},
 	{
-		name:   "FailFallback/ambiguous language",
+		name:   "Unknown/ambiguous language",
 		output: "The commit looks mostly fine but could use some cleanup.",
-		want:   VerdictFail,
+		want:   VerdictUnknown,
 	},
 	{
-		name:   "FailFallback/narrative front matter without final verdict defaults to fail",
+		name:   "Unknown/narrative front matter without final verdict",
 		output: "Reviewing the diff in context first. I'm opening the touched storage parsing code and adjacent tests to check for regressions.",
+		want:   VerdictUnknown,
+	},
+	{
+		name:   "Unknown/unstructured issue statement",
+		output: "The code has issues.",
+		want:   VerdictUnknown,
+	},
+	{
+		name:   "Unknown/diff could not be read",
+		output: "I am unable to read the diff file because it is ignored by configured ignore patterns.",
+		want:   VerdictUnknown,
+	},
+	{
+		name:   "ExplicitFail/plain verdict",
+		output: "Verdict: FAIL",
 		want:   VerdictFail,
 	},
 	{
-		name:   "FailFallback/unstructured issue statement defaults to fail",
-		output: "The code has issues.",
+		name:   "ExplicitFail/markdown verdict",
+		output: "## Verdict: Fail",
 		want:   VerdictFail,
 	},
 

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -655,6 +655,11 @@ var verdictTests = []verdictTestCase{
 		want:   VerdictUnknown,
 	},
 	{
+		name:   "Unreadable/empty agent output placeholder",
+		output: "No review output generated",
+		want:   VerdictUnknown,
+	},
+	{
 		name:   "Unreadable/severity label still reports findings",
 		output: "Note: I was unable to read the diff for vendor/, reviewed the rest.\n\n- Medium: nil deref in main.go:42",
 		want:   VerdictFail,

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -615,24 +615,49 @@ var verdictTests = []verdictTestCase{
 		want:   VerdictUnknown,
 	},
 	{
-		name:   "Unknown/ambiguous language",
+		name:   "Unknown/whitespace only",
+		output: "  \n\t\n",
+		want:   VerdictUnknown,
+	},
+	{
+		name:   "FailFallback/ambiguous language",
 		output: "The commit looks mostly fine but could use some cleanup.",
-		want:   VerdictUnknown,
+		want:   VerdictFail,
 	},
 	{
-		name:   "Unknown/narrative front matter without final verdict",
+		name:   "FailFallback/narrative front matter without final verdict",
 		output: "Reviewing the diff in context first. I'm opening the touched storage parsing code and adjacent tests to check for regressions.",
-		want:   VerdictUnknown,
+		want:   VerdictFail,
 	},
 	{
-		name:   "Unknown/unstructured issue statement",
+		name:   "FailFallback/unstructured issue statement defaults to fail",
 		output: "The code has issues.",
-		want:   VerdictUnknown,
+		want:   VerdictFail,
 	},
 	{
-		name:   "Unknown/diff could not be read",
+		name:   "Unreadable/diff could not be read",
 		output: "I am unable to read the diff file because it is ignored by configured ignore patterns.",
 		want:   VerdictUnknown,
+	},
+	{
+		name:   "Unreadable/could not read wins over later pass phrase",
+		output: "I could not read the diff at the given path.\n\nNo issues found.",
+		want:   VerdictUnknown,
+	},
+	{
+		name:   "Unreadable/ignore pattern wins over explicit pass verdict",
+		output: "The file is ignored by configured ignore patterns, so I skipped it.\n\nVerdict: PASS",
+		want:   VerdictUnknown,
+	},
+	{
+		name:   "Unreadable/curly apostrophe",
+		output: "I can\u2019t read the diff you referenced.",
+		want:   VerdictUnknown,
+	},
+	{
+		name:   "Unreadable/severity label still reports findings",
+		output: "Note: I was unable to read the diff for vendor/, reviewed the rest.\n\n- Medium: nil deref in main.go:42",
+		want:   VerdictFail,
 	},
 	{
 		name:   "ExplicitFail/plain verdict",

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -824,6 +824,7 @@ func TestClassifyOutput(t *testing.T) {
 	assert.Equal(OutputUnreadableInput, ClassifyOutput("The file is ignored by configured ignore patterns."))
 	assert.Equal(OutputReviewed, ClassifyOutput("No issues found."))
 	assert.Equal(OutputReviewed, ClassifyOutput("- High: nil deref in a.go:1"))
+	assert.Equal(OutputReviewed, ClassifyOutput("I was unable to read the diff for vendor/.\n\n- Medium: nil deref in main.go:42"))
 	assert.Equal("empty output", OutputEmpty.String())
 	assert.Equal("unreadable input", OutputUnreadableInput.String())
 }

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -815,6 +815,19 @@ var verdictTests = []verdictTestCase{
 	},
 }
 
+func TestClassifyOutput(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(OutputEmpty, ClassifyOutput(""))
+	assert.Equal(OutputEmpty, ClassifyOutput("  \n"))
+	assert.Equal(OutputEmpty, ClassifyOutput(" No review output generated \n"))
+	assert.Equal(OutputUnreadableInput, ClassifyOutput("I couldn\u2019t read the diff."))
+	assert.Equal(OutputUnreadableInput, ClassifyOutput("The file is ignored by configured ignore patterns."))
+	assert.Equal(OutputReviewed, ClassifyOutput("No issues found."))
+	assert.Equal(OutputReviewed, ClassifyOutput("- High: nil deref in a.go:1"))
+	assert.Equal("empty output", OutputEmpty.String())
+	assert.Equal("unreadable input", OutputUnreadableInput.String())
+}
+
 func TestParseVerdict(t *testing.T) {
 	runVerdictTests(t, verdictTests)
 }

--- a/internal/structuredreview/document.go
+++ b/internal/structuredreview/document.go
@@ -5,12 +5,33 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 )
 
 const SchemaVersion = 1
 
-var Schema = json.RawMessage(fmt.Sprintf(`{
+// Schema constrains a single reviewer's output.
+var Schema = schema(false)
+
+// SourcedSchema additionally requires every finding to cite the 1-based
+// numbers of the input reviews that reported it. Synthesis uses it so a
+// combined finding keeps its provenance.
+var SourcedSchema = schema(true)
+
+func schema(withSources bool) json.RawMessage {
+	required := `["severity", "problem", "fix", "location"]`
+	sources := ""
+	if withSources {
+		required = `["severity", "problem", "fix", "location", "sources"]`
+		sources = `,
+          "sources": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "integer", "minimum": 1}
+          }`
+	}
+	return json.RawMessage(fmt.Sprintf(`{
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "summary", "findings"],
@@ -22,7 +43,7 @@ var Schema = json.RawMessage(fmt.Sprintf(`{
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["severity", "problem", "fix", "location"],
+        "required": %s,
         "properties": {
           "severity": {
             "type": "string",
@@ -30,17 +51,22 @@ var Schema = json.RawMessage(fmt.Sprintf(`{
           },
           "problem": {"type": "string", "minLength": 1},
           "fix": {"type": "string", "minLength": 1},
-          "location": {"type": ["string", "null"]}
+          "location": {"type": ["string", "null"]}%s
         }
       }
     }
   }
-}`, SchemaVersion))
+}`, SchemaVersion, required, sources))
+}
 
 type Document struct {
 	SchemaVersion int       `json:"schema_version"`
 	Summary       string    `json:"summary"`
 	Findings      []Finding `json:"findings"`
+	// SourceLabels names the input reviews a sourced document cites, indexed
+	// by review number minus one. It is caller-provided, never decoded, and
+	// only used when rendering Markdown.
+	SourceLabels []string `json:"-"`
 }
 
 type Finding struct {
@@ -48,6 +74,8 @@ type Finding struct {
 	Problem  string `json:"problem"`
 	Fix      string `json:"fix"`
 	Location string `json:"location,omitempty"`
+	// Sources holds 1-based input review numbers for a sourced document.
+	Sources []int `json:"sources,omitempty"`
 }
 
 type documentWire struct {
@@ -61,6 +89,7 @@ type findingWire struct {
 	Problem  string          `json:"problem"`
 	Fix      string          `json:"fix"`
 	Location json.RawMessage `json:"location"`
+	Sources  []int           `json:"sources"`
 }
 
 func Decode(raw json.RawMessage) (Document, error) {
@@ -100,6 +129,7 @@ func Decode(raw json.RawMessage) (Document, error) {
 			Problem:  finding.Problem,
 			Fix:      finding.Fix,
 			Location: location,
+			Sources:  finding.Sources,
 		}
 	}
 	if result.SchemaVersion != SchemaVersion {
@@ -138,6 +168,26 @@ func Decode(raw json.RawMessage) (Document, error) {
 	return result, nil
 }
 
+// RequireSources validates a sourced document: every finding must cite at
+// least one input review, and every citation must fall within the count of
+// input reviews.
+func (r Document) RequireSources(reviewCount int) error {
+	for i, finding := range r.Findings {
+		if len(finding.Sources) == 0 {
+			return fmt.Errorf("structured review finding %d cites no source review", i+1)
+		}
+		for _, n := range finding.Sources {
+			if n < 1 || n > reviewCount {
+				return fmt.Errorf(
+					"structured review finding %d cites review %d, but only %d reviews were provided",
+					i+1, n, reviewCount,
+				)
+			}
+		}
+	}
+	return nil
+}
+
 func ensureEOF(dec *json.Decoder) error {
 	var extra any
 	err := dec.Decode(&extra)
@@ -159,6 +209,7 @@ func (r Document) Filter(minSeverity string) Document {
 		SchemaVersion: r.SchemaVersion,
 		Summary:       r.Summary,
 		Findings:      make([]Finding, 0, len(r.Findings)),
+		SourceLabels:  r.SourceLabels,
 	}
 	for _, finding := range r.Findings {
 		if severityRank(finding.Severity) >= threshold {
@@ -188,8 +239,28 @@ func (r Document) Markdown() string {
 		}
 		fmt.Fprintf(&out, "**Problem:** %s\n\n", finding.Problem)
 		fmt.Fprintf(&out, "**Fix:** %s\n", finding.Fix)
+		if labels := r.sourceLabels(finding); len(labels) > 0 {
+			fmt.Fprintf(&out, "\n**Reported by:** %s\n", strings.Join(labels, ", "))
+		}
 	}
 	return out.String()
+}
+
+// sourceLabels resolves a finding's review numbers to caller-provided labels,
+// in citation order without duplicates. Numbers without a label are skipped.
+func (r Document) sourceLabels(finding Finding) []string {
+	labels := make([]string, 0, len(finding.Sources))
+	for _, n := range finding.Sources {
+		if n < 1 || n > len(r.SourceLabels) {
+			continue
+		}
+		label := r.SourceLabels[n-1]
+		if label == "" || slices.Contains(labels, label) {
+			continue
+		}
+		labels = append(labels, label)
+	}
+	return labels
 }
 
 func severityRank(severity string) int {

--- a/internal/structuredreview/document.go
+++ b/internal/structuredreview/document.go
@@ -78,6 +78,23 @@ type Finding struct {
 	Sources []int `json:"sources,omitempty"`
 }
 
+// MarshalJSON emits an empty Location as JSON null so an encoded document
+// stays valid under Schema, which requires the field on every finding.
+func (f Finding) MarshalJSON() ([]byte, error) {
+	type wire struct {
+		Severity string  `json:"severity"`
+		Problem  string  `json:"problem"`
+		Fix      string  `json:"fix"`
+		Location *string `json:"location"`
+		Sources  []int   `json:"sources,omitempty"`
+	}
+	w := wire{Severity: f.Severity, Problem: f.Problem, Fix: f.Fix, Sources: f.Sources}
+	if f.Location != "" {
+		w.Location = &f.Location
+	}
+	return json.Marshal(w)
+}
+
 type documentWire struct {
 	SchemaVersion int           `json:"schema_version"`
 	Summary       string        `json:"summary"`


### PR DESCRIPTION
## Summary

- Reviews whose agent answered "I am unable to read the diff" were stored as failed reviews, indistinguishable from a review that found a real problem. The verdict parser now recognizes that phrase family and returns no verdict for it, even when the agent appends "No issues found" afterward. Every other unlabelled prose review keeps its fail verdict, so real findings are never dropped.
- A built-in review that ends without a verdict no longer creates a review row. It skips same-agent retries, fails over to the backup agent at once, and otherwise fails with the `no-verdict: ` error prefix and the agent's own output preserved in the job error. Consumers can select these jobs directly, and CI panel status lines show the member as "no verdict".
- Startup normalization clears the stored verdict on already-recorded rows whose output matches the unreadable-diff phrases, so historical never-reviewed rows stop counting as failed reviews.
- Task and insights output is free-form and no longer receives a parsed verdict. Fix jobs keep their existing behavior.
- Compact jobs use their own response contract: a clean response records a pass, a response with listed findings records a fail, and invalid output follows the retry and failover flow.
- Panel synthesis returns the same schema-validated structured review document a single reviewer returns, with one addition: each finding cites the input reviews that reported it. The pass/fail verdict derives from the surviving findings, the severity threshold is enforced after decoding, and the rendered comment adds a "Reported by" line per finding. The synthesis agent dispatch is shared between the daemon and `ci review` instead of duplicated.
- Completion, startup normalization, and sync store SQL NULL when output carries no verdict, and readers leave that verdict unset.

Closes #1104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

