### PR TITLE
feat: show release notes in local UIs

### DIFF
--- a/cmd/roborev/tui/control_types.go
+++ b/cmd/roborev/tui/control_types.go
@@ -104,6 +104,8 @@ func (v viewKind) String() string {
 		return "patch"
 	case viewColumnOptions:
 		return "column-options"
+	case viewReleaseNotes:
+		return "release-notes"
 	default:
 		return "unknown"
 	}

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	neturl "net/url"
 	"os"
@@ -381,6 +382,32 @@ func (m model) checkForUpdate() tea.Cmd {
 			return updateCheckMsg{} // No update or error
 		}
 		return updateCheckMsg{version: info.LatestVersion, isDevBuild: info.IsDevBuild}
+	}
+}
+
+func (m model) fetchReleaseNotes() tea.Cmd {
+	return func() tea.Msg {
+		req, err := http.NewRequestWithContext(
+			m.apiContext(), http.MethodGet, m.endpoint.BaseURL()+"/api/releases", nil,
+		)
+		if err != nil {
+			return releaseNotesErrMsg{err: err}
+		}
+		resp, err := m.client.Do(req)
+		if err != nil {
+			return releaseNotesErrMsg{err: err}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return releaseNotesErrMsg{err: fmt.Errorf(
+				"fetch release notes: %s", readErrorBody(resp.Body, resp.Status),
+			)}
+		}
+		var result daemon.ReleaseNotesResponse
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 2<<20)).Decode(&result); err != nil {
+			return releaseNotesErrMsg{err: fmt.Errorf("decode release notes: %w", err)}
+		}
+		return releaseNotesMsg{releases: result.Releases, stale: result.Stale}
 	}
 }
 

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -34,6 +34,8 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handlePatchKey(msg)
 	case viewColumnOptions:
 		return m.handleColumnOptionsInput(msg)
+	case viewReleaseNotes:
+		return m.handleReleaseNotesKey(msg)
 	}
 
 	// Review-scoped actions must not fire against a review the detail pane
@@ -228,6 +230,13 @@ func (m model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleBranchFilterOpenKey()
 	case "h":
 		return m.handleHideClosedKey()
+	case "u":
+		m.releaseNotesFromView = m.currentView
+		m.currentView = viewReleaseNotes
+		m.releaseNotesScroll = 0
+		m.releaseNotesLoading = true
+		m.releaseNotesErr = nil
+		return m, m.fetchReleaseNotes()
 	case "s":
 		return m.handleToggleClassifyKey()
 	case "c":

--- a/cmd/roborev/tui/release_notes.go
+++ b/cmd/roborev/tui/release_notes.go
@@ -1,0 +1,119 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/muesli/termenv"
+)
+
+func (m model) handleReleaseNotesKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m.handleQuitKey()
+	case "esc", "q":
+		m.currentView = m.releaseNotesFromView
+		return m, nil
+	case "u":
+		m.releaseNotesLoading = true
+		m.releaseNotesErr = nil
+		return m, m.fetchReleaseNotes()
+	case "home", "g":
+		m.releaseNotesScroll = 0
+	case "end", "G":
+		m.releaseNotesScroll = m.releaseNotesMaxScroll()
+	case "up", "k":
+		m.releaseNotesScroll = max(0, m.releaseNotesScroll-1)
+	case "down", "j":
+		m.releaseNotesScroll = min(m.releaseNotesMaxScroll(), m.releaseNotesScroll+1)
+	case "pgup":
+		m.releaseNotesScroll = max(0, m.releaseNotesScroll-m.releaseNotesVisibleLines())
+	case "pgdown":
+		m.releaseNotesScroll = min(
+			m.releaseNotesMaxScroll(),
+			m.releaseNotesScroll+m.releaseNotesVisibleLines(),
+		)
+	}
+	return m, nil
+}
+
+func (m model) releaseNotesVisibleLines() int {
+	return max(m.height-3, 5)
+}
+
+func (m model) releaseNotesLines() []string {
+	if m.releaseNotesLoading && len(m.releaseNotes) == 0 {
+		return []string{"Loading release notes..."}
+	}
+	if m.releaseNotesErr != nil && len(m.releaseNotes) == 0 {
+		return []string{
+			errorStyle.Render("Could not load release notes"),
+			m.releaseNotesErr.Error(),
+			"",
+			"Press u to retry.",
+		}
+	}
+	if len(m.releaseNotes) == 0 {
+		return []string{"No published releases found."}
+	}
+
+	var markdown strings.Builder
+	if m.releaseNotesStale {
+		markdown.WriteString("> GitHub could not be reached. Showing cached release notes.\n\n")
+	}
+	for i, release := range m.releaseNotes {
+		if i > 0 {
+			markdown.WriteString("\n---\n\n")
+		}
+		fmt.Fprintf(&markdown, "## %s\n\n", sanitizeForDisplay(release.Name))
+		fmt.Fprintf(&markdown, "`%s` · %s", sanitizeForDisplay(release.TagName), release.PublishedAt.Format("January 2, 2006"))
+		if release.Prerelease {
+			markdown.WriteString(" · prerelease")
+		}
+		markdown.WriteString("\n\n")
+		body := strings.TrimSpace(sanitizeForDisplay(release.Body))
+		if body == "" {
+			body = "No release notes were provided."
+		}
+		markdown.WriteString(body)
+		if release.HTMLURL != "" {
+			fmt.Fprintf(&markdown, "\n\n[View on GitHub](%s)\n", sanitizeForDisplay(release.HTMLURL))
+		}
+	}
+	profile := termenv.Ascii
+	if m.mdCache != nil {
+		profile = m.mdCache.colorProfile
+	}
+	return renderMarkdownLines(
+		markdown.String(), min(max(m.width-4, 20), 100), max(m.width, 20),
+		m.glamourStyle, 2, profile,
+	)
+}
+
+func (m model) releaseNotesMaxScroll() int {
+	return max(len(m.releaseNotesLines())-m.releaseNotesVisibleLines(), 0)
+}
+
+func (m model) renderReleaseNotesView() string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("Roborev release notes"))
+	b.WriteString("\x1b[K\n\x1b[K\n")
+
+	lines := m.releaseNotesLines()
+	visible := m.releaseNotesVisibleLines()
+	scroll := min(m.releaseNotesScroll, max(len(lines)-visible, 0))
+	end := min(scroll+visible, len(lines))
+	for _, line := range lines[scroll:end] {
+		b.WriteString(line)
+		b.WriteString("\x1b[K\n")
+	}
+	for i := end - scroll; i < visible; i++ {
+		b.WriteString("\x1b[K\n")
+	}
+	b.WriteString(renderHelpTable([][]helpItem{
+		{{"j/k", "scroll"}, {"pgup/pgdn", "page"}, {"u", "refresh"}, {"esc/q", "close"}},
+	}, m.width))
+	b.WriteString("\x1b[K\x1b[J")
+	return b.String()
+}

