### PR TITLE
fix(pi): restrict tools for non-agentic reviews

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -300,11 +300,28 @@ and commands):
 | Droid | Full (runs autonomously) |
 | Kilo | Full (runs autonomously) |
 | Kiro | Full (uses `--trust-all-tools`) |
-| Pi | Full (tools execute without confirmation) |
+| Pi | Full (agentic runs use Pi's default tools) |
 | Grok Build | Full (uses `--always-approve` in agentic mode; review uses layered read-only safety — see below) |
 
 See [Custom Tasks & Agentic Mode](/advanced/custom-tasks/) for details on review
 vs agentic modes.
+
+## Pi
+
+Non-agentic Pi reviews use a positive read-only tool allowlist:
+
+```bash
+pi -p --mode json --tools read,grep,find,ls
+```
+
+Structured reviews also allow the `json_output` tool registered by the
+configured JSON schema extension. They cannot run commands or change files.
+Agentic jobs and runs with `allow_unsafe_agents = true` omit the allowlist and
+use Pi's default tools, including `bash`, `edit`, and `write`.
+
+Roborev appends the managed allowlist after `[agent.pi].launch_args`, so a
+duplicate `--tools` option in global configuration does not replace the review
+restriction.
 
 ## Grok Build
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,9 @@ All notable changes to roborev, grouped by minor release.
 
 **Bug fixes**
 
+- Non-agentic Pi reviews can no longer run commands or change files. They use
+    Pi's read-only repository tools, while agentic jobs keep the default tool
+    set. Structured reviews also retain their required JSON output tool.
 - Large Antigravity reviews no longer fail when the prompt exceeds the operating
     system's command-line limit. Non-agentic reviews can also run the workspace
     inspection commands they need.

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -16,7 +16,11 @@ import (
 	"go.kenn.io/roborev/internal/config"
 )
 
-const piJSONSchemaInstallCommand = "pi install npm:@nqbao/pi-json-schema"
+const (
+	piJSONSchemaInstallCommand      = "pi install npm:@nqbao/pi-json-schema"
+	piReadOnlyTools                 = "read,grep,find,ls"
+	piStructuredReviewReadOnlyTools = piReadOnlyTools + ",json_output"
+)
 
 // PiAgent runs code reviews using the pi CLI
 type PiAgent struct {
@@ -105,13 +109,16 @@ func (a *PiAgent) CommandName() string {
 }
 
 func (a *PiAgent) CommandLine() string {
-	args := a.buildArgs("")
+	args := a.buildArgs("", a.Agentic || AllowUnsafeAgents())
 	return a.Command + " " + strings.Join(args, " ")
 }
 
-func (a *PiAgent) buildArgs(sessionPath string) []string {
+func (a *PiAgent) buildArgs(sessionPath string, agenticMode bool) []string {
 	args := slices.Clone(a.LaunchArgs)
 	args = append(args, "-p", "--mode", "json")
+	if !agenticMode {
+		args = append(args, "--tools", piReadOnlyTools)
+	}
 	if sessionPath != "" {
 		args = append(args, "--session", sessionPath)
 	}
@@ -125,6 +132,38 @@ func (a *PiAgent) buildArgs(sessionPath string) []string {
 		args = append(args, "--thinking", level)
 	}
 	return args
+}
+
+func (a *PiAgent) structuredReviewArgs(
+	promptPath, outputPath string,
+	schema json.RawMessage,
+	agenticMode bool,
+) []string {
+	args := slices.Clone(a.LaunchArgs)
+	args = append(args,
+		"--no-session",
+		"--extension", a.jsonSchemaExtension(),
+		"--json-schema", string(schema),
+		"--json-output", outputPath,
+		"--json-fallback", "none",
+		"-p",
+	)
+	if !agenticMode {
+		args = append(args, "--tools", piStructuredReviewReadOnlyTools)
+	}
+	if a.Provider != "" {
+		args = append(args, "--provider", a.Provider)
+	}
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	if level := a.thinkingLevel(); level != "" {
+		args = append(args, "--thinking", level)
+	}
+	return append(args,
+		"@"+promptPath,
+		"Review the repository according to the attached instructions and write the result with the structured JSON output tool.",
+	)
 }
 
 func (a *PiAgent) thinkingLevel() string {
@@ -259,28 +298,8 @@ func (a *PiAgent) ReviewWithSchema(
 		return nil, fmt.Errorf("write structured review prompt: %w", err)
 	}
 	outputPath := filepath.Join(tmpDir, "result.json")
-	args := slices.Clone(a.LaunchArgs)
-	args = append(args,
-		"--no-session",
-		"--extension", a.jsonSchemaExtension(),
-		"--json-schema", string(schema),
-		"--json-output", outputPath,
-		"--json-fallback", "none",
-		"-p",
-	)
-	if a.Provider != "" {
-		args = append(args, "--provider", a.Provider)
-	}
-	if a.Model != "" {
-		args = append(args, "--model", a.Model)
-	}
-	if level := a.thinkingLevel(); level != "" {
-		args = append(args, "--thinking", level)
-	}
-	args = append(args,
-		"@"+promptPath,
-		"Review the repository according to the attached instructions and write the result with the structured JSON output tool.",
-	)
+	agenticMode := a.Agentic || AllowUnsafeAgents()
+	args := a.structuredReviewArgs(promptPath, outputPath, schema, agenticMode)
 
 	cmd := exec.CommandContext(ctx, a.Command, args...)
 	cmd.Dir = repoPath
@@ -355,7 +374,8 @@ func (a *PiAgent) Review(
 	}
 
 	sessionPath := resolvePiSessionPath(a.SessionID)
-	args := a.buildArgs(sessionPath)
+	agenticMode := a.Agentic || AllowUnsafeAgents()
+	args := a.buildArgs(sessionPath, agenticMode)
 
 	// Add the prompt file as an input argument (prefixed with @)
 	// Pi treats @files as context/input.

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -127,15 +127,28 @@ func TestPiLaunchArgsPrecedeManagedArgsForEveryInvocation(t *testing.T) {
 	}{
 		{
 			name:          "review",
-			withoutLaunch: base.buildArgs(""),
-			withLaunch:    configured.buildArgs(""),
-			managed:       []string{"-p", "--mode", "json", "--provider", "cpa", "--model", "gpt-test", "--thinking", "low"},
+			withoutLaunch: base.buildArgs("", false),
+			withLaunch:    configured.buildArgs("", false),
+			managed:       []string{"-p", "--mode", "json", "--tools", piReadOnlyTools, "--provider", "cpa", "--model", "gpt-test", "--thinking", "low"},
 		},
 		{
 			name:          "resumed review",
-			withoutLaunch: base.buildArgs("/tmp/pi-session.jsonl"),
-			withLaunch:    configured.buildArgs("/tmp/pi-session.jsonl"),
-			managed:       []string{"-p", "--mode", "json", "--session", "/tmp/pi-session.jsonl", "--provider", "cpa", "--model", "gpt-test", "--thinking", "low"},
+			withoutLaunch: base.buildArgs("/tmp/pi-session.jsonl", false),
+			withLaunch:    configured.buildArgs("/tmp/pi-session.jsonl", false),
+			managed:       []string{"-p", "--mode", "json", "--tools", piReadOnlyTools, "--session", "/tmp/pi-session.jsonl", "--provider", "cpa", "--model", "gpt-test", "--thinking", "low"},
+		},
+		{
+			name:          "structured review",
+			withoutLaunch: base.structuredReviewArgs("prompt.md", "result.json", schema, false),
+			withLaunch:    configured.structuredReviewArgs("prompt.md", "result.json", schema, false),
+			managed: []string{
+				"--no-session", "--extension", config.DefaultPiJSONSchemaExtension,
+				"--json-schema", string(schema), "--json-output", "result.json",
+				"--json-fallback", "none", "-p", "--tools",
+				piStructuredReviewReadOnlyTools, "--provider", "cpa",
+				"--model", "gpt-test", "--thinking", "low", "@prompt.md",
+				"Review the repository according to the attached instructions and write the result with the structured JSON output tool.",
+			},
 		},
 		{
 			name:          "classifier",
@@ -157,6 +170,63 @@ func TestPiLaunchArgsPrecedeManagedArgsForEveryInvocation(t *testing.T) {
 			assert.Equal(t, tt.managed, tt.withoutLaunch)
 			wantConfigured := append(slices.Clone(wantPrefix), tt.managed...)
 			assert.Equal(t, wantConfigured, tt.withLaunch)
+		})
+	}
+}
+
+func TestPiReviewToolPermissions(t *testing.T) {
+	skipIfWindows(t)
+
+	tests := []struct {
+		name      string
+		agentic   bool
+		unsafe    bool
+		wantTools string
+	}{
+		{name: "non-agentic review", wantTools: piReadOnlyTools},
+		{name: "agentic review", agentic: true},
+		{name: "unsafe override", unsafe: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withUnsafeAgents(t, tt.unsafe)
+			mock := mockAgentCLI(t, MockCLIOpts{
+				CaptureArgs: true,
+				StdoutLines: []string{
+					`{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}`,
+				},
+			})
+
+			a := NewPiAgent(mock.CmdPath).WithAgentic(tt.agentic)
+			_, err := a.Review(context.Background(), t.TempDir(), "HEAD", "prompt", nil)
+			require.NoError(t, err)
+
+			args := readMockArgs(t, mock.ArgsFile)
+			assert.Equal(t, tt.wantTools, argAfter(args, "--tools"))
+		})
+	}
+}
+
+func TestPiStructuredReviewToolPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		agenticMode bool
+		wantTools   string
+	}{
+		{name: "non-agentic review", wantTools: piStructuredReviewReadOnlyTools},
+		{name: "agentic review", agenticMode: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := NewPiAgent("pi").structuredReviewArgs(
+				"prompt.md",
+				"result.json",
+				jsonRaw(`{"type":"object"}`),
+				tt.agenticMode,
+			)
+			assert.Equal(t, tt.wantTools, argAfter(args, "--tools"))
 		})
 	}
 }


### PR DESCRIPTION
Non-agentic Pi reviews currently inherit Pi's default `bash`, `edit`, and
`write` tools. That lets an ordinary background review execute commands, change
the checkout, or inspect a self-selected Git range instead of the frozen review
scope.

This change appends a managed `read,grep,find,ls` allowlist to non-agentic Pi
launches. Structured reviews also allow the schema extension's `json_output`
tool so they can return the required result without gaining mutation tools.
Agentic jobs and runs with `allow_unsafe_agents = true` keep Pi's default tool
set.

Closes #1124.
