### PR TITLE
Keep findings below min_severity and derive verdicts from structured output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,8 @@ Configured via `[ci]` section: `enabled`, `github_repo`, `poll_interval`, `agent
 
 **Max prompt size**: 250KB (configurable). Falls back to file listing if diff exceeds limit.
 
+**Structured output**: Agents implementing `agent.StructuredReviewAgent` (codex, claude-code, pi, grok) run every review type through `ReviewWithSchema` with the `internal/structuredreview` schema; `review.RunAgentReview` renders the Markdown and derives the verdict from the findings. Other agents run built-in types as prose and `storage.ParseVerdictAtSeverity` reads the severity labels. `min_severity` is pure post-processing: prompts never mention it, findings are never removed, and it only decides which severities fail the review. The schema (v2, v1 still decodes) also carries the agent's own `verdict`; it is rendered but does not change the outcome except `unable_to_review`, which `RunAgentReview` returns as an agent error. Fix/refine prompts still use `config.SeverityInstruction` to limit what gets addressed.
+
 ## Worktree System (`internal/worktree/`)
 
 Used for fix jobs to run agents in isolated environments:

--- a/cmd/roborev/daemon_integration_test.go
+++ b/cmd/roborev/daemon_integration_test.go
@@ -540,7 +540,7 @@ case "$*" in
 esac
 sleep 2
 printf '%s\n' '{"type":"thread.started","thread_id":"integration-session"}'
-printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"No issues found."}}'
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"schema_version\":2,\"summary\":\"No issues found.\",\"verdict\":\"pass\",\"findings\":[]}"}}'
 `
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o755))
 	return path

--- a/cmd/roborev/fix.go
+++ b/cmd/roborev/fix.go
@@ -1055,7 +1055,8 @@ func fixSingleJob(cmd *cobra.Command, repoRoot string, jobID int64, opts fixOpti
 		return fmt.Errorf("fetch review: %w", err)
 	}
 