--- a/cmd/roborev/tui/release_notes_test.go
+++ b/cmd/roborev/tui/release_notes_test.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestReleaseNotesViewRendersAndCloses(t *testing.T) {
+	m := initTestModel(withCurrentView(viewReleaseNotes), withDimensions(100, 28))
+	m.releaseNotesFromView = viewQueue
+	m.releaseNotes = []storage.ReleaseNote{{
+		TagName: "v1.2.3", Name: "Roborev 1.2.3", Body: "## Changes\n\nFixed the queue.",
+		PublishedAt: time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC),
+	}}
+
+	output := m.renderReleaseNotesView()
+	assert.Contains(t, output, "Roborev 1.2.3")
+	assert.Contains(t, output, "Fixed the queue")
+
+	updated, _ := m.handleReleaseNotesKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	closed, ok := updated.(model)
+	require.True(t, ok)
+	assert.Equal(t, viewQueue, closed.currentView)
+}

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -520,7 +520,7 @@ func (m model) renderQueueView() string {
 			if m.updateIsDevBuild {
 				updateMsg = fmt.Sprintf("Dev build - latest release: %s - run 'roborev update --force'", m.updateAvailable)
 			} else {
-				updateMsg = fmt.Sprintf("Update available: %s - run 'roborev update'", m.updateAvailable)
+				updateMsg = fmt.Sprintf("Update available: %s - press u for notes or run 'roborev update'", m.updateAvailable)
 			}
 			b.WriteString(updateStyle.Render(updateMsg))
 		}

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -258,33 +258,39 @@ func sanitizeForDisplay(s string) string {
 }
 
 type model struct {
-	endpoint         daemon.DaemonEndpoint
-	daemonVersion    string
-	client           *http.Client
-	api              *roborevclient.Client
-	glamourStyle     gansi.StyleConfig // detected once at init
-	jobs             []storage.ReviewJob
-	jobStats         storage.JobStats       // aggregate done/closed/open from server
-	cost             *storage.CostAggregate // approx agent spend for the active filter scope; nil = hidden
-	costSeq          int                    // fetchSeq of the stored cost; segment hides until it matches m.fetchSeq
-	status           storage.DaemonStatus
-	selectedIdx      int
-	selectedJobID    int64                             // Track selected job by ID to maintain position on refresh
-	expandedPanels   map[uuid.UUID]bool                // panel_run_uuid -> expanded
-	panelMembers     map[uuid.UUID][]storage.ReviewJob // panel_run_uuid -> side-fetched members
-	currentView      viewKind
-	currentReview    *storage.Review
-	currentResponses []storage.Response // Responses for current review (fetched with review)
-	currentBranch    string             // Cached branch name for current review (computed on load)
-	reviewScroll     int
-	promptScroll     int
-	promptFromQueue  bool // true if prompt view was entered from queue (not review)
-	width            int
-	height           int
-	err              error
-	updateAvailable  string // Latest version if update available, empty if up to date
-	updateIsDevBuild bool   // True if running a dev build
-	versionMismatch  bool   // True if daemon version doesn't match TUI version
+	endpoint             daemon.DaemonEndpoint
+	daemonVersion        string
+	client               *http.Client
+	api                  *roborevclient.Client
+	glamourStyle         gansi.StyleConfig // detected once at init
+	jobs                 []storage.ReviewJob
+	jobStats             storage.JobStats       // aggregate done/closed/open from server
+	cost                 *storage.CostAggregate // approx agent spend for the active filter scope; nil = hidden
+	costSeq              int                    // fetchSeq of the stored cost; segment hides until it matches m.fetchSeq
+	status               storage.DaemonStatus
+	selectedIdx          int
+	selectedJobID        int64                             // Track selected job by ID to maintain position on refresh
+	expandedPanels       map[uuid.UUID]bool                // panel_run_uuid -> expanded
+	panelMembers         map[uuid.UUID][]storage.ReviewJob // panel_run_uuid -> side-fetched members
+	currentView          viewKind
+	currentReview        *storage.Review
+	currentResponses     []storage.Response // Responses for current review (fetched with review)
+	currentBranch        string             // Cached branch name for current review (computed on load)
+	reviewScroll         int
+	promptScroll         int
+	promptFromQueue      bool // true if prompt view was entered from queue (not review)
+	width                int
+	height               int
+	err                  error
+	updateAvailable      string // Latest version if update available, empty if up to date
+	updateIsDevBuild     bool   // True if running a dev build
+	versionMismatch      bool   // True if daemon version doesn't match TUI version
+	releaseNotes         []storage.ReleaseNote
+	releaseNotesErr      error
+	releaseNotesStale    bool
+	releaseNotesLoading  bool
+	releaseNotesScroll   int
+	releaseNotesFromView viewKind
 
 	// CLI-locked filters: set via --repo/--branch flags, cannot be cleared by the user
 	lockedRepoFilter   bool // true if repo filter was set via --repo flag
@@ -1216,7 +1222,7 @@ func (m *model) getBranchForJob(job storage.ReviewJob) string {
 // released to allow native terminal text selection (copy/paste).
 func mouseDisabledView(v viewKind) bool {
 	switch v {
-	case viewLog, viewReview, viewKindPrompt, viewPatch, viewCommitMsg:
+	case viewLog, viewReview, viewKindPrompt, viewPatch, viewCommitMsg, viewReleaseNotes:
 		return true
 	}
 	return false
@@ -1264,6 +1270,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		result, cmd = m.handleCostMsg(msg)
 	case updateCheckMsg:
 		result, cmd = m.handleUpdateCheckMsg(msg)
+	case releaseNotesMsg:
+		m.releaseNotes = msg.releases
+		m.releaseNotesStale = msg.stale
+		m.releaseNotesLoading = false
+		m.releaseNotesErr = nil
+		result = m
+	case releaseNotesErrMsg:
+		m.releaseNotesLoading = false
+		m.releaseNotesErr = msg.err
+		result = m
 	case reviewMsg:
 		result, cmd = m.handleReviewMsg(msg)
 	case reviewErrMsg:
@@ -1373,6 +1389,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) viewContent() string {
+	if m.currentView == viewReleaseNotes {
+		return m.renderReleaseNotesView()
+	}
 	if m.currentView == viewKindComment {
 		return m.renderRespondView()
 	}

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -30,6 +30,7 @@ const (
 	viewKindWorktreeConfirm // Confirm creating a worktree to apply patch
 	viewPatch               // Patch viewer for fix jobs
 	viewColumnOptions       // Column toggle modal
+	viewReleaseNotes        // Recent Roborev release notes
 )
 
 // queuePrefetchBuffer is the number of extra rows to fetch beyond what's visible,
@@ -362,6 +363,13 @@ type updateCheckMsg struct {
 	version    string // Latest version if available, empty if up to date
 	isDevBuild bool   // True if running a dev build
 }
+type releaseNotesMsg struct {
+	releases []storage.ReleaseNote
+	stale    bool
+}
+
+type releaseNotesErrMsg struct{ err error }
+
 type reposMsg struct {
 	repos          []repoFilterItem
 	identities     map[string][]string

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -60,6 +60,7 @@ branch.
 | `f` | Open filter (repo/branch tree) |
 | `b` | Open filter with branches expanded |
 | `h` | Toggle hide closed/failed/canceled |
+| `u` | View recent Roborev release notes |
 | `L` | Toggle split-screen or stacked layout |
 | `D` | Toggle distraction-free mode |
 | `P` | Pause or resume queue processing |
@@ -73,6 +74,13 @@ Panel reviews appear as one synthesis parent row by default. The parent row
 shows live progress while member reviewers run and a compact member summary
 after completion. Expand the row to inspect individual member jobs. Close,
 cancel, rerun, or fix the panel from the parent row, not from a member row.
+
+When a newer Roborev version is available, the queue banner points to the
+release-notes viewer. Press `u` at any time to open it. The viewer renders the
+recent GitHub release notes and supports `j`/`k`, page scrolling, and `u` to
+refresh. Roborev caches the notes in its local SQLite database. It checks GitHub
+again after one hour and uses GitHub's cache validator so edited notes replace
+the saved copy.
 
 ## Split-Screen Review
 

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -40,6 +40,13 @@ The application has two workspaces:
 - **Analytics** summarizes cost, latency, failures, outcomes, and agent attempts
     from the daemon's SQLite history.
 
+Use the book icon in the application header to read recent Roborev release
+notes. Select a version from the list to view its rendered Markdown without
+leaving the application. The daemon shares the same SQLite-backed release-note
+cache with the terminal UI and refreshes it from GitHub after one hour. If
+GitHub is temporarily unavailable, the viewer labels and displays the saved
+copy.
+
 The Go module source archive does not contain the generated application assets.
 An installation made with `go install` still provides the CLI and terminal UI,
 but the native browser application requires a release package or a source build

--- a/internal/daemon/release_notes.go
+++ b/internal/daemon/release_notes.go
@@ -1,0 +1,114 @@
+package daemon
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/google/go-github/v90/github"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+const (
+	releaseNotesFreshFor = time.Hour
+	releaseNotesLimit    = 10
+)
+
+type ReleaseNotesResponse struct {
+	Releases  []storage.ReleaseNote `json:"releases"`
+	FetchedAt time.Time             `json:"fetched_at"`
+	Stale     bool                  `json:"stale"`
+}
+
+type releaseNotesOutput struct {
+	Body ReleaseNotesResponse
+}
+
+func (s *Server) humaListReleases(ctx context.Context, _ *struct{}) (*releaseNotesOutput, error) {
+	cache, err := s.db.GetReleaseNotesCache(ctx)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, huma.Error500InternalServerError("read cached release notes")
+	}
+	now := s.releaseNotesNow()
+	if cache != nil && now.Sub(cache.FetchedAt) < releaseNotesFreshFor {
+		return releaseNotesCacheOutput(cache, false), nil
+	}
+
+	releases, etag, notModified, fetchErr := s.fetchReleaseNotes(ctx, cache)
+	if fetchErr != nil {
+		if cache != nil {
+			return releaseNotesCacheOutput(cache, true), nil
+		}
+		return nil, huma.Error502BadGateway("fetch release notes from GitHub")
+	}
+	if notModified {
+		if err := s.db.TouchReleaseNotesCache(ctx, now); err != nil {
+			return nil, huma.Error500InternalServerError("update release notes cache")
+		}
+		cache.FetchedAt = now
+		return releaseNotesCacheOutput(cache, false), nil
+	}
+
+	cache = &storage.ReleaseNotesCache{ETag: etag, Releases: releases, FetchedAt: now}
+	if err := s.db.SaveReleaseNotesCache(ctx, *cache); err != nil {
+		return nil, huma.Error500InternalServerError("save release notes cache")
+	}
+	return releaseNotesCacheOutput(cache, false), nil
+}
+
+func releaseNotesCacheOutput(cache *storage.ReleaseNotesCache, stale bool) *releaseNotesOutput {
+	return &releaseNotesOutput{Body: ReleaseNotesResponse{
+		Releases: cache.Releases, FetchedAt: cache.FetchedAt, Stale: stale,
+	}}
+}
+
+func (s *Server) fetchReleaseNotes(
+	ctx context.Context,
+	cache *storage.ReleaseNotesCache,
+) ([]storage.ReleaseNote, string, bool, error) {
+	path := fmt.Sprintf("repos/kenn-io/roborev/releases?per_page=%d", releaseNotesLimit)
+	req, err := s.releaseNotesClient.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("create release notes request: %w", err)
+	}
+	if cache != nil && cache.ETag != "" {
+		req.Header.Set("If-None-Match", cache.ETag)
+	}
+
+	var remote []*github.RepositoryRelease
+	resp, err := s.releaseNotesClient.Do(req, &remote)
+	if resp != nil && resp.StatusCode == http.StatusNotModified {
+		return nil, "", true, nil
+	}
+	if err != nil {
+		return nil, "", false, fmt.Errorf("list GitHub releases: %w", err)
+	}
+
+	releases := make([]storage.ReleaseNote, 0, len(remote))
+	for _, release := range remote {
+		if release == nil || release.GetDraft() || release.PublishedAt == nil {
+			continue
+		}
+		publishedAt := release.PublishedAt.Time
+		updatedAt := publishedAt
+		if release.UpdatedAt != nil {
+			updatedAt = release.UpdatedAt.Time
+		}
+		name := strings.TrimSpace(release.GetName())
+		if name == "" {
+			name = release.GetTagName()
+		}
+		releases = append(releases, storage.ReleaseNote{
+			TagName: release.GetTagName(), Name: name, Body: release.GetBody(),
+			HTMLURL: release.GetHTMLURL(), PublishedAt: publishedAt,
+			UpdatedAt: updatedAt, Prerelease: release.GetPrerelease(),
+		})
+	}
+	return releases, resp.Header.Get("ETag"), false, nil
+}

--- a/internal/daemon/release_notes_test.go
+++ b/internal/daemon/release_notes_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v90/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestReleaseNotesRefreshesEditedGitHubRelease(t *testing.T) {
+	t.Parallel()
+
+	const firstETag = `"release-list-v1"`
+	requests := 0
+	seenConditionalETag := ""
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests++
+		seenConditionalETag = request.Header.Get("If-None-Match")
+		w.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			w.Header().Set("ETag", firstETag)
+			fmt.Fprint(w, `[{
+				"tag_name":"v1.2.3","name":"Roborev 1.2.3","body":"Original notes",
+				"html_url":"https://example.com/releases/v1.2.3","draft":false,
+				"prerelease":false,"published_at":"2026-08-30T12:00:00Z",
+				"updated_at":"2026-08-30T12:00:00Z"
+			}]`)
+			return
+		}
+		w.Header().Set("ETag", `"release-list-v2"`)
+		fmt.Fprint(w, `[{
+			"tag_name":"v1.2.3","name":"Roborev 1.2.3","body":"Edited notes",
+			"html_url":"https://example.com/releases/v1.2.3","draft":false,
+			"prerelease":false,"published_at":"2026-08-30T12:00:00Z",
+			"updated_at":"2026-08-31T09:30:00Z"
+		}]`)
+	}))
+	t.Cleanup(githubServer.Close)
+
+	db, err := storage.Open(filepath.Join(t.TempDir(), "reviews.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	baseURL := githubServer.URL + "/"
+	githubClient, err := github.NewClient(
+		github.WithHTTPClient(githubServer.Client()),
+		github.WithURLs(&baseURL, &baseURL),
+	)
+	require.NoError(t, err)
+	now := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	server := &Server{
+		db: db, releaseNotesClient: githubClient, releaseNotesNow: func() time.Time { return now },
+	}
+
+	first, err := server.humaListReleases(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, first.Body.Releases, 1)
+	assert.Equal(t, "Original notes", first.Body.Releases[0].Body)
+	assert.Equal(t, 1, requests)
+
+	_, err = server.humaListReleases(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, requests, "fresh cache avoids another GitHub request")
+
+	now = now.Add(releaseNotesFreshFor + time.Minute)
+	refreshed, err := server.humaListReleases(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, refreshed.Body.Releases, 1)
+	assert.Equal(t, firstETag, seenConditionalETag)
+	assert.Equal(t, "Edited notes", refreshed.Body.Releases[0].Body)
+	assert.Equal(t, time.Date(2026, 8, 31, 9, 30, 0, 0, time.UTC), refreshed.Body.Releases[0].UpdatedAt)
+}

--- a/internal/daemon/routes.go
+++ b/internal/daemon/routes.go
@@ -179,6 +179,13 @@ func (s *Server) registerHumaAPI(mux *http.ServeMux) huma.API {
 			o.Tags = []string{"daemon"}
 		})
 
