### PR TITLE
fix(web): use the kit-ui top bar height

### DIFF
--- a/web/src/lib/components/AppShell.svelte
+++ b/web/src/lib/components/AppShell.svelte
@@ -133,7 +133,6 @@
 
 <div class="app-shell">
   <TopBar
-    class="app-header"
     tabs={navigationTabs}
     active={route.page}
     onchange={navigatePage}
@@ -189,10 +188,6 @@
     flex-direction: column;
     background: var(--bg-primary);
     color: var(--text-primary);
-  }
-
-  :global(.app-header) {
-    --header-height: 48px;
   }
 
   .brand {


### PR DESCRIPTION
## Summary

- The web application header now renders at the kit-ui default height
- Roborev previously forced the header to 48px through an app-level override of the kit `--header-height` token. kit-ui sets that token to 44px and Forge does not override it, so the Roborev header sat 4px taller.
- Removes the override and the now unused `app-header` class so the kit theme owns the height.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (claude-fable-5-1)
Co-authored-by: Claude Fable 5.1 <noreply@anthropic.com>

<sup>generated by a clanker</sup>
