### PR TITLE
fix(tui): keep failed-review colour stable

### DIFF
--- a/cmd/roborev/tui/split_detail_pane.go
+++ b/cmd/roborev/tui/split_detail_pane.go
@@ -266,7 +266,7 @@ func (m model) renderDetailPane(innerW, innerH int) []string {
 		// so it can't inject terminal escapes (cursor moves, OSC clipboard
 		// writes, \r/\b overwrites) while this direct render is showing.
 		for _, l := range wrapText("Job failed:\n\n"+sanitizeForDisplay(job.Error), max(innerW-2, 20)) {
-			card = append(card, xansi.Truncate(failStyle.Render(l), innerW, ""))
+			card = append(card, xansi.Truncate(l, innerW, ""))
 		}
 		return pad(card)
 	case storage.JobStatusRunning:

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -1232,6 +1232,21 @@ func TestFollowTickSynthesizesFailedReview(t *testing.T) {
 	assert.Contains(t, got.currentReview.Output, "boom")
 }
 
+func TestFailedReviewDoesNotChangeColourAfterDetailFollow(t *testing.T) {
+	m := splitModel(withSelection(2, 1)) // job 1: failed
+	m.currentReview = nil
+
+	before := strings.Join(m.renderDetailPane(88, 25), "\n")
+	assert.Contains(t, before, "boom")
+	assert.NotContains(t, before, failStyle.Render("boom"))
+
+	m.detailFollowGen = 1
+	res, _ := m.handleDetailFollowTick(detailFollowTickMsg{gen: 1})
+	after := strings.Join(res.(model).renderDetailPane(88, 25), "\n")
+	assert.Contains(t, after, "boom")
+	assert.NotContains(t, after, failStyle.Render("boom"))
+}
+
 func TestFollowReviewMsgKeepsListFocus(t *testing.T) {
 	assert := assert.New(t)
 	m := splitModel(withSelection(1, 2))
@@ -3418,7 +3433,7 @@ func TestDetailPaneFailedJobSanitizesError(t *testing.T) {
 	joined := strings.Join(lines, "\n")
 	assert.Contains(joined, "boom")
 	assert.Contains(joined, "moretexthere")
-	// The pane's own chrome (titleStyle, failStyle, ...) legitimately emits
+	// The pane's own chrome (titleStyle, statusStyle, ...) legitimately emits
 	// SGR color codes, so assert on the malicious payload specifically
 	// rather than banning \x1b outright: no OSC/CSI injection sequences,
 	// and no raw \r/\x08 survive anywhere in the rendered output.


### PR DESCRIPTION
Failed review errors in the split TUI now keep the normal review-body colour while a selection's detail-follow update completes. The fallback previously wrapped the same error in `failStyle`, which made the pane flash red before the synthesized review rendered; it now preserves the existing sanitization and wrapping without the temporary colour override.

Closes #1123
