### PR TITLE
fix(ci): honor configured backups on quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,11 +285,9 @@ jobs:
           cache: ${{ github.repository == 'kenn-io/roborev' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Test with coverage
-        # -p 1 serializes package execution to avoid ROBOREV_DATA_DIR race conditions
-        # between tests in different packages that modify this environment variable.
         # Race coverage runs in the test and daemon-race jobs; repeating it here
         # makes the daemon package exceed its timeout without improving coverage.
-        run: go test -timeout 30m -shuffle=on -tags integration -p 1 -coverprofile=coverage.out ./...
+        run: go test -timeout 30m -shuffle=on -tags integration -coverprofile=coverage.out ./...
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -1084,7 +1083,7 @@ func TestSynthesisMultiSuccessRespectsCooldown(t *testing.T) {
 		"cooldown must divert before completing the synthesis")
 }
 
-func TestSynthesisCIReviewCooldownDoesNotFailOverToBackup(t *testing.T) {
+func TestSynthesisCIReviewCooldownFailsOverToBackup(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 
 	const memberAgent = "panel-ci-cd-member"
@@ -1115,10 +1114,9 @@ func TestSynthesisCIReviewCooldownDoesNotFailOverToBackup(t *testing.T) {
 	tc.Pool.processSynthesisJob(context.Background(), testWorkerID, synth)
 
 	assert.False(t, called, "CI synthesis must not invoke an agent in cooldown")
-	got := tc.assertJobStatus(t, synth.ID, storage.JobStatusFailed)
-	assert.Equal(t, synthAgent, got.Agent, "CI synthesis cooldown must not fail over to backup")
-	assert.True(t, strings.HasPrefix(got.Error, reviewpkg.QuotaErrorPrefix),
-		"cooldown failure should be a retryable quota skip, got %q", got.Error)
+	got := tc.assertJobStatus(t, synth.ID, storage.JobStatusQueued)
+	assert.Equal(t, "test", got.Agent)
+	assert.Empty(t, got.Error)
 }
 
 // TestSynthesisRunsAgainstWorktree verifies the synthesis agent runs against the

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1977,9 +1977,7 @@ func (wp *WorkerPool) failCooldownOrFailoverContext(
 	wp.failoverOrFailWithPrefixContext(workerID, job, agentName, errorMsg, review.QuotaErrorPrefix, "quota")
 }
 
-// failoverOrFail attempts failover to a backup agent for non-CI jobs. CI
-// reviews must preserve their configured panel member and let the CI retry
-// schedule handle quota/session availability failures.
+// failoverOrFail attempts failover to a configured backup agent.
 func (wp *WorkerPool) failoverOrFail(
 	workerID string, job *storage.ReviewJob,
 	agentName, errorMsg string,
@@ -2000,10 +1998,7 @@ func (wp *WorkerPool) failoverOrFailWithPrefixLocked(
 	workerID string, job *storage.ReviewJob,
 	agentName, errorMsg, prefix, label string,
 ) {
-	backupAgent := ""
-	if !job.IsCIReview() {
-		backupAgent = wp.resolveBackupAgent(job)
-	}
+	backupAgent := wp.resolveBackupAgent(job)
 	if backupAgent != "" && !wp.isAgentCoolingDown(backupAgent) {
 		backupModel := wp.resolveBackupModel(job)
 		failedOver, err := wp.db.FailoverJob(

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -2456,7 +2456,7 @@ func TestProcessJob_CooldownResolvesAlias(t *testing.T) {
 	tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
 }
 
-func TestProcessJob_CIReviewCooldownDoesNotFailOverToBackup(t *testing.T) {
+func TestProcessJob_CIReviewCooldownFailsOverToBackup(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)
 
@@ -2471,32 +2471,35 @@ func TestProcessJob_CIReviewCooldownDoesNotFailOverToBackup(t *testing.T) {
 
 	tc.Pool.processJob(testWorkerID, claimed)
 
-	updated := tc.assertJobStatus(t, claimed.ID, storage.JobStatusFailed)
+	updated := tc.assertJobStatus(t, claimed.ID, storage.JobStatusQueued)
 	assert := assert.New(t)
-	assert.Equal("codex", updated.Agent, "CI cooldown must not fail over to backup")
-	assert.True(strings.HasPrefix(updated.Error, review.QuotaErrorPrefix),
-		"cooldown failure should be a retryable quota skip, got %q", updated.Error)
+	assert.Equal("test", updated.Agent)
+	assert.Empty(updated.Error)
 }
 
-func TestFailOrRetryInner_CIQuotaDoesNotFailOverToBackup(t *testing.T) {
+func TestFailOrRetryInner_CIQuotaFailsOverToBackup(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	sha := testutil.GetHeadSHA(t, tc.TmpDir)
 
-	cfg := config.DefaultConfig()
-	cfg.DefaultBackupAgent = "test"
-	tc.reconfigurePool(cfg)
-
-	job := tc.createAndClaimJobWithAgent(t, sha, testWorkerID, "codex")
-	job.Source = storage.JobSourceCI
-	job.CIBaseBranch = "main"
+	job := tc.createJobWithAgent(t, sha, "codex")
+	_, err := tc.DB.Exec(
+		`UPDATE review_jobs
+		 SET source = ?, ci_base_branch = ?, backup_agent = ?, backup_model = ?
+		 WHERE id = ?`,
+		storage.JobSourceCI, "main", "test", "ci-backup-model", job.ID,
+	)
+	require.NoError(t, err)
+	job, err = tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.NotNil(t, job)
 
 	tc.Pool.failOrRetryAgent(testWorkerID, job, "codex", "resource exhausted: reset after 1h")
 
-	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusFailed)
+	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusQueued)
 	assert := assert.New(t)
-	assert.Equal("codex", updated.Agent, "CI quota must not fail over to backup")
-	assert.True(strings.HasPrefix(updated.Error, review.QuotaErrorPrefix),
-		"quota failure should be a retryable quota skip, got %q", updated.Error)
+	assert.Equal("test", updated.Agent)
+	assert.Equal("ci-backup-model", updated.Model)
+	assert.Empty(updated.Error)
 	assert.True(tc.Pool.isAgentCoolingDown("codex"), "quota should cool down the configured agent")
 }
 


### PR DESCRIPTION
CI review members and synthesis jobs now requeue under their configured backup
agent when the primary hits a quota, session limit, or active cooldown.
Previously, the worker ignored the backup already frozen onto CI jobs. That
contradicted the documented fallback behavior and could leave a pull request
without a review.

Failover uses the stored backup agent and its paired model. When no usable
backup exists, the existing quota skip and safe CI retry behavior remains
unchanged.

Coverage also lets Go run package tests concurrently again. The test harness
now isolates each package's data directory, so the old serialization only made
coverage slower and pushed the daemon package against its timeout.

Closes #1058