-	// Skip reviews that passed — no findings to fix
+	// Skip reviews that passed — a pass, including a pass under the severity
+	// threshold, has nothing to fix.
 	if review.Verdict() == "P" {
 		if !opts.quiet {
 			cmd.Printf("Job %d: review passed, skipping fix\n", jobID)

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -541,7 +541,8 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 		WithContext(ctx).
 		ForRepo(repoPath, 0).
 		WithRepoConfig(repoCfg, "").
-		WithKataClient(kata.NewCLIClient(repoPath))
+		WithKataClient(kata.NewCLIClient(repoPath)).
+		WithStructuredOutput(agent.IsStructuredReviewAgent(a))
 	var reviewPrompt string
 	var snapshotCleanup func()
 	if diffContent != "" || len(dirtyFiles) > 0 {

--- a/docs/advanced/custom-review-types.md
+++ b/docs/advanced/custom-review-types.md
@@ -127,8 +127,9 @@ The schema is fixed by roborev. The agent must return:
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "summary": "Overall assessment",
+  "verdict": "fail",
   "findings": [
     {
       "severity": "high",
@@ -140,14 +141,38 @@ The schema is fixed by roborev. The agent must return:
 }
 ```
 
-`schema_version`, `summary`, and `findings` are required. The current schema
-version is `1`; Roborev rejects missing or unsupported versions. Every finding
-requires `severity`, `problem`, `fix`, and `location`; use `null` when a finding
-has no location. Severity must be one of `critical`, `high`, `medium`, or `low`.
+`schema_version`, `summary`, `verdict`, and `findings` are required. The current
+schema version is `2`; stored version `1` documents (without a verdict) still
+load, and Roborev rejects missing or unsupported versions. `verdict` is `pass`,
+`fail`, or `unable_to_review`. Every finding requires `severity`, `problem`,
+`fix`, and `location`; use `null` when a finding has no location. Severity must
+be one of `critical`, `high`, `medium`, or `low`.
 
-Roborev removes findings below `review_min_severity` or `--min-severity`. The
-review passes when no findings remain, and fails otherwise. Built-in review
-types keep their existing prose output path.
+The agent's verdict is shown in the review as an assessment but does not change
+the outcome: the findings and the severity threshold decide pass or fail. The
+exception is `unable_to_review`, which means the agent could not assess the
+change at all. Roborev treats that as an agent failure, so normal retry and
+backup-agent failover apply instead of recording a clean pass. A `fail` verdict
+with no findings is rejected the same way, because the agent has not said what
+is wrong.
+
+| Agent verdict | Findings | Review outcome |
+|---------------|----------|----------------|
+| `pass` or `fail` | Any finding at or above the threshold | Fail |
+| `pass` or `fail` | Findings only below the threshold | Pass; findings stay in the output |
+| `pass` | None | Pass |
+| `fail` | None | Agent error; retried or failed over |
+| `unable_to_review` | Any | Agent error; retried or failed over |
+
+Panels apply the panel threshold to each member the same way. When every member
+passes but some still carry lower findings, the synthesis agent combines them so
+those findings reach the combined output.
+
+Roborev keeps every finding in the review output. `review_min_severity` or
+`--min-severity` only decides the verdict: the review fails when any finding is
+at or above the threshold and passes otherwise. Built-in review types use the
+same schema when the agent supports schema-constrained output, and fall back to
+prose for other agents.
 
 ## Writing useful severity guidance
 

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -85,7 +85,10 @@ fresh panel run; member rows cannot be rerun directly.
 
 Synthesis avoids extra agent work when it can:
 
-- If all successful members pass, the parent output is `No issues found.`
+- If all successful members pass and none of them reported a finding, the parent
+    output is `No issues found.` Members that pass only because their findings
+    fall below `min_severity` still go through synthesis so those findings reach
+    the combined output.
 - If exactly one member produced output, that output can be passed through
     directly.
 - If multiple members produced findings, a read only synthesis agent verifies,

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -94,8 +94,9 @@ Synthesis avoids extra agent work when it can:
 - If no member succeeds, roborev records a durable all failed review instead of
     pretending the code passed.
 
-When a panel uses `min_severity`, synthesis may still run for a single failed
-member so findings below the threshold can be filtered consistently.
+When a panel uses `min_severity`, member findings below the threshold stay in
+the combined output. The threshold only decides whether the panel passes or
+fails.
 
 ## Selection Rules
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,32 @@ description: Release history for roborev
 
 All notable changes to roborev, grouped by minor release.
 
+## Unreleased
+
+**Improvements**
+
+- Reviews with a minimum severity now keep every finding instead of dropping the
+    ones below the threshold. The threshold only decides the verdict: a review
+    fails when any finding is at or above it and passes otherwise, so
+    low-severity notes stay visible without failing your commit or pull request.
+    This applies to `review_min_severity`, `--min-severity`, and the CI poller's
+    `min_severity`. See
+    [Severity Filtering](/guides/reviewing-code/#severity-filtering).
+- Codex, Claude Code, Pi, and Grok now return structured findings for every
+    review type, not only custom ones. Verdicts come from the reported
+    severities instead of from parsing Markdown, and the review output uses one
+    consistent summary and findings layout. The structured schema is now version
+    2 and records the agent's own verdict alongside the findings. An agent that
+    reports it could not review the change fails the job, so an unreadable diff
+    no longer looks like a clean pass. See
+    [Custom Review Types](/advanced/custom-review-types/#structured-results-and-compatible-agents).
+
+**Bug fixes**
+
+- Non-agentic Pi reviews can no longer run commands or change files. They use
+    Pi's read-only repository tools, while agentic jobs keep the default tool
+    set. Structured reviews also retain their required JSON output tool.
+
 ## 0.67.0
 
 <small>2026-08-26</small>
@@ -46,9 +72,6 @@ All notable changes to roborev, grouped by minor release.
 
 **Bug fixes**
 
-- Non-agentic Pi reviews can no longer run commands or change files. They use
-    Pi's read-only repository tools, while agentic jobs keep the default tool
-    set. Structured reviews also retain their required JSON output tool.
 - Large Antigravity reviews no longer fail when the prompt exceeds the operating
     system's command-line limit. Non-agentic reviews can also run the workspace
     inspection commands they need.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -97,7 +97,7 @@ roborev review --branch --panel none          # Force single-agent review
 | `--type <type>` | Review type (`security`, `design`, `lookahead`); changes system prompt |
 | `--reasoning <level>` | Set a reasoning level; prefer exact `low`/`medium`/`high`/`xhigh`/`max`, while legacy presets remain supported. See [Reasoning Levels](/docs/configuration/#reasoning-levels) |
 | `--fast` | Legacy shorthand for `--reasoning fast` |
-| `--min-severity <level>` | Only report findings at or above this severity (`low`/`medium`/`high`/`critical`) |
+| `--min-severity <level>` | Lowest severity that fails the review (`low`/`medium`/`high`/`critical`); lower findings are still reported |
 | `--panel <name or none>` | Run a named review panel. Use `none` to bypass configured defaults |
 | `--local` | Run review locally without the daemon (streams output to console) |
 | `--repo <path>` | Specify repository path |
@@ -705,7 +705,7 @@ roborev ci review --comment                  # Post results as PR/MR comment
 | `--agent <names>` | Agents to use (comma-separated, default: auto-detect) |
 | `--review-types <types>` | Review types to run (comma-separated: `security`, `design`, `lookahead`, `default`) |
 | `--reasoning <level>` | Legacy (`fast`/`standard`/`thorough`/`maximum`) or exact (`low`/`medium`/`high`/`xhigh`/`max`) reasoning |
-| `--min-severity <level>` | Minimum severity to report (`low`/`medium`/`high`/`critical`) |
+| `--min-severity <level>` | Lowest severity that fails the combined review (`low`/`medium`/`high`/`critical`); lower findings are still reported |
 | `--upsert-comments` | Update the previous roborev comment instead of adding one (overrides `[ci] upsert_comments`) |
 | `--synthesis-agent <name>` | Agent for combining multi-job results |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,7 +153,7 @@ max_chars = 50000
 | `post_commit_review` | string | Post-commit hook behavior: `"commit"` (default) or `"branch"` |
 | `post_commit_batch_size` | int | Number of commits to accumulate before an automatic post-commit review. Values below `2` review every commit |
 | `hook_timeout_seconds` | int | Override the post-commit hook request timeout for this repo, in seconds. Useful for large repos where the daemon's enqueue git calls are slow. Read filesystem-only from this checkout's `.roborev.toml` (a linked worktree without its own file does not inherit the main checkout's value). Zero or negative values inherit the global / platform default |
-| `auto_close_passing_reviews` | bool | Automatically close reviews that pass with no findings |
+| `auto_close_passing_reviews` | bool | Automatically close reviews that pass, including reviews whose findings all fall below `review_min_severity` |
 | `review_reasoning` | string | Reasoning level for reviews. See [Reasoning Levels](#reasoning-levels) |
 | `refine_reasoning` | string | Reasoning level for refine. See [Reasoning Levels](#reasoning-levels) |
 | `review_min_severity` | string | Lowest severity that fails a review: `critical`, `high`, `medium`, or `low`. Lower findings are still reported. Cascades: CLI flag > repo config > global config |
@@ -845,7 +845,8 @@ review is queued, while the review still covers the entire branch.
 
 By default, all reviews remain open in the queue until you explicitly close
 them. Set `auto_close_passing_reviews = true` to automatically close reviews
-that pass with no findings:
+that pass. A review whose findings all fall below `review_min_severity` passes
+and is closed too; the findings stay readable in the closed review:
 
 ```toml
 auto_close_passing_reviews = true
@@ -906,7 +907,7 @@ column_borders = true             # Show separators between TUI columns
 | `review_guidelines` | string | - | Global reviewer instructions included in review prompts for every repo | Yes |
 | `reuse_review_session` | bool | false | (Experimental) Resume prior agent sessions on the same branch. See [Session Reuse](/docs/guides/reviewing-code/#session-reuse) | Yes |
 | `reuse_review_session_lookback` | int | 0 | Max recent session candidates to consider (0 = unlimited) | Yes |
-| `auto_close_passing_reviews` | bool | false | Automatically close reviews that pass with no findings | Yes |
+| `auto_close_passing_reviews` | bool | false | Automatically close reviews that pass, including reviews whose findings all fall below `review_min_severity` | Yes |
 | `kata_context.mode` | string | `off` | Kata task context in review prompts: `off`, `current`, or `open` | Yes |
 | `kata_context.max_chars` | int | `50000` | Maximum bytes of Kata issue context to include | Yes |
 | `review_min_severity` | string | - | Default lowest severity that fails a review: `critical`, `high`, `medium`, or `low`. Lower findings are still reported | Yes |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,7 @@ review_reasoning = "thorough"  # For code reviews (default: thorough)
 refine_reasoning = "standard"  # For refine command (default: standard)
 
 # Severity filtering
-review_min_severity = "medium"  # Skip low-severity findings in reviews
+review_min_severity = "medium"  # Low findings are reported but do not fail reviews
 fix_min_severity = "medium"     # Skip low-severity findings in fix
 refine_min_severity = "medium"  # Skip low-severity findings in refine
 
@@ -156,7 +156,7 @@ max_chars = 50000
 | `auto_close_passing_reviews` | bool | Automatically close reviews that pass with no findings |
 | `review_reasoning` | string | Reasoning level for reviews. See [Reasoning Levels](#reasoning-levels) |
 | `refine_reasoning` | string | Reasoning level for refine. See [Reasoning Levels](#reasoning-levels) |
-| `review_min_severity` | string | Minimum severity for reviews: `critical`, `high`, `medium`, or `low`. Cascades: CLI flag > repo config > global config |
+| `review_min_severity` | string | Lowest severity that fails a review: `critical`, `high`, `medium`, or `low`. Lower findings are still reported. Cascades: CLI flag > repo config > global config |
 | `fix_min_severity` | string | Minimum severity for `fix`: `critical`, `high`, `medium`, or `low` |
 | `refine_min_severity` | string | Minimum severity for `refine`: `critical`, `high`, `medium`, or `low` |
 | `reuse_review_session` | bool | (Experimental) Resume prior agent sessions on the same branch. See [Session Reuse](/docs/guides/reviewing-code/#session-reuse) |
@@ -909,7 +909,7 @@ column_borders = true             # Show separators between TUI columns
 | `auto_close_passing_reviews` | bool | false | Automatically close reviews that pass with no findings | Yes |
 | `kata_context.mode` | string | `off` | Kata task context in review prompts: `off`, `current`, or `open` | Yes |
 | `kata_context.max_chars` | int | `50000` | Maximum bytes of Kata issue context to include | Yes |
-| `review_min_severity` | string | - | Default minimum severity for reviews: `critical`, `high`, `medium`, or `low` | Yes |
+| `review_min_severity` | string | - | Default lowest severity that fails a review: `critical`, `high`, `medium`, or `low`. Lower findings are still reported | Yes |
 | `fix_min_severity` | string | - | Default minimum severity for `fix`: `critical`, `high`, `medium`, or `low` | Yes |
 | `refine_min_severity` | string | - | Default minimum severity for `refine`: `critical`, `high`, `medium`, or `low` | Yes |
 | `disable_codex_sandbox` | bool | false | Disable Codex `bwrap` sandboxing for systems where it is unavailable | Yes |

--- a/docs/guides/reviewing-code.md
+++ b/docs/guides/reviewing-code.md
@@ -213,8 +213,11 @@ roborev review --branch --min-severity medium  # Low findings are informational 
 The reviewer never sees the threshold and reports every finding with its
 severity. Roborev applies the threshold afterwards: the review fails when any
 finding is at or above it, and passes when every finding is below it. Findings
-below the threshold stay in the review output so you can still read them, and
-`roborev fix` applies its own `fix_min_severity` when choosing what to address.
+below the threshold stay in the review output so you can still read them. A
+review that passes under the threshold is a pass like any other: it is eligible
+for auto-close, and `roborev fix` and the fix skills skip it because there is
+nothing to fix. `fix_min_severity` applies only to the findings of failing
+reviews.
 
 Agents that support schema-constrained output (Codex, Claude Code, Pi, and Grok)
 return their findings as structured data for every review type, so the verdict

--- a/docs/guides/reviewing-code.md
+++ b/docs/guides/reviewing-code.md
@@ -104,7 +104,7 @@ fi
 | `--quiet` | Suppress output |
 | `--agent <name>` | Use specific agent |
 | `--reasoning <level>` | Set reasoning depth |
-| `--min-severity <level>` | Only report findings at or above this severity (`low`/`medium`/`high`/`critical`) |
+| `--min-severity <level>` | Lowest severity that fails the review (`low`/`medium`/`high`/`critical`); lower findings are still reported |
 | `--panel <name or none>` | Run a named review panel, or use `none` to force single-agent review |
 
 ## Uncommitted Changes
@@ -133,7 +133,7 @@ The `--dirty` flag includes:
 | `--quiet` | Suppress output |
 | `--agent <name>` | Use specific agent |
 | `--reasoning <level>` | Set reasoning depth |
-| `--min-severity <level>` | Only report findings at or above this severity (`low`/`medium`/`high`/`critical`) |
+| `--min-severity <level>` | Lowest severity that fails the review (`low`/`medium`/`high`/`critical`); lower findings are still reported |
 | `--panel <name or none>` | Run a named review panel, or use `none` to force single-agent review |
 
 ## Review Types
@@ -203,17 +203,27 @@ filing review findings back into Kata.
 
 ## Severity Filtering
 
-Use `--min-severity` to limit which findings the reviewer reports:
+Use `--min-severity` to decide which findings fail a review:
 
 ```bash
-roborev review --min-severity high          # Only report high and critical findings
-roborev review --branch --min-severity medium  # Skip low-severity findings in branch reviews
+roborev review --min-severity high          # Only high and critical findings fail the review
+roborev review --branch --min-severity medium  # Low findings are informational in branch reviews
 ```
 
-The severity filter is injected into the review prompt as an instruction.
-Findings below the threshold are omitted from the review output. When
-`min_severity` is set and all findings fall below the threshold, the review
-receives a passing verdict.
+The reviewer never sees the threshold and reports every finding with its
+severity. Roborev applies the threshold afterwards: the review fails when any
+finding is at or above it, and passes when every finding is below it. Findings
+below the threshold stay in the review output so you can still read them, and
+`roborev fix` applies its own `fix_min_severity` when choosing what to address.
+
+Agents that support schema-constrained output (Codex, Claude Code, Pi, and Grok)
+return their findings as structured data for every review type, so the verdict
+comes from the reported severities rather than from parsing prose. Other agents
+keep prose output, and roborev reads the severity labels in that prose the same
+way. A prose review without severity labels falls back to the agent's own pass
+or fail statement. Structured reviews also carry the agent's own verdict, shown
+in the output for context; an agent that reports it was unable to review the
+change fails the job instead of passing it.
 
 Set a default per repo in `.roborev.toml` or globally in
 `~/.roborev/config.toml`:

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -744,7 +744,7 @@ set, it takes priority over the matrix fields for that repo.
 | `review_types` | array | global `review_types` | Review types for CI reviews of this repo |
 | `reviews` | table | global `reviews` | Granular agent-to-review-type map (overrides `agents` and `review_types`; empty table disables reviews) |
 | `reasoning` | string | `"thorough"` | Legacy or exact reasoning level; see [Reasoning Levels](/docs/configuration/#reasoning-levels) |
-| `min_severity` | string | `"low"` | Minimum severity to include: `low`, `medium`, `high`, or `critical` |
+| `min_severity` | string | `"low"` | Lowest severity that fails the review: `low`, `medium`, `high`, or `critical`. Lower findings are still reported |
 | `upsert_comments` | bool | global `upsert_comments` | Override global comment upsert setting for this repo |
 | `include_costs` | bool | global `include_costs` | Include token cost estimates in PR comment footers for this repo |
 
@@ -765,7 +765,7 @@ set, it takes priority over the matrix fields for that repo.
 | `agents` | array | auto-detect | Agents to run for each PR (e.g., `["codex", "gemini"]`) |
 | `reviews` | table | | Granular agent-to-review-type map. Overrides `agents` and `review_types` when set. See [Granular Review Matrix](#granular-review-matrix). |
 | `model` | string | | Model override for CI reviews |
-| `min_severity` | string | `"low"` | Minimum severity to include in output: `low`, `medium`, `high`, or `critical` |
+| `min_severity` | string | `"low"` | Lowest severity that fails the review: `low`, `medium`, `high`, or `critical`. Lower findings are still reported |
 | `throttle_interval` | string | `"1h"` | Minimum time between reviews of the same PR. Set `"0"` to disable. |
 | `throttle_bypass_users` | array | `[]` | GitHub usernames that bypass throttling (case-insensitive) |
 | `synthesis_agent` | string | | Agent for combining implicit matrix results |
@@ -1167,7 +1167,7 @@ min_severity = "medium"
 |--------|------|---------|-------------|
 | `review_types` | array | `["security"]` | Review types to run |
 | `reasoning` | string | `"thorough"` | Reasoning level |
-| `min_severity` | string | `"low"` | Minimum severity to include in output |
+| `min_severity` | string | `"low"` | Lowest severity that fails the review; lower findings are still reported |
 
 ### Manual Workflow Setup
 

--- a/docs/integrations/gitlab.md
+++ b/docs/integrations/gitlab.md
@@ -201,25 +201,26 @@ copy the example job below.
     optional: from inside the worktree, roborev reads `.roborev.toml` from the
     merge request's tree, so its author controls the `[ci]` settings. Left
     unpinned, they could swap in a weaker agent, drop review types, or raise
-    `min_severity` to hide their own findings. Flags outrank the file, so pin
-    whatever must not be author-controlled. Model settings are the gap worth
-    knowing about: `ci review` has no `--model` flag, and a model spec may carry
-    a proxy URL (`<model>@https://host`), so an author who controls
-    `.roborev.toml` can route the review through a server that returns whatever
-    verdict they like. If that matters, review from the protected checkout
-    rather than the merge request worktree, which is the default described
-    above. `--min-severity` pins both halves of the run: the synthesis filter
-    and the threshold the individual reviews are prompted with, so a
-    `review_min_severity` in the merge request's tree cannot stop findings from
-    being reported in the first place. `review_guidelines` has no flag: it is
-    read from the default branch, but only when that branch both resolves in the
-    checkout *and* has a committed `.roborev.toml`. If either is missing — and a
-    project that never committed one always misses the second — it falls back to
-    the merge request's tree, where the author controls it. Commit a
-    `.roborev.toml` on the default branch and make sure the job can resolve that
-    branch (fetch it, or set `origin/HEAD`). The token stays out of the agents
-    either way — this is about the review's integrity, not its exposure. If the
-    runner reuses its workspace, finish with
+    `min_severity` so their own findings no longer fail the review. Flags
+    outrank the file, so pin whatever must not be author-controlled. Model
+    settings are the gap worth knowing about: `ci review` has no `--model` flag,
+    and a model spec may carry a proxy URL (`<model>@https://host`), so an
+    author who controls `.roborev.toml` can route the review through a server
+    that returns whatever verdict they like. If that matters, review from the
+    protected checkout rather than the merge request worktree, which is the
+    default described above. `--min-severity` pins the verdict threshold for the
+    combined review. Reviewers never see the threshold and every finding stays in
+    the output, so a `review_min_severity` in the merge request's tree cannot
+    hide findings; it can only change which severities fail, and the flag
+    overrides it. `review_guidelines` has no flag: it is read from the default
+    branch, but only when that branch both resolves in the checkout *and* has a
+    committed `.roborev.toml`. If either is missing — and a project that never
+    committed one always misses the second — it falls back to the merge
+    request's tree, where the author controls it. Commit a `.roborev.toml` on
+    the default branch and make sure the job can resolve that branch (fetch it,
+    or set `origin/HEAD`). The token stays out of the agents either way — this
+    is about the review's integrity, not its exposure. If the runner reuses its
+    workspace, finish with
     `cd "$CI_PROJECT_DIR" && git worktree remove --force "$mr_tree"` so the next
     run starts clean; the `cd` matters because git refuses to remove the
     worktree you are standing in.
@@ -382,7 +383,7 @@ Subgroup paths are supported: `--gl-repo group/subgroup/project`.
 | `--agent <names>` | Agents to use (comma-separated, default: auto-detect) |
 | `--review-types <types>` | Review types to run (`security`, `design`, `lookahead`, `default`) |
 | `--reasoning <level>` | Legacy or exact reasoning level; see [Reasoning Levels](/docs/configuration/#reasoning-levels) |
-| `--min-severity <level>` | Minimum severity to report (`low`/`medium`/`high`/`critical`) |
+| `--min-severity <level>` | Lowest severity that fails the combined review (`low`/`medium`/`high`/`critical`); lower findings are still reported |
 | `--synthesis-agent <name>` | Agent for combining multi-job results |
 
 Forge detection precedence, highest first:
@@ -466,7 +467,7 @@ upsert_comments = true
 |--------|------|---------|-------------|
 | `review_types` | array | `["security"]` | Review types to run |
 | `reasoning` | string | `"thorough"` | Reasoning level |
-| `min_severity` | string | `"low"` | Minimum severity to include in output |
+| `min_severity` | string | `"low"` | Lowest severity that fails the review; lower findings are still reported |
 | `upsert_comments` | bool | `false` | Update the previous roborev note instead of adding a new one |
 
 With `upsert_comments = true`, roborev finds its previous note on the merge

--- a/internal/agent/schema_agent.go
+++ b/internal/agent/schema_agent.go
@@ -47,6 +47,15 @@ func IsStructuredReviewAgent(a Agent) bool {
 	return ok
 }
 
+// SupportsStructuredReview reports whether the registered agent with this
+// name (or alias) returns schema-constrained review output. Unknown names
+// report false so prompts built before an agent is resolved fall back to the
+// prose output format.
+func SupportsStructuredReview(name string) bool {
+	a, err := Get(name)
+	return err == nil && IsStructuredReviewAgent(a)
+}
+
 // ValidateStructuredReviewSelection rejects a resolved agent that cannot run
 // a schema-constrained custom review. Built-in review types use prose output
 // and accept every Agent implementation.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4788,6 +4788,16 @@ func TestSeverityInstruction(t *testing.T) {
 	}
 }
 
+func TestSeverityRank(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(4, SeverityRank("critical"))
+	assert.Equal(3, SeverityRank(" High "))
+	assert.Equal(2, SeverityRank("medium"))
+	assert.Equal(1, SeverityRank("low"))
+	assert.Equal(0, SeverityRank(""))
+	assert.Equal(0, SeverityRank("urgent"))
+}
+
 func TestIsMarkerOnlyOutput(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -212,8 +212,8 @@ func IsMarkerOnlyOutput(output string) bool {
 	return sNoSpace == SeverityThresholdMarker
 }
 
-// SeverityInstruction returns a prompt instruction telling the agent
-// to focus only on findings at or above minSeverity. Returns "" for
+// SeverityInstruction returns a fix prompt instruction telling the agent
+// to address only findings at or above minSeverity. Returns "" for
 // empty, "low", or unrecognized input (no filtering needed).
 func SeverityInstruction(minSeverity string) string {
 	instruction, ok := severityAbove[minSeverity]
@@ -466,10 +466,11 @@ func ResolveReviewMinSeverityFromConfig(
 	return "", nil
 }
 
-// severityRank returns a numeric rank for a severity level.
-// Higher rank = stricter threshold (fewer findings pass).
-func severityRank(s string) int {
-	switch s {
+// SeverityRank returns a numeric rank for a severity level: critical is
+// 4, high 3, medium 2, low 1, and anything else 0. Higher rank means a
+// stricter threshold (fewer findings pass).
+func SeverityRank(s string) int {
+	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "critical":
 		return 4
 	case "high":
@@ -486,7 +487,7 @@ func severityRank(s string) int {
 // StricterSeverity returns whichever severity threshold is stricter
 // (filters more). Empty string means "no filter" (least strict).
 func StricterSeverity(a, b string) string {
-	if severityRank(a) >= severityRank(b) {
+	if SeverityRank(a) >= SeverityRank(b) {
 		return a
 	}
 	return b

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -176,7 +176,8 @@ func NewCIPoller(db *storage.DB, cfgGetter ConfigGetter, broadcaster Broadcaster
 		builder := prompt.NewBuilderWithConfig(p.db, cfg).
 			WithContext(ctx).
 			ForRepo(repoPath, repoID).
-			WithRepoConfig(repoCfg, repoCfgRef)
+			WithRepoConfig(repoCfg, repoCfgRef).
+			WithStructuredOutput(agent.SupportsStructuredReview(agentName))
 		return builder.BuildWithAdditionalContextAndDiffFile(
 			gitRef,
 			contextCount,
@@ -3192,7 +3193,8 @@ func (p *CIPoller) callBuildReviewPrompt(ctx context.Context, repoPath, gitRef s
 	builder := prompt.NewBuilderWithConfig(p.db, cfg).
 		WithContext(ctx).
 		ForRepo(repoPath, repoID).
-		WithRepoConfig(repoCfg, repoCfgRef)
+		WithRepoConfig(repoCfg, repoCfgRef).
+		WithStructuredOutput(agent.SupportsStructuredReview(agentName))
 	return builder.BuildWithAdditionalContextAndDiffFile(
 		gitRef,
 		contextCount,
@@ -3535,10 +3537,10 @@ func toReviewResult(
 		SkipReason:       br.SkipReason,
 		AllowFailure:     member.AllowFailure,
 	}
+	result.MinSeverity = br.MinSeverity
 	if len(br.StructuredOutput) != 0 {
 		if structured, err := reviewpkg.DecodeStructuredReview(br.StructuredOutput); err == nil {
 			result.Structured = &structured
-			result.StructuredMinSeverity = br.MinSeverity
 		}
 	}
 	return result

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -2524,52 +2524,16 @@ func TestBuildSynthesisPrompt_SanitizesErrors(t *testing.T) {
 	}
 }
 
-func TestBuildSynthesisPrompt_WithMinSeverity(t *testing.T) {
+func TestBuildSynthesisPrompt_NeverMentionsMinSeverity(t *testing.T) {
 	reviews := []review.ReviewResult{
 		{Agent: "codex", ReviewType: "security", Output: "No issues found.", Status: "done"},
 	}
-
-	t.Run("no filter when empty", func(t *testing.T) {
-		prompt := review.BuildSynthesisPrompt(reviews, "")
-		if strings.Contains(prompt, "Omit findings below") {
-			assert.Condition(t, func() bool {
-				return false
-			}, "expected no severity filter instruction when minSeverity is empty")
-		}
-	})
-
-	t.Run("no filter when low", func(t *testing.T) {
-		prompt := review.BuildSynthesisPrompt(reviews, "low")
-		if strings.Contains(prompt, "Omit findings below") {
-			assert.Condition(t, func() bool {
-				return false
-			}, "expected no severity filter instruction when minSeverity is low")
-		}
-	})
-
-	t.Run("filter for medium", func(t *testing.T) {
-		prompt := review.BuildSynthesisPrompt(reviews, "medium")
-		assertContainsAll(t, prompt, "prompt",
-			"Omit findings below medium severity",
-			"Only include Medium, High, and Critical findings.",
-		)
-	})
-
-	t.Run("filter for high", func(t *testing.T) {
-		prompt := review.BuildSynthesisPrompt(reviews, "high")
-		assertContainsAll(t, prompt, "prompt",
-			"Omit findings below high severity",
-			"Only include High and Critical findings.",
-		)
-	})
-
-	t.Run("filter for critical", func(t *testing.T) {
-		prompt := review.BuildSynthesisPrompt(reviews, "critical")
-		assertContainsAll(t, prompt, "prompt",
-			"Omit findings below critical severity",
-			"Only include Critical findings.",
-		)
-	})
+	for _, severity := range []string{"", "low", "medium", "high", "critical"} {
+		prompt := review.BuildSynthesisPrompt(reviews, severity)
+		assert.NotContains(t, prompt, "Severity threshold", "min_severity=%q", severity)
+		assert.NotContains(t, prompt, "Omit findings below", "min_severity=%q", severity)
+		assert.Contains(t, prompt, "No issues found.")
+	}
 }
 
 func TestResolveMinSeverity(t *testing.T) {

--- a/internal/daemon/synthesis_worker.go
+++ b/internal/daemon/synthesis_worker.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"go.kenn.io/roborev/internal/agent"
-	"go.kenn.io/roborev/internal/config"
 	reviewpkg "go.kenn.io/roborev/internal/review"
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -44,7 +43,7 @@ func (wp *WorkerPool) processSynthesisJob(
 	}
 	results := toReviewResults(rows)
 	for i := range results {
-		results[i] = results[i].FilterStructured(job.MinSeverity)
+		results[i] = results[i].ApplyMinSeverity(job.MinSeverity)
 	}
 	succeeded := filterSucceeded(results)
 
@@ -64,30 +63,16 @@ func (wp *WorkerPool) processSynthesisJob(
 		})
 	case 1:
 		// Exactly one member produced output — pass it through verbatim and
-		// label the review with that member's agent when no panel-level severity
-		// filter needs to be applied, or when the member already passed and
-		// there are no findings to filter.
-		if config.IsMarkerOnlyOutput(succeeded[0].Output) &&
-			succeeded[0].Passed() {
-			wp.completeSynthesisContext(workerID, job, synthesisResult{
-				agentName: succeeded[0].Agent,
-				output:    "No issues found.",
-				verdict:   succeeded[0].Verdict,
-			})
-			return
-		}
-		if !singleSuccessCanPassthrough(job.MinSeverity) &&
-			!succeeded[0].Passed() {
-			wp.synthesizeSucceededResults(ctx, workerID, job, succeeded)
-			return
-		}
+		// label the review with that member's agent. Its verdict already
+		// honors the panel threshold, so no synthesis agent is needed.
 		wp.completeSynthesisContext(workerID, job, synthesisResult{
-			agentName: succeeded[0].Agent,
-			output:    succeeded[0].Output,
-			verdict:   succeeded[0].Verdict,
+			agentName:        succeeded[0].Agent,
+			output:           succeeded[0].Output,
+			verdict:          succeeded[0].Verdict,
+			structuredOutput: succeeded[0].StructuredOutput,
 		})
 	default:
-		if allMembersPassed(results, succeeded) {
+		if allMembersPassed(results, succeeded) && !anyRetainedFindings(succeeded) {
 			wp.completeSynthesisContext(workerID, job, synthesisResult{
 				agentName: job.Agent,
 				output:    "No issues found.",
@@ -120,15 +105,6 @@ func allAvailabilitySkippedFailure(results []reviewpkg.ReviewResult) (string, bo
 	return first, true
 }
 
-func singleSuccessCanPassthrough(minSeverity string) bool {
-	switch strings.ToLower(strings.TrimSpace(minSeverity)) {
-	case "", "low":
-		return true
-	default:
-		return false
-	}
-}
-
 func (wp *WorkerPool) synthesizeSucceededResults(
 	ctx context.Context,
 	workerID string,
@@ -159,8 +135,8 @@ func (wp *WorkerPool) synthesizeSucceededResults(
 	wp.completeSynthesisContext(workerID, job, synthesisResult{
 		agentName:        resolvedAgent,
 		prompt:           prompt,
-		output:           doc.Markdown(),
-		verdict:          reviewpkg.SynthesisVerdict(doc),
+		output:           doc.Markdown(job.MinSeverity),
+		verdict:          reviewpkg.SynthesisVerdict(doc, job.MinSeverity),
 		structuredOutput: structured,
 		capturedSession:  capturedSession,
 		captureUsage:     true,
@@ -187,6 +163,24 @@ func filterSucceeded(results []reviewpkg.ReviewResult) []reviewpkg.ReviewResult 
 		}
 	}
 	return out
+}
+
+// anyRetainedFindings reports whether a passing member still carries findings
+// below the panel threshold. Those must reach the synthesized output, so the
+// clean-panel shortcut is not allowed to replace them with "No issues found."
+func anyRetainedFindings(succeeded []reviewpkg.ReviewResult) bool {
+	for _, r := range succeeded {
+		if r.Structured != nil {
+			if len(r.Structured.Findings) > 0 {
+				return true
+			}
+			continue
+		}
+		if storage.HighestSeverityLabel(r.Output) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // allMembersPassed reports whether every panel member completed successfully
@@ -244,10 +238,12 @@ func (wp *WorkerPool) failSynthesisWithoutReviewLocked(
 // capture must happen after the terminal write but before the completion
 // broadcast so a CI cost footer never renders an unpriced synthesis row.
 type synthesisResult struct {
-	agentName        string
-	prompt           string
-	output           string
-	verdict          storage.Verdict
+	agentName string
+	prompt    string
+	output    string
+	verdict   storage.Verdict
+	// structuredOutput carries a passed-through member's findings document
+	// so the synthesis review is as machine-readable as the member review.
 	structuredOutput json.RawMessage
 	capturedSession  string
 	captureUsage     bool
@@ -272,8 +268,10 @@ func (wp *WorkerPool) completeSynthesisLocked(
 	if res.verdict != storage.VerdictUnknown {
 		completeErr = wp.db.CompleteJobResult(
 			job.ID, agentName, prompt, storage.ReviewCompletion{
-				Output: output, Verdict: res.verdict,
+				Output:           output,
+				Verdict:          res.verdict,
 				StructuredOutput: res.structuredOutput,
+				MinSeverity:      job.MinSeverity,
 			},
 		)
 	} else {

--- a/internal/daemon/synthesis_worker_test.go
+++ b/internal/daemon/synthesis_worker_test.go
@@ -196,7 +196,7 @@ func TestRunSynthesisAgentMarksInvokedOnlyWhenAgentRuns(t *testing.T) {
 		agent.Register(&agent.FakeAgent{
 			NameStr: synthAgent,
 			ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
-				return `{"schema_version":1,"summary":"No issues found.","findings":[]}`, nil
+				return `{"schema_version":2,"summary":"No issues found.","verdict":"pass","findings":[]}`, nil
 			},
 		})
 		t.Cleanup(func() { agent.Unregister(synthAgent) })
@@ -245,7 +245,7 @@ func (a *synthesisEntrypointTestAgent) Synthesize(ctx context.Context, prompt st
 	if a.result != "" {
 		return json.RawMessage(a.result), nil
 	}
-	return json.RawMessage(`{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
+	return json.RawMessage(`{"schema_version":2,"summary":"synthesized output","verdict":"pass","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
 }
 
 func (a *synthesisEntrypointTestAgent) WithReasoning(agent.ReasoningLevel) agent.Agent { return a }
@@ -623,25 +623,22 @@ func TestSynthesisSingleSuccessPassthrough(t *testing.T) {
 	assert.False(synthCalled, "passthrough must not invoke an agent")
 }
 
-func TestSynthesisSingleSuccessWithMinSeverityUsesFilterPrompt(t *testing.T) {
+func TestSynthesisSingleSuccessWithMinSeverityPassesThroughBelowThreshold(t *testing.T) {
 	assert := assert.New(t)
 	tc := newWorkerTestContext(t, 1)
 
 	const memberAgent = "panel-single-minsev-member"
 	registerPassingAgent(t, memberAgent)
 
-	synthAgent := &synthesisEntrypointTestAgent{
-		name:   "panel-single-minsev-synth",
-		result: `{"schema_version":1,"summary":"No Medium, High, or Critical findings remain.","findings":[]}`,
-	}
-	agent.Register(synthAgent)
-	t.Cleanup(func() { agent.Unregister(synthAgent.name) })
+	var synthCalled bool
+	const synthAgent = "panel-single-minsev-synth"
+	registerNeverCalledAgent(t, synthAgent, &synthCalled)
 
 	runUUID, members, synthJob := enqueuePanelRun(t, tc, "single-success-minsev-panel", []memberSpec{
 		{name: "m0", agent: memberAgent},
 		{name: "m1", agent: memberAgent},
 	})
-	setSynthesisAgent(t, tc, runUUID, synthAgent.name)
+	setSynthesisAgent(t, tc, runUUID, synthAgent)
 	_, err := tc.DB.Exec(
 		"UPDATE review_jobs SET min_severity = ? WHERE id = ?",
 		"medium", synthJob.ID,
@@ -657,15 +654,11 @@ func TestSynthesisSingleSuccessWithMinSeverityUsesFilterPrompt(t *testing.T) {
 	tc.assertJobStatus(t, synth.ID, storage.JobStatusDone)
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
-	assert.Contains(review.Output, "No Medium, High, or Critical findings remain.")
-	assert.Equal(synthAgent.name, review.Agent)
-	assert.False(synthAgent.reviewCalled, "synthesis must use the synthesis entrypoint")
-	assert.Contains(synthAgent.synthPrompt, "### Review 1")
-	assert.NotContains(synthAgent.synthPrompt, "Agent="+memberAgent)
-	assert.NotContains(synthAgent.synthPrompt, "Type=")
-	assert.Contains(synthAgent.synthPrompt, "Severity: Low")
-	assert.Contains(synthAgent.synthPrompt, "Omit findings below medium severity")
-	assert.Contains(synthAgent.synthPrompt, "Only include Medium, High, and Critical findings.")
+	assert.Equal(memberOutput, review.Output, "low findings stay in the output")
+	require.NotNil(t, review.VerdictBool)
+	assert.Equal(1, *review.VerdictBool, "a low-only review passes a medium threshold")
+	assert.Equal(memberAgent, review.Agent, "passthrough remains labeled with the surviving member")
+	assert.False(synthCalled, "single-success panels never need a synthesis agent")
 }
 
 func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
@@ -691,8 +684,9 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	require.NoError(t, err)
 	const memberOutput = "## Review Findings\n\nThe summary claims a high issue.\n\n### 1. Low\n\n**Problem:** low-only\n\n**Fix:** low fix"
 	structured := json.RawMessage(`{
-  "schema_version": 1,
+  "schema_version": 2,
   "summary": "The summary claims a high issue.",
+  "verdict": "pass",
   "findings": [
     {"severity":"low","problem":"low-only","fix":"low fix","location":null}
   ]
@@ -713,40 +707,60 @@ func TestSynthesisSinglePassingSuccessWithMinSeverityPassthrough(t *testing.T) {
 	tc.assertJobStatus(t, synth.ID, storage.JobStatusDone)
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
-	assert.Contains(review.Output, "No findings at or above the configured severity threshold.")
-	assert.NotContains(review.Output, "low-only")
+	assert.Contains(review.Output, "No findings at or above medium severity.")
+	assert.Contains(review.Output, "low-only", "findings below the threshold are still rendered")
 	require.NotNil(t, review.VerdictBool)
 	assert.Equal(1, *review.VerdictBool, "panel threshold must use the structured findings")
 	assert.Equal(memberAgent, review.Agent, "passthrough remains labeled with the surviving member")
+	require.NotNil(t, review.StructuredOutput, "passthrough keeps the member's structured findings")
+	assert.Equal("The summary claims a high issue.", review.StructuredOutput["summary"])
 	assert.False(synthCalled, "passing single-success min-severity panel must not invoke synthesis")
 	memberReview, err := tc.DB.GetReviewByJobID(members[0].ID)
 	require.NoError(t, err)
 	assert.Equal("The summary claims a high issue.", memberReview.StructuredOutput["summary"])
 }
 
-func TestSynthesisSingleMarkerOnlySuccessWithMinSeverityNormalizesOutput(t *testing.T) {
+func TestSynthesisPassingMembersWithRetainedFindingsStillSynthesize(t *testing.T) {
 	assert := assert.New(t)
 	tc := newWorkerTestContext(t, 1)
 
-	const memberAgent = "panel-single-minsev-marker-member"
+	const memberAgent = "panel-retained-findings-member"
 	registerPassingAgent(t, memberAgent)
 
-	var synthCalled bool
-	const synthAgent = "panel-single-minsev-marker-synth"
-	registerNeverCalledAgent(t, synthAgent, &synthCalled)
+	synthAgent := &synthesisEntrypointTestAgent{
+		name:   "panel-retained-findings-synth",
+		result: `{"schema_version":2,"summary":"Combined.","verdict":"pass","findings":[{"severity":"low","problem":"shared nit","fix":"tidy","location":null,"sources":[1,2]}]}`,
+	}
+	agent.Register(synthAgent)
+	t.Cleanup(func() { agent.Unregister(synthAgent.name) })
 
-	runUUID, members, synthJob := enqueuePanelRun(t, tc, "single-success-minsev-marker-panel", []memberSpec{
+	runUUID, members, synthJob := enqueuePanelRun(t, tc, "retained-findings-panel", []memberSpec{
 		{name: "m0", agent: memberAgent},
 		{name: "m1", agent: memberAgent},
 	})
-	setSynthesisAgent(t, tc, runUUID, synthAgent)
+	setSynthesisAgent(t, tc, runUUID, synthAgent.name)
 	_, err := tc.DB.Exec(
-		"UPDATE review_jobs SET min_severity = ? WHERE id = ?",
-		"medium", synthJob.ID,
+		"UPDATE review_jobs SET min_severity = ? WHERE id = ?", "medium", synthJob.ID,
 	)
 	require.NoError(t, err)
-	completeMember(t, tc, members[0].ID, memberAgent, config.SeverityThresholdMarker)
-	failMember(t, tc, members[1].ID)
+	structured := json.RawMessage(`{
+  "schema_version": 2,
+  "summary": "One nit.",
+  "verdict": "pass",
+  "findings": [
+    {"severity":"low","problem":"shared nit","fix":"tidy","location":null}
+  ]
+}`)
+	for _, m := range members {
+		markMemberRunning(t, tc, m.ID)
+		require.NoError(t, tc.DB.CompleteJobResult(
+			m.ID, memberAgent, "", storage.ReviewCompletion{
+				Output:           "## Summary\n\nOne nit.\n\n## Findings\n\n### 1. Low\n\n**Problem:** shared nit\n\n**Fix:** tidy\n",
+				Verdict:          storage.VerdictFail,
+				StructuredOutput: structured,
+			},
+		))
+	}
 
 	synth := releaseAndClaimSynthesis(t, tc, runUUID)
 	tc.Pool.processSynthesisJob(context.Background(), testWorkerID, synth)
@@ -754,9 +768,12 @@ func TestSynthesisSingleMarkerOnlySuccessWithMinSeverityNormalizesOutput(t *test
 	tc.assertJobStatus(t, synth.ID, storage.JobStatusDone)
 	review, err := tc.DB.GetReviewByJobID(synth.ID)
 	require.NoError(t, err)
-	assert.Equal("No issues found.", review.Output)
-	assert.Equal(memberAgent, review.Agent, "normalized output remains labeled with the surviving member")
-	assert.False(synthCalled, "marker-only single-success min-severity panel must not invoke synthesis")
+	assert.Contains(synthAgent.synthPrompt, "shared nit", "retained findings reach the synthesis agent")
+	assert.NotContains(synthAgent.synthPrompt, "at or above", "the threshold is hidden from synthesis")
+	assert.Contains(review.Output, "shared nit", "retained findings survive synthesis")
+	assert.NotEqual("No issues found.", review.Output)
+	require.NotNil(t, review.VerdictBool)
+	assert.Equal(1, *review.VerdictBool, "low-only findings pass a medium threshold")
 }
 
 func TestSynthesisAllPassingSkipsAgent(t *testing.T) {
@@ -984,7 +1001,7 @@ func TestSynthesisMultiVerifyDedupe(t *testing.T) {
 		NameStr: synthAgent,
 		ReviewFn: func(_ context.Context, _, _, prompt string, _ io.Writer) (string, error) {
 			captured = prompt
-			return `{"schema_version":1,"summary":"Combined","findings":[{"severity":"high","problem":"Consolidated finding.","fix":"Fix it.","location":"alpha.go:1","sources":[1,2]}]}`, nil
+			return `{"schema_version":2,"summary":"Combined","verdict":"pass","findings":[{"severity":"high","problem":"Consolidated finding.","fix":"Fix it.","location":"alpha.go:1","sources":[1,2]}]}`, nil
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(synthAgent) })
@@ -1192,7 +1209,7 @@ func TestSynthesisRunsAgainstWorktree(t *testing.T) {
 		NameStr: synthAgent,
 		ReviewFn: func(_ context.Context, repoPath, _, _ string, _ io.Writer) (string, error) {
 			capturedPath = repoPath
-			return `{"schema_version":1,"summary":"Done.","findings":[]}`, nil
+			return `{"schema_version":2,"summary":"Done.","verdict":"pass","findings":[]}`, nil
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(synthAgent) })
@@ -1230,7 +1247,7 @@ func TestSynthesisStoresFindingWithoutLocation(t *testing.T) {
 	agent.Register(&agent.FakeAgent{
 		NameStr: synthAgent,
 		ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) {
-			return `{"schema_version":1,"summary":"One finding without a location.","findings":[{"severity":"medium","problem":"Missing test","fix":"Add one","location":null,"sources":[1]}]}`, nil
+			return `{"schema_version":2,"summary":"One finding without a location.","verdict":"pass","findings":[{"severity":"medium","problem":"Missing test","fix":"Add one","location":null,"sources":[1]}]}`, nil
 		},
 	})
 	t.Cleanup(func() { agent.Unregister(synthAgent) })

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -588,13 +588,21 @@ func (wp *WorkerPool) basePromptBuilderForJob(
 ) *prompt.Builder {
 	builder := prompt.NewBuilderWithConfig(wp.db, cfg).
 		WithContext(ctx).
-		ForRepo(checkout.promptRepoPath, job.RepoID)
+		ForRepo(checkout.promptRepoPath, job.RepoID).
+		WithStructuredOutput(reviewJobUsesStructuredOutput(job))
 	if !job.IsCIReview() {
 		builder = builder.WithKataClient(
 			kata.NewCLIClient(checkout.promptRepoPath),
 		)
 	}
 	return builder
+}
+
+// reviewJobUsesStructuredOutput reports whether a review job's agent returns
+// schema-constrained findings. Fix, task, and compact jobs always run as prose
+// because their stored prompts define their own output contract.
+func reviewJobUsesStructuredOutput(job *storage.ReviewJob) bool {
+	return job.IsReviewJob() && agent.SupportsStructuredReview(job.Agent)
 }
 
 // markAgentInvoked records that an agent is being invoked for this attempt. Call

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1070,6 +1070,14 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		log.Printf("[%s] Agent %s not available, using %s", workerID, job.Agent, agentName)
 	}
 
+	// A prebuilt CI prompt was written for the agent configured at enqueue
+	// time. After failover the running agent may parse output differently,
+	// so align the output instruction with the agent that will answer.
+	if job.PromptPrebuilt && job.IsReviewJob() {
+		_, structured := a.(agent.StructuredReviewAgent)
+		reviewPrompt = prompt.ReconcileStructuredOutputInstruction(reviewPrompt, structured)
+	}
+
 	// Enforce the final submission size after all prompt transformations.
 	// Oversized prompts are deterministic and should never be sent to any
 	// agent just to discover a context-window failure.

--- a/internal/daemon/worker.go
+++ b/internal/daemon/worker.go
@@ -1070,18 +1070,27 @@ func (wp *WorkerPool) processJob(workerID string, job *storage.ReviewJob) {
 		log.Printf("[%s] Agent %s not available, using %s", workerID, job.Agent, agentName)
 	}
 
+	maxPromptSize := config.ResolveMaxPromptSize(checkout.promptRepoPath, cfg)
+
 	// A prebuilt CI prompt was written for the agent configured at enqueue
 	// time. After failover the running agent may parse output differently,
-	// so align the output instruction with the agent that will answer.
+	// so align the output instruction with the agent that will answer. A
+	// prompt already at the size limit keeps running without the appended
+	// guidance rather than failing before the backup agent ever runs; the
+	// schema still constrains the answer.
 	if job.PromptPrebuilt && job.IsReviewJob() {
 		_, structured := a.(agent.StructuredReviewAgent)
-		reviewPrompt = prompt.ReconcileStructuredOutputInstruction(reviewPrompt, structured)
+		reconciled := prompt.ReconcileStructuredOutputInstruction(reviewPrompt, structured)
+		if maxPromptSize > 0 && len(reconciled) > maxPromptSize && len(reviewPrompt) <= maxPromptSize {
+			log.Printf("[%s] Prompt for job %d is at the size limit; running %s without the structured output instruction", workerID, job.ID, agentName)
+		} else {
+			reviewPrompt = reconciled
+		}
 	}
 
 	// Enforce the final submission size after all prompt transformations.
 	// Oversized prompts are deterministic and should never be sent to any
 	// agent just to discover a context-window failure.
-	maxPromptSize := config.ResolveMaxPromptSize(checkout.promptRepoPath, cfg)
 	if maxPromptSize > 0 && len(reviewPrompt) > maxPromptSize {
 		wp.failoverOrFailNonRetryableAgentContext(
 			ctx, workerID, job, agentName,

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -50,6 +50,8 @@ type workerTestContext struct {
 type structuredWorkerTestAgent struct {
 	name   string
 	result json.RawMessage
+	// prompt records the last prompt passed to ReviewWithSchema.
+	prompt string
 }
 
 func (a *structuredWorkerTestAgent) Name() string { return a.name }
@@ -61,10 +63,11 @@ func (a *structuredWorkerTestAgent) Review(
 
 func (a *structuredWorkerTestAgent) ReviewWithSchema(
 	_ context.Context,
-	_, _, _ string,
+	_, _, reviewPrompt string,
 	_ json.RawMessage,
 	_ io.Writer,
 ) (json.RawMessage, error) {
+	a.prompt = reviewPrompt
 	return a.result, nil
 }
 
@@ -1378,6 +1381,73 @@ func TestProcessJob_CIPrebuiltPromptDoesNotLoadRepoConfig(t *testing.T) {
 	updated := tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
 	assert.Equal(t, job.Prompt, capturedPrompt)
 	assert.Equal(t, job.Prompt, updated.Prompt)
+}
+
+func TestProcessJob_CIPrebuiltPromptMatchesRunningAgentOutputContract(t *testing.T) {
+	instruction := prompt.ReconcileStructuredOutputInstruction("", true)
+	require.NotEmpty(t, instruction)
+
+	enqueuePrebuilt := func(t *testing.T, tc *workerTestContext, agentName, body string) *storage.ReviewJob {
+		t.Helper()
+		sha := testutil.GetHeadSHA(t, tc.TmpDir)
+		commit, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, sha, "Author", "Subject", time.Now())
+		require.NoError(t, err)
+		job, err := tc.DB.EnqueueJob(storage.EnqueueOpts{
+			RepoID:         tc.Repo.ID,
+			CommitID:       commit.ID,
+			GitRef:         sha,
+			CIBaseBranch:   "main",
+			Agent:          agentName,
+			Prompt:         body,
+			PromptPrebuilt: true,
+			JobType:        storage.JobTypeRange,
+		})
+		require.NoError(t, err)
+		claimed, err := tc.DB.ClaimJob(testWorkerID)
+		require.NoError(t, err)
+		require.Equal(t, job.ID, claimed.ID)
+		tc.Pool.processJob(testWorkerID, claimed)
+		return job
+	}
+
+	t.Run("prose agent after failover loses the JSON instruction", func(t *testing.T) {
+		tc := newWorkerTestContext(t, 1)
+		var capturedPrompt string
+		agentName := "prebuilt-prose-after-failover"
+		agent.Register(&agent.FakeAgent{
+			NameStr: agentName,
+			ReviewFn: func(_ context.Context, _, _, reviewPrompt string, _ io.Writer) (string, error) {
+				capturedPrompt = reviewPrompt
+				return "No issues found.", nil
+			},
+		})
+		t.Cleanup(func() { agent.Unregister(agentName) })
+
+		body := "review body" + instruction + "\n"
+		job := enqueuePrebuilt(t, tc, agentName, body)
+
+		updated := tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+		assert.Contains(t, capturedPrompt, "review body")
+		assert.NotContains(t, capturedPrompt, instruction)
+		assert.Equal(t, body, updated.Prompt, "the stored prompt is left as enqueued")
+	})
+
+	t.Run("structured agent after failover gains the JSON instruction", func(t *testing.T) {
+		tc := newWorkerTestContext(t, 1)
+		agentName := "prebuilt-structured-after-failover"
+		fake := &structuredWorkerTestAgent{
+			name:   agentName,
+			result: json.RawMessage(`{"schema_version":2,"summary":"Clean.","verdict":"pass","findings":[]}`),
+		}
+		agent.Register(fake)
+		t.Cleanup(func() { agent.Unregister(agentName) })
+
+		job := enqueuePrebuilt(t, tc, agentName, "review body\n")
+
+		tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+		assert.Contains(t, fake.prompt, "review body")
+		assert.Contains(t, fake.prompt, instruction)
+	})
 }
 
 func TestProcessJob_CIPromptFallbackUsesDefaultBranchReviewTypeConfig(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -1448,6 +1448,27 @@ func TestProcessJob_CIPrebuiltPromptMatchesRunningAgentOutputContract(t *testing
 		assert.Contains(t, fake.prompt, "review body")
 		assert.Contains(t, fake.prompt, instruction)
 	})
+
+	t.Run("cap-sized prompt runs without the instruction instead of failing", func(t *testing.T) {
+		tc := newWorkerTestContext(t, 1)
+		cfg := config.DefaultConfig()
+		cfg.DefaultMaxPromptSize = 4096
+		tc.reconfigurePool(cfg)
+		agentName := "prebuilt-structured-at-cap"
+		fake := &structuredWorkerTestAgent{
+			name:   agentName,
+			result: json.RawMessage(`{"schema_version":2,"summary":"Clean.","verdict":"pass","findings":[]}`),
+		}
+		agent.Register(fake)
+		t.Cleanup(func() { agent.Unregister(agentName) })
+
+		body := "review body\n" + strings.Repeat("x", 4096-len("review body\n"))
+		require.Len(t, body, 4096)
+		job := enqueuePrebuilt(t, tc, agentName, body)
+
+		tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
+		assert.Equal(t, body, fake.prompt, "the prompt is sent unchanged rather than over the cap")
+	})
 }
 
 func TestProcessJob_CIPromptFallbackUsesDefaultBranchReviewTypeConfig(t *testing.T) {

--- a/internal/daemon/worker_test.go
+++ b/internal/daemon/worker_test.go
@@ -323,14 +323,15 @@ func TestWorkerPoolPendingCancellationAfterDBCancel(t *testing.T) {
 	}
 }
 
-func TestWorkerStoresFilteredStructuredCustomReview(t *testing.T) {
+func TestWorkerStoresStructuredCustomReviewWithEveryFinding(t *testing.T) {
 	tc := newWorkerTestContext(t, 1)
 	agentName := "structured-review-test"
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
-  "schema_version":1,
+  "schema_version":2,
   "summary":"Review complete.",
+  "verdict":"fail",
   "findings":[
     {"severity":"high","problem":"State diverges.","fix":"Use one owner.","location":null},
     {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
@@ -364,9 +365,9 @@ func TestWorkerStoresFilteredStructuredCustomReview(t *testing.T) {
 	stored, err := tc.DB.GetReviewByJobID(job.ID)
 	require.NoError(t, err)
 	assert.Contains(t, stored.Output, "State diverges.")
-	assert.NotContains(t, stored.Output, "Name is vague.")
+	assert.Contains(t, stored.Output, "Name is vague.", "findings below the threshold stay in the review")
 	require.NotNil(t, stored.VerdictBool)
-	assert.Equal(t, 0, *stored.VerdictBool)
+	assert.Equal(t, 0, *stored.VerdictBool, "the high finding fails the review")
 }
 
 func registerUnreadableDiffAgent(t *testing.T, name string) {
@@ -425,8 +426,9 @@ func TestWorkerUsesConfiguredSeverityForStructuredVerdict(t *testing.T) {
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
-	  "schema_version":1,
+	  "schema_version":2,
 	  "summary":"High: no actionable findings.",
+	  "verdict":"pass",
   "findings":[
     {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
   ]
@@ -1384,8 +1386,9 @@ func TestProcessJob_CIPromptFallbackUsesDefaultBranchReviewTypeConfig(t *testing
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
-  "schema_version":1,
+  "schema_version":2,
   "summary":"Default-branch review instructions loaded.",
+  "verdict":"pass",
   "findings":[]
 }`),
 	})
@@ -1440,8 +1443,9 @@ func TestProcessJob_CIPromptFallbackKeepsDefaultRefAfterConfigParseError(t *test
 	agent.Register(&structuredWorkerTestAgent{
 		name: agentName,
 		result: json.RawMessage(`{
-  "schema_version":1,
+  "schema_version":2,
   "summary":"Global review instructions loaded from the default branch.",
+  "verdict":"pass",
   "findings":[]
 }`),
 	})
@@ -3883,8 +3887,13 @@ func TestProcessJob_MinSeverityCascade(t *testing.T) {
 	tc.Pool.processJob("test-worker", claimed)
 
 	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
-	assert.Contains(t, capturedPrompt, "Severity filter:")
-	assert.Contains(t, capturedPrompt, "SEVERITY_THRESHOLD_MET")
+	assert.NotContains(t, capturedPrompt, "Severity threshold",
+		"the threshold is post-processing and never reaches the agent")
+	assert.NotContains(t, capturedPrompt, "SEVERITY_THRESHOLD_MET",
+		"review prompts must not ask the agent to drop findings")
+	stored, err := tc.DB.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "medium", stored.MinSeverity, "the cascaded threshold is recorded on the job")
 }
 
 func TestProcessJob_MinSeverityJobOverrideWins(t *testing.T) {
@@ -3925,7 +3934,10 @@ func TestProcessJob_MinSeverityJobOverrideWins(t *testing.T) {
 	tc.Pool.processJob("test-worker", claimed)
 
 	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
-	assert.Contains(t, capturedPrompt, "Critical")
+	assert.NotContains(t, capturedPrompt, "Severity threshold")
+	stored, err := tc.DB.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "critical", stored.MinSeverity, "the job override wins over global config")
 }
 
 func TestProcessJobExperimentPlanKeepsClearedExecutionSettings(t *testing.T) {
@@ -3974,7 +3986,7 @@ func TestProcessJobExperimentPlanKeepsClearedExecutionSettings(t *testing.T) {
 
 	tc.assertJobStatus(t, job.ID, storage.JobStatusDone)
 	assert.NotNil(t, claimed.FrozenExperimentPlan)
-	assert.NotContains(t, capturedPrompt, "Severity filter:")
+	assert.NotContains(t, capturedPrompt, "Severity threshold:")
 	assert.Empty(t, tc.Pool.resolveBackupAgent(claimed))
 	assert.Empty(t, tc.Pool.resolveBackupModel(claimed))
 }

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -14,14 +14,15 @@ import (
 	"go.kenn.io/roborev/internal/git"
 )
 
-const customReviewOutputInstruction = `
+const structuredReviewOutputInstruction = `
 
 Roborev will constrain the final response with a JSON Schema. Return a concise
-summary and every actionable finding. Each finding must include its severity,
-problem, and recommended fix; include a location when one is known. Use only
-these severity values: critical, high, medium, or low. Do not omit a real
-finding because of the configured severity threshold; Roborev applies that
-threshold after receiving the structured result.`
+summary, your overall verdict, and every actionable finding. Each finding must
+include its severity, problem, and recommended fix; include a location when one
+is known. Use only these severity values: critical, high, medium, or low. The
+verdict is "pass" when the change is acceptable, "fail" when it is not, and
+"unable_to_review" only when you could not assess the change at all, for
+example because the diff is missing or unreadable; explain why in the summary.`
 
 type customReviewTemplateData struct {
 	ReviewType string
@@ -93,7 +94,7 @@ func (b *Builder) resolveSystemPrompt(
 		)
 	}
 	result := strings.TrimSpace(rendered.String()) +
-		customReviewOutputInstruction
+		structuredReviewOutputInstruction
 	if len(result)+1 > limit {
 		return "", true, fmt.Errorf(
 			"review type %q rendered prompt is %d bytes but prompt limit is %d bytes",

--- a/internal/prompt/custom_review.go
+++ b/internal/prompt/custom_review.go
@@ -24,6 +24,25 @@ verdict is "pass" when the change is acceptable, "fail" when it is not, and
 "unable_to_review" only when you could not assess the change at all, for
 example because the diff is missing or unreadable; explain why in the summary.`
 
+// ReconcileStructuredOutputInstruction makes a prebuilt review prompt match
+// the agent that will actually run it. Prompts are built before failover,
+// so a prompt written for a structured agent may reach a prose agent and
+// vice versa. A prose agent must not be told its answer will be
+// schema-constrained, and a structured agent should be told what the schema
+// expects. The instruction is appended only when absent, so custom prompts
+// that already embed it are unchanged.
+func ReconcileStructuredOutputInstruction(prompt string, structured bool) string {
+	present := strings.Contains(prompt, structuredReviewOutputInstruction)
+	switch {
+	case structured && !present:
+		return prompt + structuredReviewOutputInstruction
+	case !structured && present:
+		return strings.ReplaceAll(prompt, structuredReviewOutputInstruction, "")
+	default:
+		return prompt
+	}
+}
+
 type customReviewTemplateData struct {
 	ReviewType string
 	Includes   map[string]string

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -213,3 +213,23 @@ func TestCustomReviewFilesUsePromptLimit(t *testing.T) {
 		)
 	require.ErrorContains(t, err, "prompt limit")
 }
+
+func TestBuiltInReviewPromptStructuredOutputInstruction(t *testing.T) {
+	repoPath := t.TempDir()
+	const diff = "diff --git a/a.go b/a.go"
+
+	prose, err := NewBuilder(nil).ForRepo(repoPath, 0).
+		BuildDirty(diff, 0, "codex", "", "high")
+	require.NoError(t, err)
+	assert.NotContains(t, prose, "Roborev will constrain the final response with a JSON Schema")
+	assert.NotContains(t, prose, "Severity threshold", "the threshold never reaches the agent")
+	assert.NotContains(t, prose, "SEVERITY_THRESHOLD_MET")
+
+	structured, err := NewBuilder(nil).ForRepo(repoPath, 0).WithStructuredOutput(true).
+		BuildDirty(diff, 0, "codex", "", "high")
+	require.NoError(t, err)
+	assert.Contains(t, structured, "Roborev will constrain the final response with a JSON Schema")
+	assert.Contains(t, structured, `"unable_to_review" only when you could not assess the change`)
+	assert.NotContains(t, structured, "Severity threshold")
+	assert.NotContains(t, structured, "high severity")
+}

--- a/internal/prompt/custom_review_test.go
+++ b/internal/prompt/custom_review_test.go
@@ -233,3 +233,17 @@ func TestBuiltInReviewPromptStructuredOutputInstruction(t *testing.T) {
 	assert.NotContains(t, structured, "Severity threshold")
 	assert.NotContains(t, structured, "high severity")
 }
+
+func TestReconcileStructuredOutputInstruction(t *testing.T) {
+	assert := assert.New(t)
+	prose := "Review the change.\n"
+	structured := prose + structuredReviewOutputInstruction
+
+	assert.Equal(structured, ReconcileStructuredOutputInstruction(prose, true),
+		"a structured agent gets the instruction appended")
+	assert.Equal(structured, ReconcileStructuredOutputInstruction(structured, true),
+		"an existing instruction is not duplicated")
+	assert.Equal(prose, ReconcileStructuredOutputInstruction(structured, false),
+		"a prose agent never sees the JSON instruction")
+	assert.Equal(prose, ReconcileStructuredOutputInstruction(prose, false))
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -97,6 +97,9 @@ type Builder struct {
 	repoPath   string
 	repoID     int64
 	kataClient kata.Client
+	// structuredOutput appends the JSON output instruction to built-in
+	// review prompts when the agent will return schema-constrained findings.
+	structuredOutput bool
 }
 
 // DiffFilePathPlaceholder is a sentinel path embedded in prebuilt
@@ -143,6 +146,15 @@ func (b *Builder) ForRepo(repoPath string, repoID int64) *Builder {
 	next := *b
 	next.repoPath = repoPath
 	next.repoID = repoID
+	return &next
+}
+
+// WithStructuredOutput returns a builder that tells built-in review prompts
+// the response will be constrained by Roborev's review JSON Schema. Custom
+// review types always carry that instruction.
+func (b *Builder) WithStructuredOutput(enabled bool) *Builder {
+	next := *b
+	next.structuredOutput = enabled
 	return &next
 }
 
@@ -806,7 +818,8 @@ type buildOpts struct {
 	// is available. Set by BuildWithDiffFile so the worker can
 	// detect when a snapshot is needed.
 	requireDiffFile bool
-	// minSeverity, when non-empty, injects a severity filter
+	// minSeverity is accepted for call-site symmetry. The threshold is applied
+	// after the review runs and is never shown to the agent.
 	// instruction into the system prompt.
 	minSeverity string
 }
@@ -832,12 +845,11 @@ func (b *Builder) newPromptBuildContext(agentName, reviewType, minSeverity, defa
 	if err != nil {
 		return promptBuildContext{}, err
 	}
-	requiredPrefix := systemPrompt + "\n"
-	if !custom {
-		if inst := config.SeverityInstruction(minSeverity); inst != "" {
-			requiredPrefix += inst + "\n"
-		}
+	requiredPrefix := systemPrompt
+	if !custom && b.structuredOutput {
+		requiredPrefix += structuredReviewOutputInstruction
 	}
+	requiredPrefix += "\n"
 	if custom && len(requiredPrefix) > promptCap {
 		return promptBuildContext{}, fmt.Errorf(
 			"custom review prompt is %d bytes but prompt limit is %d bytes",

--- a/internal/prompt/testdata/golden/single_with_severity_filter.golden
+++ b/internal/prompt/testdata/golden/single_with_severity_filter.golden
@@ -52,8 +52,6 @@ Check the manifests for each changed file's language, including every language a
 
 Current date: GOLDEN_DATE (UTC)
 
-Severity filter: Only include Medium, High, and Critical findings. Ignore any findings below medium severity. If ALL findings in the review are below medium severity, output the exact text SEVERITY_THRESHOLD_MET and make no code changes.
-
 ## Current Commit
 
 **Commit:** fde21d1

--- a/internal/review/batch.go
+++ b/internal/review/batch.go
@@ -37,7 +37,8 @@ type BatchConfig struct {
 	// AgentRegistry is an optional registry for dependency injection in testing.
 	// If nil, the global agent registry is used.
 	AgentRegistry map[string]agent.Agent
-	// MinSeverity is the minimum severity threshold for the review prompt.
+	// MinSeverity is the lowest severity that fails a review. Lower
+	// findings are still reported.
 	// When non-empty (and not "low"), agents are instructed to filter findings.
 	MinSeverity string
 }
@@ -192,7 +193,8 @@ func runSingle(
 	builder := prompt.NewBuilderWithConfig(nil, cfg.GlobalConfig).
 		WithContext(ctx).
 		ForRepo(cfg.RepoPath, 0).
-		WithRepoConfig(cfg.RepoConfig, cfg.RepoConfigRef)
+		WithRepoConfig(cfg.RepoConfig, cfg.RepoConfigRef).
+		WithStructuredOutput(agent.IsStructuredReviewAgent(resolvedAgent))
 
 	// Normalize review type for prompt building
 	promptReviewType := reviewType
@@ -236,7 +238,7 @@ func runSingle(
 	result.Output = agentReview.Output
 	result.Structured = agentReview.Structured
 	result.StructuredOutput = agentReview.StructuredOutput
-	result.StructuredMinSeverity = agentReview.StructuredMinSeverity
+	result.MinSeverity = agentReview.MinSeverity
 	result.Verdict = agentReview.Verdict
 	return result
 }

--- a/internal/review/batch_test.go
+++ b/internal/review/batch_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go.kenn.io/roborev/internal/agent"
 	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )
 
@@ -390,7 +391,8 @@ func TestRunBatchPreservesStructuredVerdict(t *testing.T) {
 	structuredAgent := &structuredBatchAgent{
 		name: "structured-batch",
 		result: json.RawMessage(`{
-	  "schema_version":1,
+	  "schema_version":2,
+	  "verdict": "pass",
 	  "summary":"High: no actionable findings.",
   "findings":[
     {"severity":"low","problem":"Name is vague.","fix":"Rename it.","location":null}
@@ -607,6 +609,8 @@ func TestRunBatch_CodexReviewSettings(t *testing.T) {
 	results := RunBatch(context.Background(), cfg)
 	require.Len(t, results, 1)
 	require.Equal(t, ResultDone, results[0].Status, "status=%q err=%q", results[0].Status, results[0].Error)
+	require.NotNil(t, results[0].Structured, "codex built-in reviews use schema output")
+	assert.Equal(t, storage.VerdictPass, results[0].Verdict)
 
 	argsBytes, err := os.ReadFile(argsPath)
 	require.NoError(t, err)
@@ -624,7 +628,9 @@ func writeFakeCodex(t *testing.T) (cmdPath string, argsPath string) {
 		"#!/bin/sh",
 		"case \"$*\" in *--help*) echo 'usage --sandbox --ignore-user-config'; exit 0;; esac",
 		fmt.Sprintf("echo \"$@\" > %q", argsPath),
-		"echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"No issues found.\"}}'",
+		// The fake returns a structured review document because the real
+		// codex agent supports schema-constrained output for every review type.
+		"echo '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"{\\\"schema_version\\\":2,\\\"summary\\\":\\\"ok\\\",\\\"verdict\\\":\\\"pass\\\",\\\"findings\\\":[]}\"}}'",
 	}, "\n") + "\n"
 
 	cmdPath = filepath.Join(dir, "codex")

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -30,10 +31,11 @@ type ReviewResult struct {
 	// StructuredOutput is the unfiltered JSON returned by the agent. Queued
 	// reviews persist it so a later panel threshold can use the same findings.
 	StructuredOutput json.RawMessage
-	// StructuredMinSeverity is the threshold already applied to Output and
-	// Verdict. Later consumers combine it with their own threshold instead of
-	// accidentally restoring findings that were already excluded.
-	StructuredMinSeverity string
+	// MinSeverity is the threshold already applied to Verdict (and, for
+	// structured reviews, to the rendered Output). Later consumers combine it
+	// with their own threshold instead of relaxing a verdict that was already
+	// decided under a stricter one.
+	MinSeverity string
 
 	// Skipped/SkipReason are populated for skipped (auto-design) rows so
 	// synthesis can render them as a distinct short section instead of
@@ -56,20 +58,24 @@ func (r ReviewResult) Passed() bool {
 	return storage.ParseVerdict(r.Output) == storage.VerdictPass
 }
 
-// FilterStructured applies minSeverity to schema-backed output and updates the
-// rendered text and verdict together. Prose review results are unchanged.
-func (r ReviewResult) FilterStructured(minSeverity string) ReviewResult {
-	if r.Structured == nil {
+// ApplyMinSeverity re-derives the verdict under the stricter of the result's
+// own threshold and minSeverity. Findings are never dropped: structured
+// reviews re-render every finding and pass when none reaches the threshold,
+// and prose reviews re-parse their severity labels the same way. Failed and
+// skipped results are returned unchanged.
+func (r ReviewResult) ApplyMinSeverity(minSeverity string) ReviewResult {
+	effective := config.StricterSeverity(r.MinSeverity, minSeverity)
+	if r.Structured != nil {
+		r.MinSeverity = effective
+		r.Verdict = storage.VerdictFromPassed(r.Structured.Passed(effective))
+		r.Output = r.Structured.Markdown(effective)
 		return r
 	}
-	effectiveMinSeverity := stricterMinSeverity(
-		r.StructuredMinSeverity, minSeverity,
-	)
-	filtered := r.Structured.Filter(effectiveMinSeverity)
-	r.Structured = &filtered
-	r.StructuredMinSeverity = effectiveMinSeverity
-	r.Verdict = storage.VerdictFromPassed(filtered.Passed())
-	r.Output = filtered.Markdown()
+	if effective == r.MinSeverity || !IsSubstantiveOutput(r) {
+		return r
+	}
+	r.MinSeverity = effective
+	r.Verdict = storage.ParseVerdictAtSeverity(r.Output, effective)
 	return r
 }
 

--- a/internal/review/result.go
+++ b/internal/review/result.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -32,9 +31,8 @@ type ReviewResult struct {
 	// reviews persist it so a later panel threshold can use the same findings.
 	StructuredOutput json.RawMessage
 	// MinSeverity is the threshold already applied to Verdict (and, for
-	// structured reviews, to the rendered Output). Later consumers combine it
-	// with their own threshold instead of relaxing a verdict that was already
-	// decided under a stricter one.
+	// structured reviews, to the rendered Output). Findings are never dropped,
+	// so a later consumer can re-derive the verdict under its own threshold.
 	MinSeverity string
 
 	// Skipped/SkipReason are populated for skipped (auto-design) rows so
@@ -58,13 +56,19 @@ func (r ReviewResult) Passed() bool {
 	return storage.ParseVerdict(r.Output) == storage.VerdictPass
 }
 
-// ApplyMinSeverity re-derives the verdict under the stricter of the result's
-// own threshold and minSeverity. Findings are never dropped: structured
+// ApplyMinSeverity re-derives the verdict under minSeverity, replacing the
+// threshold the result was decided under. A panel or CI threshold therefore
+// applies to the combined review exactly as configured, whether it is looser
+// or stricter than the member's own. Findings are never dropped: structured
 // reviews re-render every finding and pass when none reaches the threshold,
-// and prose reviews re-parse their severity labels the same way. Failed and
-// skipped results are returned unchanged.
+// and prose reviews re-parse their severity labels the same way. An empty
+// minSeverity keeps the result's threshold. Failed and skipped results are
+// returned unchanged.
 func (r ReviewResult) ApplyMinSeverity(minSeverity string) ReviewResult {
-	effective := config.StricterSeverity(r.MinSeverity, minSeverity)
+	effective := strings.ToLower(strings.TrimSpace(minSeverity))
+	if effective == "" {
+		effective = r.MinSeverity
+	}
 	if r.Structured != nil {
 		r.MinSeverity = effective
 		r.Verdict = storage.VerdictFromPassed(r.Structured.Passed(effective))

--- a/internal/review/result_test.go
+++ b/internal/review/result_test.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,7 +9,142 @@ import (
 	"go.kenn.io/roborev/internal/storage"
 )
 
-func TestApplyMinSeverityProseReparsesUnderStricterThreshold(t *testing.T) {
+func TestTrimPartialRune(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"ascii only", "hello", "hello"},
+		{
+			"clean emoji boundary",
+			"abc😀",
+			"abc😀",
+		},
+		{
+			"split 4-byte emoji after 1 byte",
+			"abc" + string([]byte{0xF0}),
+			"abc",
+		},
+		{
+			"split 4-byte emoji after 2 bytes",
+			"abc" + string([]byte{0xF0, 0x9F}),
+			"abc",
+		},
+		{
+			"split 4-byte emoji after 3 bytes",
+			"abc" + string([]byte{0xF0, 0x9F, 0x98}),
+			"abc",
+		},
+		{
+			"split 2-byte char after 1 byte",
+			"abc" + string([]byte{0xC3}),
+			"abc",
+		},
+		{
+			"interior invalid bytes preserved",
+			"a" + string([]byte{0xFF}) + "b",
+			"a" + string([]byte{0xFF}) + "b",
+		},
+		{
+			"orphan continuation byte",
+			"abc" + string([]byte{0x80}),
+			"abc",
+		},
+		{
+			"two orphan continuation bytes",
+			"abc" + string([]byte{0x80, 0x80}),
+			"abc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TrimPartialRune(tt.in)
+			assert.Equalf(tt.want, got, "TrimPartialRune(%q) = %q, want %q", tt.in, got, tt.want)
+		})
+	}
+}
+
+func TestTrimPartialRune_NoFullStringScan(t *testing.T) {
+	assert := assert.New(t)
+
+	// Verify that a string with interior invalid UTF-8 is NOT
+	// stripped down to empty — only the trailing boundary matters.
+	// This is the bug that utf8.ValidString would cause.
+	interior := strings.Repeat("x", 1000) +
+		string([]byte{0xFF}) +
+		strings.Repeat("y", 1000)
+	got := TrimPartialRune(interior)
+	assert.Equalf(interior, got, "interior invalid bytes should be preserved, got len %d want len %d", len(got), len(interior))
+}
+
+func TestHasSubstantiveOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		results []ReviewResult
+		want    bool
+	}{
+		{name: "empty batch"},
+		{
+			name: "completed output",
+			results: []ReviewResult{{
+				Status: ResultDone,
+				Output: "## Findings\n",
+			}},
+			want: true,
+		},
+		{
+			name: "completed whitespace",
+			results: []ReviewResult{{
+				Status: ResultDone,
+				Output: " \n\t",
+			}},
+		},
+		{
+			name: "completed empty-output placeholder",
+			results: []ReviewResult{{
+				Status: ResultDone,
+				Output: "No review output generated",
+			}},
+		},
+		{
+			name: "failed output",
+			results: []ReviewResult{{
+				Status: ResultFailed,
+				Output: "partial diagnostics",
+			}},
+		},
+		{
+			name: "skipped output",
+			results: []ReviewResult{{
+				Status: ResultSkipped,
+				Output: "not a review",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasSubstantiveOutput(tt.results))
+		})
+	}
+}
+
+func TestUnavailableError(t *testing.T) {
+	assert.Equal(t,
+		UnavailableErrorPrefix+"agent review: native package missing",
+		UnavailableError("agent review: native package missing"),
+	)
+	assert.Equal(t,
+		UnavailableErrorPrefix+"already categorized",
+		UnavailableError(UnavailableErrorPrefix+"already categorized"),
+	)
+}
+
+func TestApplyMinSeverityProseReparsesUnderNewThreshold(t *testing.T) {
 	assert := assert.New(t)
 	result := ReviewResult{
 		Status:      ResultDone,
@@ -17,18 +153,22 @@ func TestApplyMinSeverityProseReparsesUnderStricterThreshold(t *testing.T) {
 		MinSeverity: "low",
 	}
 
-	relaxed := result.ApplyMinSeverity("")
-	assert.Equal(storage.VerdictFail, relaxed.Verdict, "a looser threshold never relaxes a verdict")
-	assert.Equal("low", relaxed.MinSeverity)
+	same := result.ApplyMinSeverity("")
+	assert.Equal(storage.VerdictFail, same.Verdict, "an empty threshold keeps the result's own")
+	assert.Equal("low", same.MinSeverity)
 
 	stricter := result.ApplyMinSeverity("medium")
 	assert.Equal(storage.VerdictPass, stricter.Verdict)
 	assert.Equal("medium", stricter.MinSeverity)
 	assert.Equal(result.Output, stricter.Output, "prose output is never rewritten")
 
+	looser := stricter.ApplyMinSeverity("low")
+	assert.Equal(storage.VerdictFail, looser.Verdict, "a looser panel threshold applies as configured")
+	assert.Equal("low", looser.MinSeverity)
+
 	failed := ReviewResult{Status: ResultFailed, Error: "boom"}.ApplyMinSeverity("high")
 	assert.Equal(storage.VerdictUnknown, failed.Verdict)
-	assert.Empty(failed.MinSeverity)
+	assert.Empty(failed.MinSeverity, "failed results are returned unchanged")
 }
 
 func TestApplyMinSeverityStructuredRerendersEveryFinding(t *testing.T) {
@@ -54,6 +194,13 @@ func TestApplyMinSeverityStructuredRerendersEveryFinding(t *testing.T) {
 	assert.Contains(high.Output, "No findings at or above high severity.")
 	assert.Contains(high.Output, "Off by one.")
 
-	assert.Equal(storage.VerdictPass, high.ApplyMinSeverity("medium").Verdict,
-		"the stricter threshold already applied wins")
+	// A member decided under "critical" still fails a CI panel whose
+	// threshold is "medium": the panel threshold is the lowest severity that
+	// fails the combined review, not a floor under the member's own.
+	critical := result.ApplyMinSeverity("critical")
+	assert.Equal(storage.VerdictPass, critical.Verdict)
+	combined := critical.ApplyMinSeverity("medium")
+	assert.Equal(storage.VerdictFail, combined.Verdict)
+	assert.Equal("medium", combined.MinSeverity)
+	assert.NotContains(combined.Output, "No findings at or above")
 }

--- a/internal/review/result_test.go
+++ b/internal/review/result_test.go
@@ -1,143 +1,59 @@
 package review
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
 )
 
-func TestTrimPartialRune(t *testing.T) {
+func TestApplyMinSeverityProseReparsesUnderStricterThreshold(t *testing.T) {
 	assert := assert.New(t)
+	result := ReviewResult{
+		Status:      ResultDone,
+		Output:      "Summary.\n\n- Low: naming nit\n",
+		Verdict:     storage.VerdictFail,
+		MinSeverity: "low",
+	}
 
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"empty", "", ""},
-		{"ascii only", "hello", "hello"},
-		{
-			"clean emoji boundary",
-			"abc😀",
-			"abc😀",
-		},
-		{
-			"split 4-byte emoji after 1 byte",
-			"abc" + string([]byte{0xF0}),
-			"abc",
-		},
-		{
-			"split 4-byte emoji after 2 bytes",
-			"abc" + string([]byte{0xF0, 0x9F}),
-			"abc",
-		},
-		{
-			"split 4-byte emoji after 3 bytes",
-			"abc" + string([]byte{0xF0, 0x9F, 0x98}),
-			"abc",
-		},
-		{
-			"split 2-byte char after 1 byte",
-			"abc" + string([]byte{0xC3}),
-			"abc",
-		},
-		{
-			"interior invalid bytes preserved",
-			"a" + string([]byte{0xFF}) + "b",
-			"a" + string([]byte{0xFF}) + "b",
-		},
-		{
-			"orphan continuation byte",
-			"abc" + string([]byte{0x80}),
-			"abc",
-		},
-		{
-			"two orphan continuation bytes",
-			"abc" + string([]byte{0x80, 0x80}),
-			"abc",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := TrimPartialRune(tt.in)
-			assert.Equalf(tt.want, got, "TrimPartialRune(%q) = %q, want %q", tt.in, got, tt.want)
-		})
-	}
+	relaxed := result.ApplyMinSeverity("")
+	assert.Equal(storage.VerdictFail, relaxed.Verdict, "a looser threshold never relaxes a verdict")
+	assert.Equal("low", relaxed.MinSeverity)
+
+	stricter := result.ApplyMinSeverity("medium")
+	assert.Equal(storage.VerdictPass, stricter.Verdict)
+	assert.Equal("medium", stricter.MinSeverity)
+	assert.Equal(result.Output, stricter.Output, "prose output is never rewritten")
+
+	failed := ReviewResult{Status: ResultFailed, Error: "boom"}.ApplyMinSeverity("high")
+	assert.Equal(storage.VerdictUnknown, failed.Verdict)
+	assert.Empty(failed.MinSeverity)
 }
 
-func TestTrimPartialRune_NoFullStringScan(t *testing.T) {
+func TestApplyMinSeverityStructuredRerendersEveryFinding(t *testing.T) {
 	assert := assert.New(t)
-
-	// Verify that a string with interior invalid UTF-8 is NOT
-	// stripped down to empty — only the trailing boundary matters.
-	// This is the bug that utf8.ValidString would cause.
-	interior := strings.Repeat("x", 1000) +
-		string([]byte{0xFF}) +
-		strings.Repeat("y", 1000)
-	got := TrimPartialRune(interior)
-	assert.Equalf(interior, got, "interior invalid bytes should be preserved, got len %d want len %d", len(got), len(interior))
-}
-
-func TestHasSubstantiveOutput(t *testing.T) {
-	tests := []struct {
-		name    string
-		results []ReviewResult
-		want    bool
-	}{
-		{name: "empty batch"},
-		{
-			name: "completed output",
-			results: []ReviewResult{{
-				Status: ResultDone,
-				Output: "## Findings\n",
-			}},
-			want: true,
-		},
-		{
-			name: "completed whitespace",
-			results: []ReviewResult{{
-				Status: ResultDone,
-				Output: " \n\t",
-			}},
-		},
-		{
-			name: "completed empty-output placeholder",
-			results: []ReviewResult{{
-				Status: ResultDone,
-				Output: "No review output generated",
-			}},
-		},
-		{
-			name: "failed output",
-			results: []ReviewResult{{
-				Status: ResultFailed,
-				Output: "partial diagnostics",
-			}},
-		},
-		{
-			name: "skipped output",
-			results: []ReviewResult{{
-				Status: ResultSkipped,
-				Output: "not a review",
-			}},
+	structured := StructuredReview{
+		SchemaVersion: storage.StructuredReviewSchemaVersion,
+		Summary:       "Two findings.",
+		Findings: []StructuredFinding{
+			{Severity: "medium", Problem: "Off by one.", Fix: "Fix the bound."},
+			{Severity: "low", Problem: "Name is vague.", Fix: "Rename it."},
 		},
 	}
+	result := ReviewResult{Status: ResultDone, Structured: &structured}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, HasSubstantiveOutput(tt.results))
-		})
-	}
-}
+	medium := result.ApplyMinSeverity("medium")
+	assert.Equal(storage.VerdictFail, medium.Verdict)
+	assert.Contains(medium.Output, "Off by one.")
+	assert.Contains(medium.Output, "Name is vague.")
 
-func TestUnavailableError(t *testing.T) {
-	assert.Equal(t,
-		UnavailableErrorPrefix+"agent review: native package missing",
-		UnavailableError("agent review: native package missing"),
-	)
-	assert.Equal(t,
-		UnavailableErrorPrefix+"already categorized",
-		UnavailableError(UnavailableErrorPrefix+"already categorized"),
-	)
+	high := medium.ApplyMinSeverity("high")
+	assert.Equal(storage.VerdictPass, high.Verdict)
+	assert.Equal("high", high.MinSeverity)
+	assert.Contains(high.Output, "No findings at or above high severity.")
+	assert.Contains(high.Output, "Off by one.")
+
+	assert.Equal(storage.VerdictPass, high.ApplyMinSeverity("medium").Verdict,
+		"the stricter threshold already applied wins")
 }

--- a/internal/review/runner.go
+++ b/internal/review/runner.go
@@ -11,34 +11,38 @@ import (
 	"go.kenn.io/roborev/internal/storage"
 )
 
-// RunAgentReview owns the built-in versus custom review execution contract.
-// Built-in reviews derive their verdict once from prose. Custom reviews derive
-// it from schema output, then carry that verdict beside the rendered Markdown.
+// RunAgentReview owns the structured versus prose review execution contract.
+// Agents that support schema-constrained output return structured findings
+// for every review type, so the verdict comes from the reported severities
+// rather than from parsing Markdown. Other agents run built-in review types
+// as prose and derive the verdict from the rendered output; custom review
+// types require schema support. minSeverity never removes findings: it only
+// decides which severities count against the verdict.
 func RunAgentReview(
 	ctx context.Context,
 	a agent.Agent,
 	repoPath, gitRef, reviewPrompt, reviewType, minSeverity string,
 	out io.Writer,
 ) (ReviewResult, error) {
-	if config.IsBuiltInReviewType(reviewType) {
+	structuredAgent, ok := a.(agent.StructuredReviewAgent)
+	if !ok {
+		if !config.IsBuiltInReviewType(reviewType) {
+			return ReviewResult{}, fmt.Errorf(
+				"agent %q does not support schema-constrained reviews", a.Name(),
+			)
+		}
 		output, err := a.Review(ctx, repoPath, gitRef, reviewPrompt, out)
 		if err != nil {
 			return ReviewResult{}, err
 		}
-		result := ReviewResult{Output: output}
+		result := ReviewResult{Output: output, MinSeverity: minSeverity}
 		if noVerdict := NoVerdict(output); noVerdict != nil {
 			return result, noVerdict
 		}
-		result.Verdict = storage.ParseVerdict(output)
+		result.Verdict = storage.ParseVerdictAtSeverity(output, minSeverity)
 		return result, nil
 	}
 
-	structuredAgent, ok := a.(agent.StructuredReviewAgent)
-	if !ok {
-		return ReviewResult{}, fmt.Errorf(
-			"agent %q does not support schema-constrained reviews", a.Name(),
-		)
-	}
 	raw, err := structuredAgent.ReviewWithSchema(
 		ctx, repoPath, gitRef, reviewPrompt, CustomReviewSchema, out,
 	)
@@ -49,16 +53,18 @@ func RunAgentReview(
 	if err != nil {
 		return ReviewResult{}, err
 	}
-	filtered := structured.Filter(minSeverity)
-	output := filtered.Markdown()
+	if err := validateLiveDocument(a.Name(), structured); err != nil {
+		return ReviewResult{}, err
+	}
+	output := structured.Markdown(minSeverity)
 	if out != nil {
 		_, _ = fmt.Fprintln(out, output)
 	}
 	return ReviewResult{
-		Output:                output,
-		Verdict:               storage.VerdictFromPassed(filtered.Passed()),
-		Structured:            &structured,
-		StructuredOutput:      append(json.RawMessage(nil), raw...),
-		StructuredMinSeverity: minSeverity,
+		Output:           output,
+		Verdict:          storage.VerdictFromPassed(structured.Passed(minSeverity)),
+		Structured:       &structured,
+		StructuredOutput: append(json.RawMessage(nil), raw...),
+		MinSeverity:      minSeverity,
 	}, nil
 }

--- a/internal/review/runner_test.go
+++ b/internal/review/runner_test.go
@@ -16,7 +16,8 @@ func TestRunAgentReviewKeepsCustomVerdictWithRenderedOutput(t *testing.T) {
 	a := &structuredBatchAgent{
 		name: "structured",
 		result: json.RawMessage(`{
-	  "schema_version": 1,
+	  "schema_version": 2,
+	  "verdict": "pass",
 	  "summary": "High: no actionable findings remain.",
   "findings": [
     {"severity":"low","problem":"Vague name.","fix":"Rename it.","location":null}
@@ -34,12 +35,61 @@ func TestRunAgentReviewKeepsCustomVerdictWithRenderedOutput(t *testing.T) {
 	require.Len(t, got.Structured.Findings, 1)
 	assert.Equal(t, "low", got.Structured.Findings[0].Severity)
 	assert.JSONEq(t, string(a.result), string(got.StructuredOutput))
-	assert.Equal(t, "medium", got.StructuredMinSeverity)
-	assert.NotContains(t, got.Output, "Vague name")
+	assert.Equal(t, "medium", got.MinSeverity)
+	assert.Contains(t, got.Output, "Vague name", "findings below the threshold stay in the output")
+	assert.Contains(t, got.Output, "No findings at or above medium severity.")
 	assert.Equal(t, storage.VerdictPass, got.Verdict)
 	assert.Equal(t, got.Output+"\n", streamed.String())
 	assert.Equal(t, storage.VerdictFail, storage.ParseVerdict(got.Output),
 		"rendered prose must not replace the structured verdict")
+}
+
+func TestRunAgentReviewUsesSchemaForBuiltInTypesWhenSupported(t *testing.T) {
+	a := &structuredBatchAgent{
+		name: "structured", output: "PROSE FALLBACK",
+		result: json.RawMessage(`{
+  "schema_version": 2,
+  "verdict": "pass",
+  "summary": "One real bug.",
+  "findings": [
+    {"severity":"high","problem":"Nil deref.","fix":"Check the pointer.","location":"main.go:10"}
+  ]
+}`),
+	}
+
+	got, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "", nil,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got.Structured)
+	assert.Equal(t, storage.VerdictFail, got.Verdict)
+	assert.Contains(t, got.Output, "### 1. High")
+	assert.Contains(t, got.Output, "**Location:** main.go:10")
+	assert.NotContains(t, got.Output, "PROSE FALLBACK",
+		"structured agents must not fall back to prose reviews")
+}
+
+func TestRunAgentReviewProseVerdictHonorsMinSeverity(t *testing.T) {
+	const output = "Summary of the change.\n\n- Low: variable name could be clearer\n"
+	a := &mockAgent{name: "prose", output: output}
+
+	got, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "medium", nil,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, got.Structured)
+	assert.Equal(t, output, got.Output, "prose output is stored untouched")
+	assert.Equal(t, "medium", got.MinSeverity)
+	assert.Equal(t, storage.VerdictPass, got.Verdict, "a low-only review passes a medium threshold")
+
+	got, err = RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "low", nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, storage.VerdictFail, got.Verdict)
 }
 
 func TestRunAgentReviewDerivesBuiltInVerdict(t *testing.T) {
@@ -107,4 +157,66 @@ func TestNoVerdictMessage(t *testing.T) {
 
 	assert.True(IsNoVerdictFailure(ReviewResult{Status: ResultFailed, Error: msg}))
 	assert.False(IsNoVerdictFailure(ReviewResult{Status: ResultFailed, Error: "agent: boom"}))
+}
+
+func TestRunAgentReviewTreatsUnableToReviewAsFailure(t *testing.T) {
+	a := &structuredBatchAgent{
+		name: "structured",
+		result: json.RawMessage(`{
+  "schema_version": 2,
+  "summary": "The diff was truncated before any code appeared.",
+  "verdict": "unable_to_review",
+  "findings": []
+}`),
+	}
+
+	_, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "", nil,
+	)
+	require.ErrorContains(t, err, "could not review the change")
+	require.ErrorContains(t, err, "truncated before any code appeared")
+}
+
+func TestRunAgentReviewRendersAgentVerdict(t *testing.T) {
+	a := &structuredBatchAgent{
+		name: "structured",
+		result: json.RawMessage(`{
+  "schema_version": 2,
+  "summary": "Clean change.",
+  "verdict": "pass",
+  "findings": []
+}`),
+	}
+
+	got, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt",
+		"default", "", nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, storage.VerdictPass, got.Verdict)
+	assert.Contains(t, got.Output, "**Agent assessment:** Pass")
+	assert.Contains(t, got.Output, "No issues found.")
+}
+
+func TestRunAgentReviewRejectsOldSchemaFromLiveAgent(t *testing.T) {
+	a := &structuredBatchAgent{
+		name:   "structured",
+		result: json.RawMessage(`{"schema_version":1,"summary":"Clean.","findings":[]}`),
+	}
+	_, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt", "default", "", nil,
+	)
+	require.ErrorContains(t, err, "schema_version 1, want 2")
+}
+
+func TestRunAgentReviewRejectsFailWithoutFindings(t *testing.T) {
+	a := &structuredBatchAgent{
+		name:   "structured",
+		result: json.RawMessage(`{"schema_version":2,"summary":"Bad.","verdict":"fail","findings":[]}`),
+	}
+	_, err := RunAgentReview(
+		context.Background(), a, t.TempDir(), "HEAD", "prompt", "default", "", nil,
+	)
+	require.ErrorContains(t, err, "failing verdict without any finding")
 }

--- a/internal/review/structured.go
+++ b/internal/review/structured.go
@@ -2,7 +2,7 @@ package review
 
 import (
 	"encoding/json"
-	"strings"
+	"fmt"
 
 	"go.kenn.io/roborev/internal/structuredreview"
 )
@@ -17,26 +17,30 @@ func DecodeStructuredReview(raw json.RawMessage) (StructuredReview, error) {
 	return structuredreview.Decode(raw)
 }
 
-func stricterMinSeverity(first, second string) string {
-	first = strings.ToLower(strings.TrimSpace(first))
-	second = strings.ToLower(strings.TrimSpace(second))
-	if severityRank(first) >= severityRank(second) {
-		return first
+// validateLiveDocument rejects documents a live agent must not return. Stored
+// documents may be older versions, but a live agent must honor the schema it
+// was given: an older shape means the provider ignored it. A failing verdict
+// with no finding says nothing actionable, and unable_to_review means the
+// agent never assessed the change; both are agent errors so retry and backup
+// failover run instead of recording a misleading review.
+func validateLiveDocument(agentName string, doc StructuredReview) error {
+	if doc.SchemaVersion != structuredreview.SchemaVersion {
+		return fmt.Errorf(
+			"agent %s returned structured review schema_version %d, want %d",
+			agentName, doc.SchemaVersion, structuredreview.SchemaVersion,
+		)
 	}
-	return second
-}
-
-func severityRank(severity string) int {
-	switch severity {
-	case "critical":
-		return 4
-	case "high":
-		return 3
-	case "medium":
-		return 2
-	case "low":
-		return 1
-	default:
-		return 0
+	if doc.Verdict == structuredreview.VerdictFail && len(doc.Findings) == 0 {
+		return fmt.Errorf(
+			"agent %s reported a failing verdict without any finding: %s",
+			agentName, doc.Summary,
+		)
 	}
+	if doc.UnableToReview() {
+		return fmt.Errorf(
+			"agent %s could not review the change: %s",
+			agentName, doc.Summary,
+		)
+	}
+	return nil
 }

--- a/internal/review/structured_test.go
+++ b/internal/review/structured_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStructuredReviewFiltersAndRenders(t *testing.T) {
+func TestStructuredReviewKeepsFindingsBelowThreshold(t *testing.T) {
 	raw := json.RawMessage(`{
   "schema_version": 1,
   "summary": "Two maintainability risks found.",
@@ -20,40 +20,96 @@ func TestStructuredReviewFiltersAndRenders(t *testing.T) {
 
 	decoded, err := DecodeStructuredReview(raw)
 	require.NoError(t, err)
-	filtered := decoded.Filter("medium")
-	require.Len(t, filtered.Findings, 1)
-	assert.False(t, filtered.Passed())
-	markdown := filtered.Markdown()
+	require.Len(t, decoded.Findings, 2)
+	assert.False(t, decoded.Passed("medium"))
+	assert.True(t, decoded.Passed("critical"))
+	markdown := decoded.Markdown("medium")
 	assert.Contains(t, markdown, "### 1. High")
 	assert.Contains(t, markdown, "**Location:** state.go:20")
-	assert.NotContains(t, markdown, "Name is vague")
+	assert.Contains(t, markdown, "### 2. Low")
+	assert.Contains(t, markdown, "Name is vague")
+	assert.NotContains(t, markdown, "No findings at or above")
 }
 
-func TestStructuredReviewPassesAfterSeverityFiltering(t *testing.T) {
+func TestStructuredReviewPassesWhenAllFindingsBelowThreshold(t *testing.T) {
 	decoded, err := DecodeStructuredReview(json.RawMessage(
 		`{"schema_version":1,"summary":"Minor issue.","findings":[{"severity":"low","problem":"Vague name.","fix":"Rename it.","location":null}]}`,
 	))
 	require.NoError(t, err)
-	filtered := decoded.Filter("high")
-	assert.True(t, filtered.Passed())
-	assert.Contains(t, filtered.Markdown(), "No findings at or above")
+	assert.True(t, decoded.Passed("high"))
+	assert.False(t, decoded.Passed(""))
+	assert.False(t, decoded.Passed("low"))
+	markdown := decoded.Markdown("high")
+	assert.Contains(t, markdown, "No findings at or above high severity.")
+	assert.Contains(t, markdown, "Vague name.")
+	assert.NotContains(t, decoded.Markdown(""), "No findings at or above")
+}
+
+func TestStructuredReviewNoFindingsRendersNoIssues(t *testing.T) {
+	decoded, err := DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":1,"summary":"Clean change.","findings":[]}`,
+	))
+	require.NoError(t, err)
+	assert.True(t, decoded.Passed(""))
+	assert.Contains(t, decoded.Markdown("high"), "No issues found.")
 }
 
 func TestStructuredReviewRejectsUnknownFields(t *testing.T) {
 	_, err := DecodeStructuredReview(json.RawMessage(
-		`{"schema_version":1,"summary":"Done.","findings":[],"verdict":"pass"}`,
+		`{"schema_version":2,"summary":"Done.","verdict":"pass","findings":[],"confidence":1}`,
 	))
 	require.ErrorContains(t, err, "unknown field")
 }
 
-func TestStructuredReviewRequiresCurrentSchemaVersion(t *testing.T) {
+func TestStructuredReviewRequiresKnownSchemaVersion(t *testing.T) {
 	_, err := DecodeStructuredReview(json.RawMessage(
-		`{"schema_version":2,"summary":"Done.","findings":[]}`,
+		`{"schema_version":3,"summary":"Done.","verdict":"pass","findings":[]}`,
 	))
-	require.ErrorContains(t, err, "unsupported structured review schema_version 2")
+	require.ErrorContains(t, err, "unsupported structured review schema_version 3")
 }
 
-func TestStricterMinSeverity(t *testing.T) {
-	assert.Equal(t, "high", stricterMinSeverity("low", "high"))
-	assert.Equal(t, "high", stricterMinSeverity("high", "low"))
+func TestStructuredReviewVersionTwoCarriesVerdict(t *testing.T) {
+	decoded, err := DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":2,"summary":"Looks wrong overall.","verdict":"FAIL","findings":[{"severity":"low","problem":"Nit.","fix":"Tidy.","location":null}]}`,
+	))
+	require.NoError(t, err)
+	assert.Equal(t, "fail", decoded.Verdict)
+	assert.True(t, decoded.Passed("medium"),
+		"the agent verdict is informational; findings decide the outcome")
+	assert.Contains(t, decoded.Markdown("medium"), "**Agent assessment:** Fail")
+	assert.False(t, decoded.UnableToReview())
+}
+
+func TestStructuredReviewVersionOneStillDecodes(t *testing.T) {
+	decoded, err := DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":1,"summary":"Legacy.","findings":[]}`,
+	))
+	require.NoError(t, err)
+	assert.Empty(t, decoded.Verdict)
+	assert.NotContains(t, decoded.Markdown(""), "Agent assessment")
+
+	_, err = DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":1,"summary":"Legacy.","verdict":"pass","findings":[]}`,
+	))
+	require.ErrorContains(t, err, "schema_version 1 does not carry a verdict")
+}
+
+func TestStructuredReviewRejectsInvalidVerdict(t *testing.T) {
+	_, err := DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":2,"summary":"Done.","verdict":"maybe","findings":[]}`,
+	))
+	require.ErrorContains(t, err, `invalid verdict "maybe"`)
+
+	_, err = DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":2,"summary":"Done.","findings":[]}`,
+	))
+	require.ErrorContains(t, err, "invalid verdict")
+}
+
+func TestStructuredReviewUnableToReview(t *testing.T) {
+	decoded, err := DecodeStructuredReview(json.RawMessage(
+		`{"schema_version":2,"summary":"The diff was empty.","verdict":"unable_to_review","findings":[]}`,
+	))
+	require.NoError(t, err)
+	assert.True(t, decoded.UnableToReview())
 }

--- a/internal/review/synthesis.go
+++ b/internal/review/synthesis.go
@@ -38,9 +38,10 @@ func DecodeSynthesisDocument(raw json.RawMessage, reviews []ReviewResult) (Synth
 }
 
 // SynthesisVerdict is the canonical verdict of a synthesis document: pass when
-// no finding survived the severity threshold, otherwise fail.
-func SynthesisVerdict(doc SynthesisDocument) storage.Verdict {
-	return storage.VerdictFromPassed(doc.Passed())
+// no finding reaches the severity threshold, otherwise fail. Findings below
+// the threshold stay in the document.
+func SynthesisVerdict(doc SynthesisDocument, minSeverity string) storage.Verdict {
+	return storage.VerdictFromPassed(doc.Passed(minSeverity))
 }
 
 // SynthesisSourceLabels names each input review for readers: the agent, plus
@@ -60,14 +61,6 @@ func SynthesisSourceLabels(reviews []ReviewResult) []string {
 		labels[i] = label
 	}
 	return labels
-}
-
-// severityAbove maps a minimum severity to the instruction
-// describing which levels to include in synthesis output.
-var severityAbove = map[string]string{
-	"critical": "Only include Critical findings.",
-	"high":     "Only include High and Critical findings.",
-	"medium":   "Only include Medium, High, and Critical findings.",
 }
 
 // VerifyDedupePreamble returns the instruction block used by the compact
@@ -93,20 +86,20 @@ func VerifyDedupePreamble() string {
 		"   - The summary may mention how many prior findings were dropped as fixed, duplicates, or false positives\n\n"
 }
 
-// BuildSynthesisPrompt creates the prompt for the synthesis agent.
-// When minSeverity is non-empty (and not "low"), a filtering
-// instruction is appended.
+// BuildSynthesisPrompt creates the prompt for the synthesis agent. The
+// severity threshold is applied to the synthesized output afterwards and is
+// never shown to the agent, so every finding survives synthesis.
 func BuildSynthesisPrompt(
 	reviews []ReviewResult,
-	minSeverity string,
+	_ string,
 ) string {
 	var b strings.Builder
 	b.WriteString(
 		"You are combining multiple code review outputs " +
 			"into a single GitHub PR comment.\n" +
 			"Return exactly one JSON object with this shape and no code fence: " +
-			`{"schema_version":1,"summary":"...","findings":[{"severity":"critical|high|medium|low","problem":"...","fix":"...","location":"file:line or null","sources":[1]}]}` + "\n" +
-			"Put a one-line overall summary in `summary`. " +
+			`{"schema_version":2,"summary":"...","verdict":"pass|fail","findings":[{"severity":"critical|high|medium|low","problem":"...","fix":"...","location":"file:line or null","sources":[1]}]}` + "\n" +
+			"Put a one-line overall summary in `summary` and your overall judgment in `verdict`. " +
 			"List every finding that requires changes in `findings`; " +
 			"return an empty `findings` array if the reviewers agree the code is clean.\n" +
 			"In `sources`, list the numbers of the reviews below (### Review N) " +
@@ -117,12 +110,6 @@ func BuildSynthesisPrompt(
 			"- Order findings by severity (Critical > High > Medium > Low)\n" +
 			"- Preserve file/line references in `location`\n" +
 			"- No preamble about yourself\n")
-
-	if instruction, ok := severityAbove[minSeverity]; ok {
-		b.WriteString(
-			"- Omit findings below " + minSeverity +
-				" severity. " + instruction + "\n")
-	}
 
 	b.WriteString("\n")
 
@@ -154,6 +141,10 @@ func BuildSynthesisPrompt(
 		} else if IsTransientFailure(r) {
 			b.WriteString(
 				"(review skipped — provider unavailable)")
+		} else if r.Structured != nil {
+			// Render without the threshold so the synthesis agent never
+			// learns which severities are informational.
+			b.WriteString(TruncateOutput(r.Structured.Markdown(""), maxPerReview))
 		} else if r.Output != "" {
 			b.WriteString(TruncateOutput(r.Output, maxPerReview))
 		} else if r.Status == ResultFailed {

--- a/internal/review/synthesis_dispatch.go
+++ b/internal/review/synthesis_dispatch.go
@@ -115,5 +115,11 @@ func RunSynthesisAgent(
 	if err != nil {
 		return SynthesisDocument{}, err
 	}
-	return doc.Filter(minSeverity), nil
+	if err := validateLiveDocument(a.Name(), doc); err != nil {
+		return SynthesisDocument{}, err
+	}
+	// minSeverity never removes findings; callers apply it when rendering
+	// and deriving the verdict.
+	_ = minSeverity
+	return doc, nil
 }

--- a/internal/review/synthesis_test.go
+++ b/internal/review/synthesis_test.go
@@ -176,9 +176,9 @@ func TestDecodeSynthesisDocument(t *testing.T) {
 		]}`,
 	), reviews)
 	require.NoError(t, err)
-	assert.Equal(storage.VerdictFail, SynthesisVerdict(doc))
+	assert.Equal(storage.VerdictFail, SynthesisVerdict(doc, ""))
 	assert.Equal([]string{"codex", "gemini (security)"}, doc.SourceLabels)
-	md := doc.Markdown()
+	md := doc.Markdown("")
 	assert.Contains(md, "One shared finding.")
 	assert.Contains(md, "**Reported by:** gemini (security), codex")
 
@@ -186,8 +186,8 @@ func TestDecodeSynthesisDocument(t *testing.T) {
 		`{"schema_version":1,"summary":"Clean.","findings":[]}`,
 	), reviews)
 	require.NoError(t, err)
-	assert.Equal(storage.VerdictPass, SynthesisVerdict(clean))
-	assert.NotContains(clean.Markdown(), "Reported by")
+	assert.Equal(storage.VerdictPass, SynthesisVerdict(clean, ""))
+	assert.NotContains(clean.Markdown(""), "Reported by")
 
 	tests := []struct {
 		name string
@@ -280,8 +280,8 @@ func TestBuildSynthesisPrompt_Severity(t *testing.T) {
 		wantContains    string
 		wantNotContains string
 	}{
-		{"high severity", "high", "Only include High and Critical", ""},
-		{"low severity", "low", "", "Omit findings"},
+		{"high severity", "high", "", "Severity threshold"},
+		{"low severity", "low", "", "Severity threshold"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -674,4 +674,22 @@ func TestBuildSynthesisPrompt_TransientSkipped(t *testing.T) {
 		"[SKIPPED]",
 		"provider unavailable",
 	})
+}
+
+func TestBuildSynthesisPromptRendersStructuredMembersWithoutThreshold(t *testing.T) {
+	structured := StructuredReview{
+		SchemaVersion: storage.StructuredReviewSchemaVersion,
+		Summary:       "One nit.",
+		Verdict:       "pass",
+		Findings:      []StructuredFinding{{Severity: "low", Problem: "Nit.", Fix: "Tidy."}},
+	}
+	member := ReviewResult{
+		Agent: "codex", ReviewType: "review", Status: ResultDone, Structured: &structured,
+	}.ApplyMinSeverity("medium")
+	require.Contains(t, member.Output, "No findings at or above medium severity.")
+
+	prompt := BuildSynthesisPrompt([]ReviewResult{member}, "medium")
+	assert.Contains(t, prompt, "Nit.")
+	assert.NotContains(t, prompt, "at or above")
+	assert.NotContains(t, prompt, "medium severity")
 }

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -35,7 +35,8 @@ type SynthesizeOpts struct {
 	Agent string
 	// Model override for the synthesis agent.
 	Model string
-	// MinSeverity filters findings below this level.
+	// MinSeverity is the lowest severity that fails the combined review.
+	// Findings below it are kept in the output as information.
 	MinSeverity string
 	// RepoPath is the working directory for the synthesis agent.
 	RepoPath string
@@ -60,7 +61,7 @@ func Synthesize(
 	opts SynthesizeOpts,
 ) (string, error) {
 	for i := range results {
-		results[i] = results[i].FilterStructured(opts.MinSeverity)
+		results[i] = results[i].ApplyMinSeverity(opts.MinSeverity)
 	}
 
 	successCount := 0
@@ -88,12 +89,9 @@ func Synthesize(
 		return comment, ErrAllFailed
 	}
 
-	// Single result — return directly unless CI min-severity
-	// filtering is needed (synthesis applies the filter).
-	// "low" means no filtering, so treat same as empty.
-	if len(results) == 1 && successCount == 1 &&
-		(opts.MinSeverity == "" || opts.MinSeverity == "low" ||
-			results[0].Structured != nil) {
+	// Single result — return directly. Its verdict already honors
+	// opts.MinSeverity, so there is nothing for a synthesis agent to add.
+	if len(results) == 1 && successCount == 1 {
 		return formatSingleResult(
 			results[0], opts.HeadSHA), nil
 	}
@@ -164,5 +162,5 @@ func runSynthesis(
 	}
 
 	return FormatSynthesizedComment(
-		doc.Markdown(), results, opts.HeadSHA), nil
+		doc.Markdown(opts.MinSeverity), results, opts.HeadSHA), nil
 }

--- a/internal/review/synthesize_test.go
+++ b/internal/review/synthesize_test.go
@@ -66,7 +66,7 @@ func (a *capturingAgent) Review(
 	_ context.Context, _, gitRef, _ string, _ io.Writer,
 ) (string, error) {
 	a.capturedGitRef = gitRef
-	return `{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`, nil
+	return `{"schema_version":2,"summary":"synthesized output","verdict":"pass","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`, nil
 }
 func (a *capturingAgent) CommandLine() string { return "capture" }
 
@@ -94,7 +94,7 @@ func (a *synthesisEntrypointAgent) Synthesize(
 	_ context.Context, prompt string, _ io.Writer,
 ) (json.RawMessage, error) {
 	a.synthPrompt = prompt
-	return json.RawMessage(`{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
+	return json.RawMessage(`{"schema_version":2,"summary":"synthesized output","verdict":"pass","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
 }
 func (a *synthesisEntrypointAgent) CommandLine() string { return "synthesis-entrypoint" }
 
@@ -124,7 +124,7 @@ func (a *structuredSynthesisAgent) ReviewWithSchema(
 ) (json.RawMessage, error) {
 	a.schema = schema
 	a.repoPath = repoPath
-	return json.RawMessage(`{"schema_version":1,"summary":"synthesized output","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
+	return json.RawMessage(`{"schema_version":2,"summary":"synthesized output","verdict":"pass","findings":[{"severity":"medium","problem":"combined","fix":"fix","location":"file.go:1","sources":[1]}]}`), nil
 }
 func (a *structuredSynthesisAgent) CommandLine() string { return a.Name() }
 
@@ -522,7 +522,7 @@ func TestSynthesizeFiltersStructuredResultWithoutReparsingSummary(t *testing.T) 
 		ReviewType: "custom",
 		Status:     ResultDone,
 		Structured: &structured,
-	}.FilterStructured("low")
+	}.ApplyMinSeverity("low")
 
 	comment, err := Synthesize(context.Background(), []ReviewResult{result}, SynthesizeOpts{
 		MinSeverity: "high",
@@ -531,8 +531,8 @@ func TestSynthesizeFiltersStructuredResultWithoutReparsingSummary(t *testing.T) 
 
 	require.NoError(t, err)
 	assert.Contains(t, comment, "Review Passed")
-	assert.Contains(t, comment, "No findings at or above")
-	assert.NotContains(t, comment, "Name is vague")
+	assert.Contains(t, comment, "No findings at or above high severity.")
+	assert.Contains(t, comment, "Name is vague", "low findings stay in the comment")
 }
 
 func TestSynthesize_EmptyAgentAutoSelectsAvailableAgent(t *testing.T) {

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -143,7 +143,7 @@ func ClassifyOutput(output string) OutputKind {
 	}
 	// A severity-labelled finding is a real review even if the agent also
 	// says part of the input was unreadable.
-	if hasSeverityLabel(trimmed) {
+	if HighestSeverityLabel(trimmed) != "" {
 		return OutputReviewed
 	}
 	lower := strings.ReplaceAll(strings.ToLower(trimmed), "\u2019", "'")

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -196,14 +196,28 @@ func verdictBoolFromOutput(output string) any {
 // too chatty or mixes process narration with findings, that should be fixed in
 // the review prompt rather than by adding more verdict heuristics here.
 func ParseVerdict(output string) Verdict {
+	return ParseVerdictAtSeverity(output, "")
+}
+
+// ParseVerdictAtSeverity is ParseVerdict with a minimum severity. Labeled
+// findings at or above minSeverity fail the review. When every labeled
+// finding is below the threshold the review passes: the findings stay in the
+// output as information, they just do not count against it. Output without
+// severity labels falls back to the agent's own pass/fail statement. Empty,
+// "low", and unknown thresholds count every labeled finding.
+func ParseVerdictAtSeverity(output, minSeverity string) Verdict {
 	if ClassifyOutput(output) != OutputReviewed {
 		return VerdictUnknown
 	}
 
 	// Severity labels indicate actual findings. They appear as
 	// "- Medium —", "* Low:", "Critical -", etc.
-	if hasSeverityLabel(output) {
-		return VerdictFail
+	if highest := HighestSeverityLabel(output); highest != "" {
+		threshold := max(config.SeverityRank(minSeverity), config.SeverityRank("low"))
+		if config.SeverityRank(highest) >= threshold {
+			return VerdictFail
+		}
+		return VerdictPass
 	}
 
 	// Marker signals pass ONLY when it stands alone. A loose
@@ -349,15 +363,22 @@ func stripFieldLabel(s string) string {
 	return s
 }
 
-// hasSeverityLabel checks if the output contains severity labels indicating findings.
+// HighestSeverityLabel returns the highest severity label found in prose
+// review output, or "" when the output has no severity-labeled findings.
 // Matches patterns like "- Medium —", "* Low:", "Critical — issue", etc.
 // Checks lines that start with bullets/numbers OR directly with severity words.
 // Requires separators to be followed by space to avoid "High-level overview".
 // Skips lines that appear to be part of a severity legend/rubric.
-func hasSeverityLabel(output string) bool {
+func HighestSeverityLabel(output string) string {
 	lc := strings.ToLower(output)
 	severities := []string{"critical", "high", "medium", "low"}
 	lines := strings.Split(lc, "\n")
+	highest := ""
+	record := func(sev string) {
+		if config.SeverityRank(sev) > config.SeverityRank(highest) {
+			highest = sev
+		}
+	}
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -379,6 +400,20 @@ func hasSeverityLabel(output string) bool {
 
 		// Strip markdown formatting (bold, headers) before checking
 		checkText = stripMarkdown(checkText)
+
+		// Structured reviews render each finding as a numbered heading whose
+		// whole text is the severity: "### 1. Low". Recognize that form so
+		// rendered structured output parses the same way as prose findings.
+		if first == '#' {
+			heading := stripListMarker(checkText)
+			for _, sev := range severities {
+				if heading == sev && !isLegendEntry(lines, i) {
+					record(sev)
+					break
+				}
+			}
+			continue
+		}
 
 		// Check if text starts with a severity word
 		for _, sev := range severities {
@@ -418,7 +453,8 @@ func hasSeverityLabel(output string) bool {
 				continue
 			}
 
-			return true
+			record(sev)
+			break
 		}
 
 		// Check for "severity: <level>" pattern (e.g., "**Severity**: High")
@@ -438,14 +474,15 @@ func hasSeverityLabel(output string) bool {
 				for _, sev := range severities {
 					if strings.HasPrefix(rest, sev) {
 						if !isLegendEntry(lines, i) {
-							return true
+							record(sev)
 						}
+						break
 					}
 				}
 			}
 		}
 	}
-	return false
+	return highest
 }
 
 // isLegendEntry checks if a line at index i appears to be part of a severity legend/rubric

--- a/internal/storage/verdict.go
+++ b/internal/storage/verdict.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"database/sql"
+	"slices"
 	"strings"
 
 	"go.kenn.io/roborev/internal/config"
@@ -404,15 +405,16 @@ func HighestSeverityLabel(output string) string {
 		// Structured reviews render each finding as a numbered heading whose
 		// whole text is the severity: "### 1. Low". Recognize that form so
 		// rendered structured output parses the same way as prose findings.
+		// Any other heading falls through to the prose checks below, so
+		// "### High — crash" still counts.
 		if first == '#' {
 			heading := stripListMarker(checkText)
-			for _, sev := range severities {
-				if heading == sev && !isLegendEntry(lines, i) {
-					record(sev)
-					break
+			if slices.Contains(severities, heading) {
+				if !isLegendEntry(lines, i) {
+					record(heading)
 				}
+				continue
 			}
-			continue
 		}
 
 		// Check if text starts with a severity word

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -832,3 +832,35 @@ func TestClassifyOutput(t *testing.T) {
 func TestParseVerdict(t *testing.T) {
 	runVerdictTests(t, verdictTests)
 }
+
+func TestParseVerdictAtSeverity(t *testing.T) {
+	const lowOnly = "Summary.\n\n- Low: naming nit\n\n---\n\n- Low — another nit"
+	const mixed = "Summary.\n\n- Low: naming nit\n\n**Severity**: High\nProblem: crash"
+	tests := []struct {
+		name        string
+		output      string
+		minSeverity string
+		want        Verdict
+	}{
+		{"no threshold counts every label", lowOnly, "", VerdictFail},
+		{"low threshold counts every label", lowOnly, "low", VerdictFail},
+		{"medium threshold passes low-only findings", lowOnly, "medium", VerdictPass},
+		{"critical threshold passes low-only findings", lowOnly, "critical", VerdictPass},
+		{"highest label decides", mixed, "medium", VerdictFail},
+		{"highest label below threshold passes", mixed, "critical", VerdictPass},
+		{"mixed case threshold is normalized", lowOnly, " Medium ", VerdictPass},
+		{"unknown threshold counts every label", lowOnly, "bogus", VerdictFail},
+		{"unlabeled pass statement still passes", "No issues found.", "high", VerdictPass},
+		{"unlabeled prose finding still fails", "The auth module leaks tokens.", "high", VerdictFail},
+		{"legend entries are not findings", "Severity levels:\n- High: bad\n- Low: meh\n\nNo issues found.", "medium", VerdictPass},
+		{"structured heading low-only passes medium", "## Summary\n\nOne nit.\n\n## Findings\n\n### 1. Low\n\n**Problem:** nit\n\n**Fix:** tidy\n", "medium", VerdictPass},
+		{"structured heading low-only fails without threshold", "## Summary\n\nOne nit.\n\n## Findings\n\n### 1. Low\n\n**Problem:** nit\n\n**Fix:** tidy\n", "", VerdictFail},
+		{"structured heading high fails medium", "## Summary\n\nBug.\n\n## Findings\n\n### 1. Low\n\n**Problem:** nit\n\n**Fix:** tidy\n\n### 2. High\n\n**Problem:** crash\n\n**Fix:** guard\n", "medium", VerdictFail},
+		{"heading text is not a label", "### High-level overview\n\nNo issues found.", "", VerdictPass},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ParseVerdictAtSeverity(tt.output, tt.minSeverity))
+		})
+	}
+}

--- a/internal/storage/verdict_test.go
+++ b/internal/storage/verdict_test.go
@@ -857,6 +857,9 @@ func TestParseVerdictAtSeverity(t *testing.T) {
 		{"structured heading low-only fails without threshold", "## Summary\n\nOne nit.\n\n## Findings\n\n### 1. Low\n\n**Problem:** nit\n\n**Fix:** tidy\n", "", VerdictFail},
 		{"structured heading high fails medium", "## Summary\n\nBug.\n\n## Findings\n\n### 1. Low\n\n**Problem:** nit\n\n**Fix:** tidy\n\n### 2. High\n\n**Problem:** crash\n\n**Fix:** guard\n", "medium", VerdictFail},
 		{"heading text is not a label", "### High-level overview\n\nNo issues found.", "", VerdictPass},
+		{"prose heading with separator fails", "## Findings\n\n### High — security bug\n\nInput is not escaped.", "medium", VerdictFail},
+		{"prose heading with colon passes above it", "## Findings\n\n### Low: naming issue\n\nRename it.", "medium", VerdictPass},
+		{"prose heading with severity label", "### Severity: Medium\n\nRace on shutdown.", "medium", VerdictFail},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/structuredreview/document.go
+++ b/internal/structuredreview/document.go
@@ -9,7 +9,19 @@ import (
 	"strings"
 )
 
-const SchemaVersion = 1
+// SchemaVersion is the version agents must return. Version 1 documents
+// (without a verdict) are still decoded so stored reviews keep working.
+const SchemaVersion = 2
+
+// Verdict values the agent may report. The verdict never relaxes a finding:
+// a review with a finding at or above the severity threshold fails whatever
+// the agent says. VerdictUnableToReview means the agent could not assess the
+// change at all and is treated as an agent failure, not a clean pass.
+const (
+	VerdictPass           = "pass"
+	VerdictFail           = "fail"
+	VerdictUnableToReview = "unable_to_review"
+)
 
 // Schema constrains a single reviewer's output.
 var Schema = schema(false)
@@ -34,10 +46,11 @@ func schema(withSources bool) json.RawMessage {
 	return json.RawMessage(fmt.Sprintf(`{
   "type": "object",
   "additionalProperties": false,
-  "required": ["schema_version", "summary", "findings"],
+  "required": ["schema_version", "summary", "verdict", "findings"],
   "properties": {
     "schema_version": {"type": "integer", "const": %d},
     "summary": {"type": "string", "minLength": 1},
+    "verdict": {"type": "string", "enum": [%q, %q, %q]},
     "findings": {
       "type": "array",
       "items": {
@@ -56,13 +69,15 @@ func schema(withSources bool) json.RawMessage {
       }
     }
   }
-}`, SchemaVersion, required, sources))
+}`, SchemaVersion, VerdictPass, VerdictFail, VerdictUnableToReview, required, sources))
 }
 
 type Document struct {
-	SchemaVersion int       `json:"schema_version"`
-	Summary       string    `json:"summary"`
-	Findings      []Finding `json:"findings"`
+	SchemaVersion int    `json:"schema_version"`
+	Summary       string `json:"summary"`
+	// Verdict is the agent's own judgment. Empty for version 1 documents.
+	Verdict  string    `json:"verdict,omitempty"`
+	Findings []Finding `json:"findings"`
 	// SourceLabels names the input reviews a sourced document cites, indexed
 	// by review number minus one. It is caller-provided, never decoded, and
 	// only used when rendering Markdown.
@@ -98,6 +113,7 @@ func (f Finding) MarshalJSON() ([]byte, error) {
 type documentWire struct {
 	SchemaVersion int           `json:"schema_version"`
 	Summary       string        `json:"summary"`
+	Verdict       string        `json:"verdict"`
 	Findings      []findingWire `json:"findings"`
 }
 
@@ -125,6 +141,7 @@ func Decode(raw json.RawMessage) (Document, error) {
 	result := Document{
 		SchemaVersion: wire.SchemaVersion,
 		Summary:       wire.Summary,
+		Verdict:       strings.ToLower(strings.TrimSpace(wire.Verdict)),
 		Findings:      make([]Finding, len(wire.Findings)),
 	}
 	for i, finding := range wire.Findings {
@@ -149,7 +166,22 @@ func Decode(raw json.RawMessage) (Document, error) {
 			Sources:  finding.Sources,
 		}
 	}
-	if result.SchemaVersion != SchemaVersion {
+	switch result.SchemaVersion {
+	case 1:
+		if result.Verdict != "" {
+			return Document{}, fmt.Errorf(
+				"structured review schema_version 1 does not carry a verdict",
+			)
+		}
+	case SchemaVersion:
+		switch result.Verdict {
+		case VerdictPass, VerdictFail, VerdictUnableToReview:
+		default:
+			return Document{}, fmt.Errorf(
+				"structured review has invalid verdict %q", wire.Verdict,
+			)
+		}
+	default:
 		return Document{}, fmt.Errorf(
 			"unsupported structured review schema_version %d",
 			result.SchemaVersion,
@@ -217,36 +249,54 @@ func ensureEOF(dec *json.Decoder) error {
 	return fmt.Errorf("structured review contains trailing JSON")
 }
 
-func (r Document) Filter(minSeverity string) Document {
+// thresholdRank converts a minimum severity into the rank a finding must
+// reach to count against the verdict. Empty and unknown values mean every
+// finding counts, the same as "low".
+func thresholdRank(minSeverity string) int {
 	threshold := severityRank(strings.ToLower(strings.TrimSpace(minSeverity)))
 	if threshold == 0 {
 		threshold = severityRank("low")
 	}
-	filtered := Document{
-		SchemaVersion: r.SchemaVersion,
-		Summary:       r.Summary,
-		Findings:      make([]Finding, 0, len(r.Findings)),
-		SourceLabels:  r.SourceLabels,
-	}
+	return threshold
+}
+
+// UnableToReview reports whether the agent declared it could not assess the
+// change. Callers treat that as an agent failure rather than a verdict.
+func (r Document) UnableToReview() bool {
+	return r.Verdict == VerdictUnableToReview
+}
+
+// Passed reports whether no finding reaches minSeverity. Findings below the
+// threshold are kept in the document and rendered, but do not fail the review.
+// The agent's own verdict is recorded and rendered but does not change the
+// outcome; the findings are the source of truth.
+func (r Document) Passed(minSeverity string) bool {
+	threshold := thresholdRank(minSeverity)
 	for _, finding := range r.Findings {
 		if severityRank(finding.Severity) >= threshold {
-			filtered.Findings = append(filtered.Findings, finding)
+			return false
 		}
 	}
-	return filtered
+	return true
 }
 
-func (r Document) Passed() bool {
-	return len(r.Findings) == 0
-}
-
-func (r Document) Markdown() string {
+// Markdown renders the summary and every finding. When minSeverity is set and
+// no finding reaches it, the rendering says so before listing the findings so
+// a reader can see why the review passed without losing the content.
+func (r Document) Markdown(minSeverity string) string {
 	var out strings.Builder
 	out.WriteString("## Summary\n\n")
 	out.WriteString(strings.TrimSpace(r.Summary))
+	if r.Verdict != "" {
+		fmt.Fprintf(&out, "\n\n**Agent assessment:** %s", verdictLabel(r.Verdict))
+	}
 	if len(r.Findings) == 0 {
-		out.WriteString("\n\nNo findings at or above the configured severity threshold.\n")
+		out.WriteString("\n\nNo issues found.\n")
 		return out.String()
+	}
+	minSeverity = strings.ToLower(strings.TrimSpace(minSeverity))
+	if severityRank(minSeverity) > severityRank("low") && r.Passed(minSeverity) {
+		fmt.Fprintf(&out, "\n\nNo findings at or above %s severity.", minSeverity)
 	}
 	out.WriteString("\n\n## Findings\n")
 	for i, finding := range r.Findings {
@@ -292,6 +342,19 @@ func severityRank(severity string) int {
 		return 1
 	default:
 		return 0
+	}
+}
+
+func verdictLabel(verdict string) string {
+	switch verdict {
+	case VerdictPass:
+		return "Pass"
+	case VerdictFail:
+		return "Fail"
+	case VerdictUnableToReview:
+		return "Unable to review"
+	default:
+		return verdict
 	}
 }
 


### PR DESCRIPTION
## Summary

Stacked on #1120: this PR targets its branch and should merge after it.

- A review with `review_min_severity` or `--min-severity` set previously told the agent to drop every finding below the threshold and answer with a marker when nothing remained, so low-severity notes vanished from the review. Reviews now keep every finding. The threshold is pure post-processing: prompts never mention it, and it only decides the verdict. A review fails when any finding is at or above the threshold and passes otherwise. A pass under the threshold is a pass: it auto-closes and `roborev fix` and skill discovery skip it, since there is nothing to fix.
- Codex, Claude Code, Pi, and Grok now return structured findings for every review type, not only custom ones, so their verdicts come from the reported severities instead of Markdown parsing. Other agents keep prose, and the prose parser now reads the highest severity label rather than failing on any label. It also recognizes the numbered severity headings that structured reviews render, so rendered output parses the same way. Design reviews use the same schema; their section labels collapse into the findings list.
- The structured schema is version 2 and records the agent's own assessment (`pass`, `fail`, `unable_to_review`), rendered as an "Agent assessment" line. It does not change the outcome. `unable_to_review`, `fail` with no findings, and a live document of an older schema version are rejected as agent errors so retry and backup-agent failover run. Stored version 1 documents still decode; nothing is migrated and existing verdicts are untouched.
- Panels and the CI poller apply their threshold per member without dropping findings. A lone surviving member passes through with no synthesis call and keeps its structured JSON on the synthesis review. A panel where every member passes but some retain lower findings goes through synthesis so those findings reach the combined output. Synthesis, which #1120 turned into a sourced structured document, applies the threshold the same way when it renders and derives its verdict.
- Panel and CI thresholds apply to the combined review exactly as configured, replacing the member's own threshold rather than combining with it under the stricter one.
- Prebuilt CI prompts are aligned with the agent that actually runs them: after failover the JSON output instruction is removed for prose agents and appended for structured agents, so a backup agent's output is parsed correctly.
- Pi reviews now always go through the schema path and therefore require the `pi-json-schema` extension; without it, reviews fail instead of falling back to prose.
- Changelog entries for this work and for #1127 sit under a new Unreleased section instead of the shipped 0.67.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>