+	huma.Get(api, "/api/releases", s.humaListReleases,
+		func(o *huma.Operation) {
+			o.OperationID = "list-releases"
+			o.Summary = "List recent Roborev release notes"
+			o.Tags = []string{"daemon"}
+		})
+
 	huma.Post(api, "/api/queue/pause", s.humaPauseQueue,
 		func(o *huma.Operation) {
 			o.OperationID = "pause-queue"

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -21,7 +21,9 @@ import (
 	"github.com/coreos/go-systemd/v22/activation"
 	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/google/go-github/v90/github"
 	gitrepo "go.kenn.io/kit/git/repo"
+	"go.kenn.io/kit/selfupdate"
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/agenthook"
@@ -54,6 +56,8 @@ type Server struct {
 	hookRunner              *HookRunner
 	errorLog                *ErrorLog
 	activityLog             *ActivityLog
+	releaseNotesClient      *github.Client
+	releaseNotesNow         func() time.Time
 	telemetry               telemetry.Client
 	telemetryOnce           sync.Once
 	telemetryStop           chan struct{}
@@ -149,17 +153,30 @@ func newServerWithLogs(
 	// Create hook runner to fire hooks on review events
 	hookRunner := NewHookRunner(configWatcher, broadcaster, log.Default())
 
+	releaseNotesOptions := []github.ClientOptionsFunc{
+		github.WithHTTPClient(&http.Client{Timeout: 10 * time.Second}),
+	}
+	if token := selfupdate.EnvironmentGitHubToken(); token != "" {
+		releaseNotesOptions = append(releaseNotesOptions, github.WithAuthToken(token))
+	}
+	releaseNotesClient, err := github.NewClient(releaseNotesOptions...)
+	if err != nil {
+		panic(fmt.Sprintf("create GitHub client for release notes: %v", err))
+	}
+
 	s := &Server{
-		db:            db,
-		configWatcher: configWatcher,
-		broadcaster:   broadcaster,
-		workerPool:    NewWorkerPool(db, configWatcher, cfg.MaxWorkers, broadcaster, errorLog, activityLog),
-		hookRunner:    hookRunner,
-		errorLog:      errorLog,
-		activityLog:   activityLog,
-		telemetryStop: make(chan struct{}),
-		startTime:     time.Now(),
-		shutdownCh:    make(chan struct{}),
+		db:                 db,
+		configWatcher:      configWatcher,
+		broadcaster:        broadcaster,
+		workerPool:         NewWorkerPool(db, configWatcher, cfg.MaxWorkers, broadcaster, errorLog, activityLog),
+		hookRunner:         hookRunner,
+		errorLog:           errorLog,
+		activityLog:        activityLog,
+		releaseNotesClient: releaseNotesClient,
+		releaseNotesNow:    time.Now,
+		telemetryStop:      make(chan struct{}),
+		startTime:          time.Now(),
+		shutdownCh:         make(chan struct{}),
 	}
 	s.updateCoordinator = &updateDrainCoordinator{server: s, now: time.Now}
 	s.agentHookState, s.agentHookStateErr = agenthook.LoadState(

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -166,6 +166,15 @@ CREATE TABLE IF NOT EXISTS daemon_state (
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- release_notes_cache is local-only presentation data fetched from GitHub.
+-- It is deliberately not synced to PostgreSQL.
+CREATE TABLE IF NOT EXISTS release_notes_cache (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  etag TEXT NOT NULL DEFAULT '',
+  releases_json TEXT NOT NULL,
+  fetched_at TEXT NOT NULL
+);
+
 -- agent_hook_snoozes is local-only workspace state. It is deliberately not
 -- synced to PostgreSQL because worktree paths and snooze intent are specific to
 -- this machine.

--- a/internal/storage/release_notes.go
+++ b/internal/storage/release_notes.go
@@ -1,0 +1,77 @@
+package storage
+
+import (
+	"context"
+	"encoding/json/v2"
+	"fmt"
+	"time"
+)
+
+// ReleaseNote is one published GitHub release shown in the local clients.
+type ReleaseNote struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	Body        string    `json:"body"`
+	HTMLURL     string    `json:"html_url"`
+	PublishedAt time.Time `json:"published_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Prerelease  bool      `json:"prerelease"`
+}
+
+// ReleaseNotesCache is the local copy of recent GitHub release notes.
+type ReleaseNotesCache struct {
+	ETag      string
+	Releases  []ReleaseNote
+	FetchedAt time.Time
+}
+
+func (db *DB) GetReleaseNotesCache(ctx context.Context) (*ReleaseNotesCache, error) {
+	var etag, releasesJSON, fetchedAt string
+	err := db.QueryRowContext(ctx, `
+		SELECT etag, releases_json, fetched_at
+		FROM release_notes_cache
+		WHERE id = 1
+	`).Scan(&etag, &releasesJSON, &fetchedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	var releases []ReleaseNote
+	if err := json.Unmarshal([]byte(releasesJSON), &releases); err != nil {
+		return nil, fmt.Errorf("decode cached release notes: %w", err)
+	}
+	fetched, err := time.Parse(time.RFC3339Nano, fetchedAt)
+	if err != nil {
+		return nil, fmt.Errorf("parse release notes fetch time: %w", err)
+	}
+	return &ReleaseNotesCache{ETag: etag, Releases: releases, FetchedAt: fetched}, nil
+}
+
+func (db *DB) SaveReleaseNotesCache(ctx context.Context, cache ReleaseNotesCache) error {
+	releasesJSON, err := json.Marshal(cache.Releases)
+	if err != nil {
+		return fmt.Errorf("encode release notes cache: %w", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO release_notes_cache (id, etag, releases_json, fetched_at)
+		VALUES (1, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			etag = excluded.etag,
+			releases_json = excluded.releases_json,
+			fetched_at = excluded.fetched_at
+	`, cache.ETag, string(releasesJSON), cache.FetchedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("save release notes cache: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) TouchReleaseNotesCache(ctx context.Context, fetchedAt time.Time) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE release_notes_cache SET fetched_at = ? WHERE id = 1
+	`, fetchedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("touch release notes cache: %w", err)
+	}
+	return nil
+}

--- a/packages/roborev-ui/src/generated.ts
+++ b/packages/roborev-ui/src/generated.ts
@@ -429,6 +429,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List recent Roborev release notes */
+        get: operations["list-releases"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/remap": {
         parameters: {
             query?: never;
@@ -1794,6 +1811,29 @@ export interface components {
              */
             readonly $schema?: string;
             repo_path: string;
+        };
+        ReleaseNote: {
+            body: string;
+            html_url: string;
+            name: string;
+            prerelease: boolean;
+            /** Format: date-time */
+            published_at: string;
+            tag_name: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        ReleaseNotesResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ReleaseNotesResponse.json
+             */
+            readonly $schema?: string;
+            /** Format: date-time */
+            fetched_at: string;
+            releases: components["schemas"]["ReleaseNote"][] | null;
+            stale: boolean;
         };
         ReleaseUpdateOutputBody: {
             /**
@@ -3277,6 +3317,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["QueuePauseOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "list-releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseNotesResponse"];
                 };
             };
             /** @description Error */

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -131,6 +131,10 @@ type ClientInterface interface {
 	UnpauseQueue(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*UnpauseQueueResponse, error)
 	UnpauseQueueWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*UnpauseQueueResp, error)
 
+	// ListReleases List recent Roborev release notes
+	ListReleases(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListReleasesResponse, error)
+	ListReleasesWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListReleasesResp, error)
+
 	// RemapJobs Remap jobs after git history rewrite
 	RemapJobs(ctx context.Context, options *RemapJobsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RemapJobsResponse, error)
 	RemapJobsWithResponse(ctx context.Context, options *RemapJobsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RemapJobsResp, error)
@@ -1885,6 +1889,68 @@ func (c *Client) UnpauseQueue(ctx context.Context, reqEditors ...runtime.Request
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/queue/unpause")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ListReleases List recent Roborev release notes
+func (c *Client) ListReleases(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListReleasesResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/releases",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListReleasesResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListReleasesErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListReleasesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListReleasesResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListReleasesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/releases")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -1381,6 +1381,54 @@ func (c *Client) UnpauseQueueWithResponse(ctx context.Context, reqEditors ...run
 	}
 }
 
+// ListReleases List recent Roborev release notes
+func (c *Client) ListReleasesWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListReleasesResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/releases",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/releases")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListReleasesResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListReleasesResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListReleasesResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // RemapJobs Remap jobs after git history rewrite
 func (c *Client) RemapJobsWithResponse(ctx context.Context, options *RemapJobsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RemapJobsResp, error) {
 	var err error

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -191,6 +191,10 @@ type UnpauseQueueResponse = QueuePauseOutputBody
 
 type UnpauseQueueErrorResponse = ErrorModel
 
+type ListReleasesResponse = ReleaseNotesResponse
+
+type ListReleasesErrorResponse = ErrorModel
+
 type RemapJobsResponse = RemapResult
 
 type RemapJobsErrorResponse = ErrorModel
@@ -475,6 +479,13 @@ type UnpauseQueueResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *UnpauseQueueResponse
+}
+
+type ListReleasesResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListReleasesResponse
 }
 
 type RemapJobsResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -1864,6 +1864,46 @@ func (r RegisterRepoRequest) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(r))
 }
 
+type ReleaseNote struct {
+	Body        string    `json:"body" validate:"required"`
+	HTMLURL     string    `json:"html_url" validate:"required"`
+	Name        string    `json:"name" validate:"required"`
+	Prerelease  bool      `json:"prerelease"`
+	PublishedAt time.Time `json:"published_at" validate:"required"`
+	TagName     string    `json:"tag_name" validate:"required"`
+	UpdatedAt   time.Time `json:"updated_at" validate:"required"`
+}
+
+func (r ReleaseNote) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type ReleaseNotesResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema    *string       `json:"$schema,omitempty"`
+	FetchedAt time.Time     `json:"fetched_at" validate:"required"`
+	Releases  []ReleaseNote `json:"releases,omitempty" validate:"required"`
+	Stale     bool          `json:"stale"`
+}
+
+func (r ReleaseNotesResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(r.FetchedAt, "required"); err != nil {
+		errors = errors.Append("FetchedAt", err)
+	}
+	for i, item := range r.Releases {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Releases[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type ReleaseUpdateOutputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema   *string `json:"$schema,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2241,6 +2241,60 @@ components:
       required:
         - repo_path
       type: object
+    ReleaseNote:
+      additionalProperties: false
+      properties:
+        body:
+          type: string
+        html_url:
+          type: string
+        name:
+          type: string
+        prerelease:
+          type: boolean
+        published_at:
+          format: date-time
+          type: string
+        tag_name:
+          type: string
+        updated_at:
+          format: date-time
+          type: string
+      required:
+        - tag_name
+        - name
+        - body
+        - html_url
+        - published_at
+        - updated_at
+        - prerelease
+      type: object
+    ReleaseNotesResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/ReleaseNotesResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        fetched_at:
+          format: date-time
+          type: string
+        releases:
+          items:
+            $ref: "#/components/schemas/ReleaseNote"
+          type:
+            - array
+            - "null"
+        stale:
+          type: boolean
+      required:
+        - releases
+        - fetched_at
+        - stale
+      type: object
     ReleaseUpdateOutputBody:
       additionalProperties: false
       properties:
@@ -4319,6 +4373,25 @@ paths:
                 $ref: "#/components/schemas/ErrorModel"
           description: Error
       summary: Resume queue processing
+      tags:
+        - daemon
+  /api/releases:
+    get:
+      operationId: list-releases
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseNotesResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ErrorModel"
+          description: Error
+      summary: List recent Roborev release notes
       tags:
         - daemon
   /api/remap:

--- a/web/src/lib/api/generated.ts
+++ b/web/src/lib/api/generated.ts
@@ -429,6 +429,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List recent Roborev release notes */
+        get: operations["list-releases"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/remap": {
         parameters: {
             query?: never;
@@ -1794,6 +1811,29 @@ export interface components {
              */
             readonly $schema?: string;
             repo_path: string;
+        };
+        ReleaseNote: {
+            body: string;
+            html_url: string;
+            name: string;
+            prerelease: boolean;
+            /** Format: date-time */
+            published_at: string;
+            tag_name: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        ReleaseNotesResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ReleaseNotesResponse.json
+             */
+            readonly $schema?: string;
+            /** Format: date-time */
+            fetched_at: string;
+            releases: components["schemas"]["ReleaseNote"][] | null;
+            stale: boolean;
         };
         ReleaseUpdateOutputBody: {
             /**
@@ -3277,6 +3317,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["QueuePauseOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "list-releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseNotesResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/lib/components/AppShell.svelte
+++ b/web/src/lib/components/AppShell.svelte
@@ -93,7 +93,7 @@
 
   function openReleaseNotes(): void {
     releaseNotesOpen = true;
-    if (releaseNotes.length === 0 && !releaseNotesLoading) loadReleaseNotes();
+    if (!releaseNotesLoading) loadReleaseNotes();
   }
 
   function loadReleaseNotes(): void {

--- a/web/src/lib/components/AppShell.svelte
+++ b/web/src/lib/components/AppShell.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import { TopBar, type TopBarTab } from "@kenn-io/kit-ui";
+  import { IconButton, TopBar, type TopBarTab } from "@kenn-io/kit-ui";
+  import BookOpenIcon from "@lucide/svelte/icons/book-open";
   import { Effect } from "effect";
   import { onDestroy } from "svelte";
 
   import { appPath } from "../base-path";
-  import { createRoborevClient } from "../api/client";
+  import { createRoborevClient, executeRoborevRequest } from "../api/client";
+  import type { components } from "../api/generated";
   import type { SessionCapabilities } from "../api/session";
   import { createRouter } from "../router/router.svelte";
   import { setAppRuntime, setRoborevClient } from "../runtime/context";
@@ -13,6 +15,9 @@
   import { provideReviewStores } from "../stores/context";
   import AnalyticsView from "../views/AnalyticsView.svelte";
   import ReviewsView from "../views/ReviewsView.svelte";
+  import ReleaseNotesModal from "./ReleaseNotesModal.svelte";
+
+  type ReleaseNote = components["schemas"]["ReleaseNote"];
 
   interface Props {
     capabilities: SessionCapabilities;
@@ -28,6 +33,12 @@
     { id: "analytics", label: "Analytics" },
   ];
   let actionError = $state<string | null>(null);
+  let releaseNotesOpen = $state(false);
+  let releaseNotes = $state<ReadonlyArray<ReleaseNote>>([]);
+  let releaseNotesLoading = $state(false);
+  let releaseNotesStale = $state(false);
+  let releaseNotesError = $state<string | null>(null);
+  let releaseNotesRequest: ReturnType<typeof runtime.runCommand> | undefined;
   const stores = createReviewStores({
     runtime,
     client,
@@ -50,6 +61,7 @@
 
   onDestroy(() => {
     polling.interrupt();
+    releaseNotesRequest?.interrupt();
     stores.roborevJobs.dispose();
     router.dispose();
     void Effect.runPromise(runtime.disposeEffect);
@@ -78,6 +90,45 @@
       !event.altKey
     );
   }
+
+  function openReleaseNotes(): void {
+    releaseNotesOpen = true;
+    if (releaseNotes.length === 0 && !releaseNotesLoading) loadReleaseNotes();
+  }
+
+  function loadReleaseNotes(): void {
+    releaseNotesRequest?.interrupt();
+    releaseNotesLoading = true;
+    releaseNotesError = null;
+    releaseNotesRequest = runtime.runCommand(
+      executeRoborevRequest("list Roborev releases", (signal) =>
+        client.GET("/api/releases", { signal }),
+      ).pipe(
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            if (result.data) {
+              releaseNotes = result.data.releases ?? [];
+              releaseNotesStale = result.data.stale;
+              return;
+            }
+            releaseNotesError = "The daemon could not retrieve release notes.";
+          }),
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            releaseNotesLoading = false;
+          }),
+        ),
+      ),
+      {
+        operation: "list Roborev releases",
+        safeContext: {},
+        onFailure: () => {
+          releaseNotesError = "The daemon could not retrieve release notes.";
+        },
+      },
+    );
+  }
 </script>
 
 <div class="app-shell">
@@ -92,6 +143,11 @@
       <a class="brand" href={appPath("/reviews")} onclick={navigateReviews}
         >Roborev</a
       >
+    {/snippet}
+    {#snippet right()}
+      <IconButton ariaLabel="Release notes" onclick={openReleaseNotes}>
+        <BookOpenIcon size="16" strokeWidth="2" aria-hidden="true" />
+      </IconButton>
     {/snippet}
   </TopBar>
 
@@ -112,6 +168,15 @@
       >
     </div>
   {/if}
+  <ReleaseNotesModal
+    open={releaseNotesOpen}
+    releases={releaseNotes}
+    loading={releaseNotesLoading}
+    stale={releaseNotesStale}
+    error={releaseNotesError}
+    onclose={() => (releaseNotesOpen = false)}
+    onretry={loadReleaseNotes}
+  />
 </div>
 
 <style>

--- a/web/src/lib/components/ReleaseNotesModal.svelte
+++ b/web/src/lib/components/ReleaseNotesModal.svelte
@@ -1,0 +1,320 @@
+<script lang="ts">
+  import { Button, Modal } from "@kenn-io/kit-ui";
+  import type { Component } from "svelte";
+
+  import type { components } from "../api/generated";
+  import { pushModalFrame } from "../keyboard/modal-stack.svelte";
+  import { untrack } from "svelte";
+
+  type ReleaseNote = components["schemas"]["ReleaseNote"];
+  type ReleaseContentComponent = Component<{
+    output: string;
+    emptyMessage?: string;
+  }>;
+
+  interface Props {
+    open: boolean;
+    releases: ReadonlyArray<ReleaseNote>;
+    loading: boolean;
+    stale: boolean;
+    error: string | null;
+    onclose: () => void;
+    onretry: () => void;
+  }
+
+  let { open, releases, loading, stale, error, onclose, onretry }: Props =
+    $props();
+  let selectedTag = $state("");
+  let ReleaseContent = $state<ReleaseContentComponent>();
+  let rendererError = $state(false);
+  let rendererPromise: Promise<void> | undefined;
+  const selectedRelease = $derived(
+    releases.find((release) => release.tag_name === selectedTag) ?? releases[0],
+  );
+
+  $effect(() => {
+    if (!open) return;
+    return untrack(() => pushModalFrame("roborev-release-notes", []));
+  });
+
+  $effect(() => {
+    if (open && !ReleaseContent) void loadRenderer();
+  });
+
+  $effect(() => {
+    if (releases.length === 0) {
+      selectedTag = "";
+      return;
+    }
+    if (!releases.some((release) => release.tag_name === selectedTag)) {
+      selectedTag = releases[0].tag_name;
+    }
+  });
+
+  function releaseDate(value: string): string {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(new Date(value));
+  }
+
+  async function loadRenderer(): Promise<void> {
+    if (ReleaseContent) return;
+    if (rendererPromise) return rendererPromise;
+    rendererError = false;
+    rendererPromise = import("@kenn-io/roborev-ui/review-content")
+      .then((module) => {
+        ReleaseContent = module.default;
+      })
+      .catch(() => {
+        rendererError = true;
+      })
+      .finally(() => {
+        rendererPromise = undefined;
+      });
+    return rendererPromise;
+  }
+</script>
+
+{#if open}
+  <Modal
+    title="Roborev release notes"
+    {onclose}
+    width="min(960px, calc(100vw - 32px))"
+    maxWidth="min(960px, calc(100vw - 32px))"
+  >
+    {#if loading && releases.length === 0}
+      <div class="release-state" aria-live="polite">
+        Loading release notes...
+      </div>
+    {:else if error && releases.length === 0}
+      <div class="release-state release-error" role="alert">
+        <strong>Could not load release notes</strong>
+        <p>{error}</p>
+        <Button onclick={onretry}>Try again</Button>
+      </div>
+    {:else if releases.length === 0}
+      <div class="release-state">No published releases found.</div>
+    {:else}
+      <div class="release-layout">
+        <nav class="release-list" aria-label="Recent releases">
+          {#each releases as release (release.tag_name)}
+            <button
+              type="button"
+              class:active={release.tag_name === selectedRelease?.tag_name}
+              aria-current={release.tag_name === selectedRelease?.tag_name
+                ? "true"
+                : undefined}
+              onclick={() => (selectedTag = release.tag_name)}
+            >
+              <span>{release.name}</span>
+              <small>
+                {release.tag_name} · {releaseDate(release.published_at)}
+              </small>
+            </button>
+          {/each}
+        </nav>
+
+        {#if selectedRelease}
+          <article class="release-detail">
+            <header>
+              <div>
+                <h2>{selectedRelease.name}</h2>
+                <p>
+                  {selectedRelease.tag_name} · {releaseDate(
+                    selectedRelease.published_at,
+                  )}
+                  {selectedRelease.prerelease ? " · prerelease" : ""}
+                </p>
+              </div>
+              <a
+                href={selectedRelease.html_url}
+                target="_blank"
+                rel="noreferrer">View on GitHub</a
+              >
+            </header>
+            <div class="release-copy">
+              {#if ReleaseContent}
+                <ReleaseContent
+                  output={selectedRelease.body}
+                  emptyMessage="No release notes were provided."
+                />
+              {:else if rendererError}
+                <div class="release-state release-error" role="alert">
+                  <strong>Could not render release notes</strong>
+                  <Button onclick={() => void loadRenderer()}>Try again</Button>
+                </div>
+              {:else}
+                <div class="release-state" aria-live="polite">
+                  Rendering release notes...
+                </div>
+              {/if}
+            </div>
+          </article>
+        {/if}
+      </div>
+      {#if stale}
+        <p class="stale-note" role="status">
+          GitHub could not be reached. These notes came from the local cache.
+        </p>
+      {/if}
+    {/if}
+  </Modal>
+{/if}
+
+<style>
+  .release-layout {
+    display: grid;
+    min-height: min(580px, calc(100vh - 160px));
+    grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  }
+
+  .release-list {
+    overflow-y: auto;
+    padding: var(--space-2);
+    border-right: var(--border-width) solid var(--border-default);
+    background: var(--bg-inset);
+  }
+
+  .release-list button {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 12px;
+    border: 0;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .release-list button:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .release-list button:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: -2px;
+  }
+
+  .release-list button.active {
+    background: color-mix(in srgb, var(--accent-blue) 18%, var(--bg-inset));
+  }
+
+  .release-list span {
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .release-list small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.35;
+  }
+
+  .release-detail {
+    min-width: 0;
+    background: var(--bg-primary);
+  }
+
+  .release-detail > header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 18px 20px 14px;
+    border-bottom: var(--border-width) solid var(--border-default);
+  }
+
+  .release-detail h2 {
+    margin: 0;
+    font-size: var(--font-size-lg);
+    letter-spacing: -0.01em;
+  }
+
+  .release-detail p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+  }
+
+  .release-detail a {
+    flex-shrink: 0;
+    color: var(--accent-blue);
+    font-size: var(--font-size-sm);
+    text-underline-offset: 3px;
+  }
+
+  .release-copy {
+    overflow-y: auto;
+    max-height: min(520px, calc(100vh - 230px));
+  }
+
+  .release-copy :global(.review-content) {
+    max-width: 75ch;
+    margin: 0 auto;
+    padding: 24px 28px 36px;
+  }
+
+  .release-state {
+    display: flex;
+    min-height: 280px;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 10px;
+    color: var(--text-muted);
+    text-align: center;
+  }
+
+  .release-state p {
+    margin: 0;
+  }
+
+  .release-error strong {
+    color: var(--text-primary);
+  }
+
+  .stale-note {
+    margin: 0;
+    padding: 8px 12px;
+    border-top: var(--border-width) solid var(--accent-amber);
+    background: var(--bg-inset);
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  @media (max-width: 680px) {
+    .release-layout {
+      min-height: calc(100vh - 112px);
+      grid-template-columns: 1fr;
+      grid-template-rows: auto minmax(0, 1fr);
+    }
+
+    .release-list {
+      display: flex;
+      overflow-x: auto;
+      padding: var(--space-2);
+      border-right: 0;
+      border-bottom: var(--border-width) solid var(--border-default);
+    }
+
+    .release-list button {
+      width: 180px;
+      flex: 0 0 auto;
+    }
+
+    .release-detail > header {
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .release-copy {
+      max-height: calc(100vh - 280px);
+    }
+  }
+</style>

--- a/web/src/lib/components/ReleaseNotesModal.test.ts
+++ b/web/src/lib/components/ReleaseNotesModal.test.ts
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+
+import ReleaseNotesModal from "./ReleaseNotesModal.svelte";
+
+describe("ReleaseNotesModal", () => {
+  it("shows recent releases and switches the selected notes", async () => {
+    render(ReleaseNotesModal, {
+      open: true,
+      loading: false,
+      stale: false,
+      error: null,
+      onclose: () => {},
+      onretry: () => {},
+      releases: [
+        {
+          tag_name: "v2.0.0",
+          name: "Roborev 2.0",
+          body: "Latest notes",
+          html_url: "https://example.com/releases/v2.0.0",
+          prerelease: false,
+          published_at: "2026-09-01T12:00:00Z",
+          updated_at: "2026-09-01T12:00:00Z",
+        },
+        {
+          tag_name: "v1.9.0",
+          name: "Roborev 1.9",
+          body: "Earlier notes",
+          html_url: "https://example.com/releases/v1.9.0",
+          prerelease: false,
+          published_at: "2026-08-20T12:00:00Z",
+          updated_at: "2026-08-20T12:00:00Z",
+        },
+      ],
+    });
+
+    expect(await screen.findByText("Latest notes")).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole("button", { name: /Roborev 1.9/ }));
+    expect(await screen.findByText("Earlier notes")).toBeInTheDocument();
+  });
+});

--- a/web/src/lib/views/ReviewsView.svelte
+++ b/web/src/lib/views/ReviewsView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { EmptyState } from "@kenn-io/kit-ui";
+  import { getStackDepth } from "../keyboard/modal-stack.svelte";
   import { getAppRuntime } from "../runtime/context";
   import { getReviewStores } from "../stores/context";
   import FilterBar from "../components/reviews/FilterBar.svelte";
@@ -66,6 +67,8 @@
       }
       return;
     }
+
+    if (getStackDepth() > 0) return;
 
     const drawerOpen = stores.roborevJobs?.getSelectedJobId() !== undefined;
 

--- a/web/tests/e2e/reviews.spec.ts
+++ b/web/tests/e2e/reviews.spec.ts
@@ -461,6 +461,15 @@ test.describe.serial("native review workspace", () => {
     const id = (
       await highlighted.locator(".col-id .mono").textContent()
     )?.trim();
+
+    await page.getByRole("button", { name: "Release notes" }).click();
+    await expect(
+      page.getByText("Roborev release notes", { exact: true }),
+    ).toBeVisible();
+    await page.keyboard.press("j");
+    await expect(highlighted.locator(".col-id .mono")).toHaveText(id ?? "");
+    await page.keyboard.press("Escape");
+
     await page.keyboard.press("Enter");
     await expect(page).toHaveURL(new RegExp(`/reviews/${id}$`));
     await page.keyboard.press("Escape");

--- a/web/tests/e2e/reviews.spec.ts
+++ b/web/tests/e2e/reviews.spec.ts
@@ -444,6 +444,17 @@ test.describe.serial("native review workspace", () => {
   test("preserves transplanted keyboard navigation and help", async ({
     page,
   }) => {
+    let releaseRequests = 0;
+    await page.route("**/api/releases", async (route) => {
+      releaseRequests += 1;
+      await route.fulfill({
+        json: {
+          releases: [],
+          fetched_at: "2026-09-01T12:00:00Z",
+          stale: false,
+        },
+      });
+    });
     await openReviews(page);
 
     await page.keyboard.press("?");
@@ -466,8 +477,15 @@ test.describe.serial("native review workspace", () => {
     await expect(
       page.getByText("Roborev release notes", { exact: true }),
     ).toBeVisible();
+    await expect(page.getByText("No published releases found.")).toBeVisible();
+    expect(releaseRequests).toBe(1);
     await page.keyboard.press("j");
     await expect(highlighted.locator(".col-id .mono")).toHaveText(id ?? "");
+    await page.keyboard.press("Escape");
+
+    await page.getByRole("button", { name: "Release notes" }).click();
+    await expect(page.getByText("No published releases found.")).toBeVisible();
+    expect(releaseRequests).toBe(2);
     await page.keyboard.press("Escape");
 
     await page.keyboard.press("Enter");


### PR DESCRIPTION
Adds recent Roborev release notes to the terminal and web applications, so an
update prompt can show users what changed before they install it. The TUI opens
the notes with `u`; the web application opens them from the header.

The daemon fetches the ten latest releases through the pinned `go-github`
client and stores them in a local-only SQLite cache. It revalidates the cache
after one hour with GitHub's ETag, replaces edited notes, and returns the saved
copy with a stale marker if GitHub is unavailable. Release notes do not sync to
PostgreSQL.

The new daemon endpoint is part of the generated OpenAPI clients, and both user
interfaces cover loading, empty, failure, retry, prerelease, and stale-cache
states.

Closes #1103
