### PR TITLE
fix(skills): recover unfetched remote refs in review-branch validation

### DIFF
--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -128,11 +128,18 @@ Review all commits since the current branch diverged from main:
 ```
 /roborev-review-branch
 /roborev-review-branch --base develop
+/roborev-review-branch --base upstream/main
 /roborev-review-branch --type security
 ```
 
 The skill enqueues a branch review and waits for results so the agent can
 present them inline.
+
+When `--base` names a configured remote and branch, such as `upstream/main`, the
+skill fetches that branch if the ref is missing locally, then validates it again
+before requesting the review. Refs that already resolve locally do not trigger a
+fetch. If the remote is not configured, the branch does not exist, or fetching
+fails, the skill reports the Git error and stops without requesting a review.
 
 ### Design review
 

--- a/docs/guides/agent-skills.md
+++ b/docs/guides/agent-skills.md
@@ -140,6 +140,9 @@ skill fetches that branch if the ref is missing locally, then validates it again
 before requesting the review. Refs that already resolve locally do not trigger a
 fetch. If the remote is not configured, the branch does not exist, or fetching
 fails, the skill reports the Git error and stops without requesting a review.
+After recovery, the review uses the exact remote-tracking branch ref so a tag
+fetched alongside it cannot change the base. Tag fetching remains enabled, and
+existing tag refs can be used with `--base`.
 
 ### Design review
 

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -91,7 +91,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
+    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
@@ -141,7 +141,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
+    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -50,7 +50,7 @@ When the user invokes `/roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. It searches configured remote names from the longest slash-delimited prefix, so remote names that contain slashes are supported. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref with no configured remote prefix.
 
 If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
@@ -71,9 +71,26 @@ read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
 if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
-  remote=${branch%%/*}
-  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
-    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  remote=
+  remote_branch="${branch##*/}"
+  remote_candidate="${branch%/*}"
+  while :; do
+    if [ "$remote_candidate" != "$branch" ] && git config --get "remote.$remote_candidate.url" >/dev/null; then
+      remote="$remote_candidate"
+      break
+    fi
+    case "$remote_candidate" in
+      */*)
+        remote_branch="${remote_candidate##*/}/$remote_branch"
+        remote_candidate="${remote_candidate%/*}"
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  if [ -n "$remote" ]; then
+    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
@@ -103,9 +120,26 @@ read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
 if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
-  remote=${branch%%/*}
-  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
-    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  remote=
+  remote_branch="${branch##*/}"
+  remote_candidate="${branch%/*}"
+  while :; do
+    if [ "$remote_candidate" != "$branch" ] && git config --get "remote.$remote_candidate.url" >/dev/null; then
+      remote="$remote_candidate"
+      break
+    fi
+    case "$remote_candidate" in
+      */*)
+        remote_branch="${remote_candidate##*/}/$remote_branch"
+        remote_candidate="${remote_candidate%/*}"
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  if [ -n "$remote" ]; then
+    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -90,6 +90,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
     esac
   done
   if [ -n "$remote" ]; then
+    git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
@@ -139,6 +140,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
     esac
   done
   if [ -n "$remote" ]; then
+    git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -91,7 +91,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
@@ -141,7 +141,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -50,7 +50,9 @@ When the user invokes `/roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-If validation fails, inform the user the ref is invalid. Do not proceed.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+
+If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
 ### 2. Build the command
 
@@ -68,7 +70,13 @@ If a base branch is specified, run:
 read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
-git rev-parse --verify -- "$branch" || exit 1
+if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
+  remote=${branch%%/*}
+  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
+    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  fi
+  git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
+fi
 roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]
 ```
 
@@ -94,7 +102,13 @@ If a base branch is specified, run:
 read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
-git rev-parse --verify -- "$branch" || exit 1
+if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
+  remote=${branch%%/*}
+  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
+    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  fi
+  git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
+fi
 roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]
 ```
 

--- a/internal/skills/claude/roborev-review-branch/SKILL.md
+++ b/internal/skills/claude/roborev-review-branch/SKILL.md
@@ -92,6 +92,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    branch="refs/remotes/$remote/$remote_branch"
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
@@ -142,6 +143,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    branch="refs/remotes/$remote/$remote_branch"
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -49,7 +49,9 @@ When the user invokes `$roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-If validation fails, inform the user the ref is invalid. Do not proceed.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+
+If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
 ### 2. Build and run the command
 
@@ -67,7 +69,13 @@ If a base branch is specified, run:
 read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
-git rev-parse --verify -- "$branch" || exit 1
+if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
+  remote=${branch%%/*}
+  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
+    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  fi
+  git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
+fi
 roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]
 ```
 
@@ -125,7 +133,7 @@ Agent:
 User: `$roborev-review-branch --base develop --type security`
 
 Agent:
-1. Validates: `git rev-parse --verify -- "develop"`
+1. Validates: `git rev-parse --verify --end-of-options "develop"`
 2. Executes `roborev review --branch --wait --base develop --type security`
 3. Presents the verdict and findings
 4. If findings exist: "Would you like me to address these findings? Run `$roborev-fix 1043`"

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -89,6 +89,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
     esac
   done
   if [ -n "$remote" ]; then
+    git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -49,7 +49,7 @@ When the user invokes `$roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. It searches configured remote names from the longest slash-delimited prefix, so remote names that contain slashes are supported. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref with no configured remote prefix.
 
 If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
@@ -70,9 +70,26 @@ read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
 if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
-  remote=${branch%%/*}
-  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
-    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  remote=
+  remote_branch="${branch##*/}"
+  remote_candidate="${branch%/*}"
+  while :; do
+    if [ "$remote_candidate" != "$branch" ] && git config --get "remote.$remote_candidate.url" >/dev/null; then
+      remote="$remote_candidate"
+      break
+    fi
+    case "$remote_candidate" in
+      */*)
+        remote_branch="${remote_candidate##*/}/$remote_branch"
+        remote_candidate="${remote_candidate%/*}"
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  if [ -n "$remote" ]; then
+    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -90,7 +90,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
+    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -90,7 +90,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/codex/roborev-review-branch/SKILL.md
+++ b/internal/skills/codex/roborev-review-branch/SKILL.md
@@ -91,6 +91,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    branch="refs/remotes/$remote/$remote_branch"
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/droid/roborev-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-review-branch/SKILL.md
@@ -89,6 +89,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
     esac
   done
   if [ -n "$remote" ]; then
+    git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1

--- a/internal/skills/droid/roborev-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-review-branch/SKILL.md
@@ -90,7 +90,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
+    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/droid/roborev-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-review-branch/SKILL.md
@@ -49,7 +49,7 @@ When the user invokes `/roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. It searches configured remote names from the longest slash-delimited prefix, so remote names that contain slashes are supported. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref with no configured remote prefix.
 
 If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
@@ -70,9 +70,26 @@ read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
 if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
-  remote=${branch%%/*}
-  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
-    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  remote=
+  remote_branch="${branch##*/}"
+  remote_candidate="${branch%/*}"
+  while :; do
+    if [ "$remote_candidate" != "$branch" ] && git config --get "remote.$remote_candidate.url" >/dev/null; then
+      remote="$remote_candidate"
+      break
+    fi
+    case "$remote_candidate" in
+      */*)
+        remote_branch="${remote_candidate##*/}/$remote_branch"
+        remote_candidate="${remote_candidate%/*}"
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  if [ -n "$remote" ]; then
+    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/droid/roborev-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-review-branch/SKILL.md
@@ -49,7 +49,9 @@ When the user invokes `/roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-If validation fails, inform the user the ref is invalid. Do not proceed.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+
+If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
 ### 2. Build and run the command
 
@@ -67,7 +69,13 @@ If a base branch is specified, run:
 read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
-git rev-parse --verify -- "$branch" || exit 1
+if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
+  remote=${branch%%/*}
+  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
+    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  fi
+  git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
+fi
 roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]
 ```
 
@@ -125,7 +133,7 @@ Agent:
 User: `/roborev-review-branch --base develop --type security`
 
 Agent:
-1. Validates: `git rev-parse --verify -- "develop"`
+1. Validates: `git rev-parse --verify --end-of-options "develop"`
 2. Executes `roborev review --branch --wait --base develop --type security`
 3. Presents the verdict and findings
 4. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1043`"

--- a/internal/skills/droid/roborev-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-review-branch/SKILL.md
@@ -90,7 +90,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/droid/roborev-review-branch/SKILL.md
+++ b/internal/skills/droid/roborev-review-branch/SKILL.md
@@ -91,6 +91,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    branch="refs/remotes/$remote/$remote_branch"
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/grok/roborev-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-review-branch/SKILL.md
@@ -90,6 +90,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
     esac
   done
   if [ -n "$remote" ]; then
+    git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1

--- a/internal/skills/grok/roborev-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-review-branch/SKILL.md
@@ -50,7 +50,9 @@ When the user invokes `/roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-If validation fails, inform the user the ref is invalid. Do not proceed.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+
+If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
 ### 2. Build and run the command
 
@@ -68,7 +70,13 @@ If a base branch is specified, run:
 read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
-git rev-parse --verify -- "$branch" || exit 1
+if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
+  remote=${branch%%/*}
+  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
+    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  fi
+  git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
+fi
 roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]
 ```
 
@@ -126,7 +134,7 @@ Agent:
 User: `/roborev-review-branch --base develop --type security`
 
 Agent:
-1. Validates: `git rev-parse --verify -- "develop"`
+1. Validates: `git rev-parse --verify --end-of-options "develop"`
 2. Executes `roborev review --branch --wait --base develop --type security`
 3. Presents the verdict and findings
 4. If findings exist: "Would you like me to address these findings? Run `/roborev-fix 1043`"

--- a/internal/skills/grok/roborev-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-review-branch/SKILL.md
@@ -50,7 +50,7 @@ When the user invokes `/roborev-review-branch [--base <branch>] [--type security
 
 If a base branch is provided, use the base-branch command snippet below; it stores and validates the ref before invoking `roborev review`.
 
-The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref whose first path segment is not a configured remote.
+The snippet recovers one case on its own: when the ref names a configured remote followed by a branch (for example `upstream/main`) and that remote-tracking ref has not been fetched into this worktree yet, it fetches that one branch from that one remote and re-validates. It searches configured remote names from the longest slash-delimited prefix, so remote names that contain slashes are supported. Every other unresolvable ref is still rejected, and no fetch is attempted for a ref with no configured remote prefix.
 
 If validation fails, inform the user the ref is invalid and report the git error. Do not proceed.
 
@@ -71,9 +71,26 @@ read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
 if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
-  remote=${branch%%/*}
-  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
-    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  remote=
+  remote_branch="${branch##*/}"
+  remote_candidate="${branch%/*}"
+  while :; do
+    if [ "$remote_candidate" != "$branch" ] && git config --get "remote.$remote_candidate.url" >/dev/null; then
+      remote="$remote_candidate"
+      break
+    fi
+    case "$remote_candidate" in
+      */*)
+        remote_branch="${remote_candidate##*/}/$remote_branch"
+        remote_candidate="${remote_candidate%/*}"
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  if [ -n "$remote" ]; then
+    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/grok/roborev-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-review-branch/SKILL.md
@@ -91,7 +91,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
+    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/grok/roborev-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-review-branch/SKILL.md
@@ -91,7 +91,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/grok/roborev-review-branch/SKILL.md
+++ b/internal/skills/grok/roborev-review-branch/SKILL.md
@@ -92,6 +92,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    branch="refs/remotes/$remote/$remote_branch"
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1298,7 +1298,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 				require.Error(t, precondition.Run(), "%s must start unfetched", ref)
 			}
 			if tc.prepareFetchedRef {
-				work.RunGit("fetch", "--quiet", "--end-of-options", "origin", "main")
+				work.RunGit("fetch", "--quiet", "--", "origin", "main")
 			}
 
 			localHeadRefs := func() string {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,6 +1,7 @@
 package skills
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -9,7 +10,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -1134,7 +1134,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
+    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
@@ -1164,27 +1164,22 @@ func reviewBranchRefSnippets(t *testing.T, agent Agent) []string {
 }
 
 type reviewBranchIssueArtifact struct {
-	Body            string `json:"body"`
-	Number          int    `json:"number"`
-	URL             string `json:"url"`
+	Body         string `json:"body"`
+	Number       int    `json:"number"`
+	URL          string `json:"url"`
+	Reproduction struct {
+		BaseRef string `json:"base_ref"`
+	} `json:"reproduction"`
 	ReproductionRef string `json:"-"`
 }
 
+//go:embed testdata/roborev-issue-442.json
+var reviewBranchIssueFixture []byte
+
 func loadReviewBranchIssueArtifact(t *testing.T) reviewBranchIssueArtifact {
 	t.Helper()
-	artifactPath := os.Getenv("ROBOREV_ISSUE_ARTIFACT")
-	if artifactPath == "" {
-		_, sourcePath, _, ok := runtime.Caller(0)
-		require.True(t, ok)
-		repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(sourcePath)))
-		artifactPath = filepath.Join(repoRoot, "..", ".claude", "pr-sweep", "bodies", "roborev-issue-442.json")
-	}
-
-	content, err := os.ReadFile(artifactPath)
-	require.NoError(t, err, "read issue artifact %s", artifactPath)
-
 	var artifact reviewBranchIssueArtifact
-	require.NoError(t, json.Unmarshal(content, &artifact))
+	require.NoError(t, json.Unmarshal(reviewBranchIssueFixture, &artifact))
 	require.Equal(t, 442, artifact.Number)
 	require.Equal(t, "https://github.com/kenn-io/roborev/issues/442", artifact.URL)
 
@@ -1195,8 +1190,9 @@ func loadReviewBranchIssueArtifact(t *testing.T) reviewBranchIssueArtifact {
 			reproductionRef = match[1]
 		}
 	}
-	require.Equal(t, "upstream/main", reproductionRef, "issue artifact must declare the valid upstream/main reproduction")
-	artifact.ReproductionRef = reproductionRef
+	require.Equal(t, "upstream/main", reproductionRef, "issue fixture must preserve the valid upstream/main reproduction")
+	require.Equal(t, reproductionRef, artifact.Reproduction.BaseRef, "issue fixture base must bind to its declared reproduction")
+	artifact.ReproductionRef = artifact.Reproduction.BaseRef
 	return artifact
 }
 
@@ -1245,17 +1241,19 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 
 	pwnPath := filepath.Join(t.TempDir(), "pwn")
 	cases := []struct {
-		name              string
-		ref               string
-		prepareFetchedRef bool
-		wantSuccess       bool
-		wantRun           bool
-		wantRemoteRefs    []string
+		name                      string
+		ref                       string
+		prepareFetchedRef         bool
+		maliciousFetchDestination bool
+		wantSuccess               bool
+		wantRun                   bool
+		wantRemoteRefs            []string
 	}{
 		{name: "upstream_main", ref: issueArtifact.ReproductionRef, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/main"}},
 		{name: "upstream_feature_x", ref: "upstream/feature/x", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/feature/x"}},
 		{name: "slash_remote_main", ref: "team/upstream/main", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/team/upstream/main"}},
 		{name: "origin_main_fetched", ref: "origin/main", prepareFetchedRef: true, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/origin/main"}},
+		{name: "malicious_remote_fetch_destination", ref: "origin/main", maliciousFetchDestination: true, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/origin/main"}},
 		{name: "feat", ref: "feat", wantSuccess: true, wantRun: true},
 		{name: "main", ref: "main", wantSuccess: true, wantRun: true},
 		{name: "develop", ref: "develop"},
@@ -1266,6 +1264,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 		{name: "slash_main", ref: "/main"},
 		{name: "exec_id", ref: "--exec=id"},
 		{name: "upload_pack", ref: "origin/--upload-pack=touch " + pwnPath},
+		{name: "substitution_shape", ref: "origin/$(touch " + pwnPath + ")"},
 		{name: "malformed_destination", ref: "origin/main:foo"},
 		{name: "malformed_heads_destination", ref: "origin/main:refs/heads/pwn"},
 	}
@@ -1278,6 +1277,9 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 			work.AddRemote("upstream", filepath.ToSlash(upstreamRepo.Path()))
 			work.AddRemote("origin", filepath.ToSlash(upstreamRepo.Path()))
 			work.AddRemote("team/upstream", filepath.ToSlash(upstreamRepo.Path()))
+			if tc.maliciousFetchDestination {
+				work.RunGit("config", "remote.origin.fetch", "+refs/heads/main:refs/heads/pwn")
+			}
 
 			for _, ref := range []string{
 				"refs/remotes/upstream/main",

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -1112,9 +1113,26 @@ const wantReviewBranchRefSnippet = `read -r branch <<'ROBOREV_REF'
 <branch>
 ROBOREV_REF
 if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
-  remote=${branch%%/*}
-  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
-    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  remote=
+  remote_branch="${branch##*/}"
+  remote_candidate="${branch%/*}"
+  while :; do
+    if [ "$remote_candidate" != "$branch" ] && git config --get "remote.$remote_candidate.url" >/dev/null; then
+      remote="$remote_candidate"
+      break
+    fi
+    case "$remote_candidate" in
+      */*)
+        remote_branch="${remote_candidate##*/}/$remote_branch"
+        remote_candidate="${remote_candidate%/*}"
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  if [ -n "$remote" ]; then
+    git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
@@ -1179,24 +1197,31 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 	}
 
 	upstreamRepo := testutil.InitTestRepo(t)
+	upstreamRepo.CheckoutNewBranch("feature/x")
+	upstreamRepo.CommitFile("nested-feature.txt", "nested feature", "nested feature commit")
 
 	snippets := reviewBranchRefSnippets(t, AgentCodex)
 	require.Len(t, snippets, 1)
 
 	pwnPath := filepath.Join(t.TempDir(), "pwn")
 	cases := []struct {
-		name          string
-		ref           string
-		wantSuccess   bool
-		wantRun       bool
-		wantRemoteRef bool
+		name           string
+		ref            string
+		wantSuccess    bool
+		wantRun        bool
+		wantRemoteRefs []string
 	}{
-		{name: "upstream_main", ref: "upstream/main", wantSuccess: true, wantRun: true, wantRemoteRef: true},
+		{name: "upstream_main", ref: "upstream/main", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/main"}},
+		{name: "upstream_feature_x", ref: "upstream/feature/x", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/feature/x"}},
+		{name: "slash_remote_main", ref: "team/upstream/main", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/team/upstream/main"}},
 		{name: "feat", ref: "feat", wantSuccess: true, wantRun: true},
 		{name: "main", ref: "main", wantSuccess: true, wantRun: true},
 		{name: "develop", ref: "develop"},
 		{name: "upstream_ghost", ref: "upstream/ghost"},
 		{name: "release_1_2", ref: "release/1.2"},
+		{name: "nosuchremote_main", ref: "nosuchremote/main"},
+		{name: "empty", ref: ""},
+		{name: "slash_main", ref: "/main"},
 		{name: "exec_id", ref: "--exec=id"},
 		{name: "upload_pack", ref: "origin/--upload-pack=touch " + pwnPath},
 	}
@@ -1207,10 +1232,19 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 			work.CheckoutNewBranch("feat")
 			work.CommitFile("feature.txt", "feature", "feature commit")
 			work.AddRemote("upstream", filepath.ToSlash(upstreamRepo.Path()))
+			work.AddRemote("origin", filepath.ToSlash(upstreamRepo.Path()))
+			work.AddRemote("team/upstream", filepath.ToSlash(upstreamRepo.Path()))
 
-			precondition := exec.Command("git", "rev-parse", "--verify", "--end-of-options", "refs/remotes/upstream/main")
-			precondition.Dir = work.Path()
-			require.Error(t, precondition.Run(), "upstream/main must start unfetched")
+			for _, ref := range []string{
+				"refs/remotes/upstream/main",
+				"refs/remotes/upstream/feature/x",
+				"refs/remotes/team/upstream/main",
+				"refs/remotes/origin/main",
+			} {
+				precondition := exec.Command("git", "rev-parse", "--verify", "--end-of-options", ref)
+				precondition.Dir = work.Path()
+				require.Error(t, precondition.Run(), "%s must start unfetched", ref)
+			}
 
 			script := strings.Replace(snippets[0], "<branch>", tc.ref, 1)
 			script = strings.Replace(script, "roborev review --branch --wait --base \"$branch\" [--type <type>] [--panel <name>|none]", "echo ROBOREV_WOULD_RUN", 1)
@@ -1226,10 +1260,17 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 			assert.Equal(t, tc.wantSuccess, runErr == nil, "stderr: %s", stderr.String())
 			assert.Equal(t, tc.wantRun, strings.Contains(stdout.String(), "ROBOREV_WOULD_RUN"), "stdout: %s", stdout.String())
 
-			remoteRef := exec.Command("git", "rev-parse", "--verify", "--end-of-options", "refs/remotes/upstream/main")
-			remoteRef.Dir = work.Path()
-			afterRemoteRef := remoteRef.Run() == nil
-			assert.Equal(t, tc.wantRemoteRef, afterRemoteRef)
+			for _, ref := range []string{
+				"refs/remotes/upstream/main",
+				"refs/remotes/upstream/feature/x",
+				"refs/remotes/team/upstream/main",
+				"refs/remotes/origin/main",
+			} {
+				remoteRef := exec.Command("git", "rev-parse", "--verify", "--end-of-options", ref)
+				remoteRef.Dir = work.Path()
+				got := remoteRef.Run() == nil
+				assert.Equal(t, slices.Contains(tc.wantRemoteRefs, ref), got, "%s", ref)
+			}
 			_, err := os.Stat(pwnPath)
 			assert.Error(t, err)
 		})

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/roborev/internal/autofix"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 type agentCase struct {
@@ -1102,6 +1104,134 @@ func TestFixSkillsRecognizeRuntimeAutofixGuidelines(t *testing.T) {
 			}
 			require.NotEmpty(t, content)
 			assert.Contains(t, content, autofix.GuidelinesHeading)
+		})
+	}
+}
+
+const wantReviewBranchRefSnippet = `read -r branch <<'ROBOREV_REF'
+<branch>
+ROBOREV_REF
+if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
+  remote=${branch%%/*}
+  if [ "$remote" != "$branch" ] && git config --get "remote.$remote.url" >/dev/null; then
+    git fetch --quiet --end-of-options "$remote" "${branch#*/}" || exit 1
+  fi
+  git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
+fi
+roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]`
+
+func reviewBranchRefSnippets(t *testing.T, agent Agent) []string {
+	t.Helper()
+	spec, ok := lookupAgent(agent)
+	require.True(t, ok)
+	skills, err := embeddedSkillsForAgent(spec)
+	require.NoError(t, err)
+
+	var snippets []string
+	for _, skill := range skills {
+		if skill.DirName != "roborev-review-branch" {
+			continue
+		}
+		content := strings.ReplaceAll(string(skill.Content), "\r\n", "\n")
+		for _, block := range strings.Split(content, "```bash\n")[1:] {
+			body, _, ok := strings.Cut(block, "\n```")
+			if ok && strings.Contains(body, "ROBOREV_REF") {
+				snippets = append(snippets, body)
+			}
+		}
+	}
+	return snippets
+}
+
+func TestReviewBranchSkillsShareOneRefValidationSnippet(t *testing.T) {
+	wantCounts := map[Agent]int{
+		AgentClaude: 2,
+		AgentCodex:  1,
+		AgentDroid:  1,
+		AgentGrok:   1,
+	}
+
+	for _, agent := range []Agent{AgentClaude, AgentCodex, AgentDroid, AgentGrok} {
+		t.Run(string(agent), func(t *testing.T) {
+			snippets := reviewBranchRefSnippets(t, agent)
+			require.Len(t, snippets, wantCounts[agent])
+			for _, snippet := range snippets {
+				assert.Equal(t, wantReviewBranchRefSnippet, snippet)
+			}
+
+			spec, ok := lookupAgent(agent)
+			require.True(t, ok)
+			skills, err := embeddedSkillsForAgent(spec)
+			require.NoError(t, err)
+			for _, skill := range skills {
+				if skill.DirName == "roborev-review-branch" {
+					assert.NotContains(t, string(skill.Content), "--verify -- ")
+				}
+			}
+		})
+	}
+}
+
+func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skipf("bash unavailable: %v", err)
+	}
+
+	upstreamRepo := testutil.InitTestRepo(t)
+
+	snippets := reviewBranchRefSnippets(t, AgentCodex)
+	require.Len(t, snippets, 1)
+
+	pwnPath := filepath.Join(t.TempDir(), "pwn")
+	cases := []struct {
+		name          string
+		ref           string
+		wantSuccess   bool
+		wantRun       bool
+		wantRemoteRef bool
+	}{
+		{name: "upstream_main", ref: "upstream/main", wantSuccess: true, wantRun: true, wantRemoteRef: true},
+		{name: "feat", ref: "feat", wantSuccess: true, wantRun: true},
+		{name: "main", ref: "main", wantSuccess: true, wantRun: true},
+		{name: "develop", ref: "develop"},
+		{name: "upstream_ghost", ref: "upstream/ghost"},
+		{name: "release_1_2", ref: "release/1.2"},
+		{name: "exec_id", ref: "--exec=id"},
+		{name: "upload_pack", ref: "origin/--upload-pack=touch " + pwnPath},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			work := testutil.InitTestRepo(t)
+			work.CheckoutNewBranch("feat")
+			work.CommitFile("feature.txt", "feature", "feature commit")
+			work.AddRemote("upstream", filepath.ToSlash(upstreamRepo.Path()))
+
+			precondition := exec.Command("git", "rev-parse", "--verify", "--end-of-options", "refs/remotes/upstream/main")
+			precondition.Dir = work.Path()
+			require.Error(t, precondition.Run(), "upstream/main must start unfetched")
+
+			script := strings.Replace(snippets[0], "<branch>", tc.ref, 1)
+			script = strings.Replace(script, "roborev review --branch --wait --base \"$branch\" [--type <type>] [--panel <name>|none]", "echo ROBOREV_WOULD_RUN", 1)
+			scriptPath := filepath.Join(t.TempDir(), "review-branch.sh")
+			require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+
+			var stdout, stderr strings.Builder
+			cmd := exec.Command(bash, scriptPath)
+			cmd.Dir = work.Path()
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			runErr := cmd.Run()
+			assert.Equal(t, tc.wantSuccess, runErr == nil, "stderr: %s", stderr.String())
+			assert.Equal(t, tc.wantRun, strings.Contains(stdout.String(), "ROBOREV_WOULD_RUN"), "stdout: %s", stdout.String())
+
+			remoteRef := exec.Command("git", "rev-parse", "--verify", "--end-of-options", "refs/remotes/upstream/main")
+			remoteRef.Dir = work.Path()
+			afterRemoteRef := remoteRef.Run() == nil
+			assert.Equal(t, tc.wantRemoteRef, afterRemoteRef)
+			_, err := os.Stat(pwnPath)
+			assert.Error(t, err)
 		})
 	}
 }

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -1238,6 +1237,8 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 	upstreamRepo := testutil.InitTestRepo(t)
 	upstreamRepo.CheckoutNewBranch("feature/x")
 	upstreamRepo.CommitFile("nested-feature.txt", "nested feature", "nested feature commit")
+	upstreamMainSHA := upstreamRepo.RevParse("main")
+	upstreamFeatureSHA := upstreamRepo.HeadSHA()
 
 	snippets := reviewBranchRefSnippets(t, AgentCodex)
 	require.Len(t, snippets, 1)
@@ -1250,17 +1251,18 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 		maliciousFetchDestination bool
 		wantSuccess               bool
 		wantRun                   bool
-		wantRemoteRefs            []string
+		wantFetches               int
+		wantRemoteRefs            map[string]string
 	}{
-		{name: "upstream_main", ref: issueArtifact.ReproductionRef, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/main"}},
-		{name: "upstream_feature_x", ref: "upstream/feature/x", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/feature/x"}},
-		{name: "slash_remote_main", ref: "team/upstream/main", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/team/upstream/main"}},
-		{name: "origin_main_fetched", ref: "origin/main", prepareFetchedRef: true, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/origin/main"}},
-		{name: "malicious_remote_fetch_destination", ref: "origin/main", maliciousFetchDestination: true, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/origin/main"}},
+		{name: "upstream_main", ref: issueArtifact.ReproductionRef, wantFetches: 1, wantSuccess: true, wantRun: true, wantRemoteRefs: map[string]string{"refs/remotes/upstream/main": upstreamMainSHA}},
+		{name: "upstream_feature_x", ref: "upstream/feature/x", wantFetches: 1, wantSuccess: true, wantRun: true, wantRemoteRefs: map[string]string{"refs/remotes/upstream/feature/x": upstreamFeatureSHA}},
+		{name: "slash_remote_main", ref: "team/upstream/main", wantFetches: 1, wantSuccess: true, wantRun: true, wantRemoteRefs: map[string]string{"refs/remotes/team/upstream/main": upstreamMainSHA}},
+		{name: "origin_main_fetched", ref: "origin/main", prepareFetchedRef: true, wantSuccess: true, wantRun: true, wantRemoteRefs: map[string]string{"refs/remotes/origin/main": upstreamMainSHA}},
+		{name: "malicious_remote_fetch_destination", ref: "origin/main", maliciousFetchDestination: true, wantFetches: 1, wantSuccess: true, wantRun: true, wantRemoteRefs: map[string]string{"refs/remotes/origin/main": upstreamMainSHA}},
 		{name: "feat", ref: "feat", wantSuccess: true, wantRun: true},
 		{name: "main", ref: "main", wantSuccess: true, wantRun: true},
 		{name: "develop", ref: "develop"},
-		{name: "upstream_ghost", ref: "upstream/ghost"},
+		{name: "upstream_ghost", ref: "upstream/ghost", wantFetches: 1},
 		{name: "release_1_2", ref: "release/1.2"},
 		{name: "nosuchremote_main", ref: "nosuchremote/main"},
 		{name: "empty", ref: ""},
@@ -1282,6 +1284,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 			work.AddRemote("team/upstream", filepath.ToSlash(upstreamRepo.Path()))
 			if tc.maliciousFetchDestination {
 				work.RunGit("config", "remote.origin.fetch", "+refs/heads/main:refs/heads/pwn")
+				work.RunGit("update-ref", "refs/heads/pwn", work.HeadSHA())
 			}
 
 			for _, ref := range []string{
@@ -1306,8 +1309,19 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 				return string(output)
 			}
 			beforeHeadRefs := localHeadRefs()
+			var beforePwnSHA string
+			if tc.maliciousFetchDestination {
+				beforePwnSHA = work.RevParse("refs/heads/pwn")
+			}
 
-			script := strings.Replace(snippets[0], "<branch>", tc.ref, 1)
+			script := "fetch_log=.fetch-invocations\n" +
+				"git() {\n" +
+				"  if [ \"$1\" = fetch ]; then\n" +
+				"    printf '%s\\n' \"$*\" >> \"$fetch_log\"\n" +
+				"  fi\n" +
+				"  command git \"$@\"\n" +
+				"}\n" +
+				strings.Replace(snippets[0], "<branch>", tc.ref, 1)
 			script = strings.Replace(script, "roborev review --branch --wait --base \"$branch\" [--type <type>] [--panel <name>|none]", "echo ROBOREV_WOULD_RUN", 1)
 			scriptPath := filepath.Join(t.TempDir(), "review-branch.sh")
 			require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
@@ -1329,11 +1343,26 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 			} {
 				remoteRef := exec.Command("git", "rev-parse", "--verify", "--end-of-options", ref)
 				remoteRef.Dir = work.Path()
-				got := remoteRef.Run() == nil
-				assert.Equal(t, slices.Contains(tc.wantRemoteRefs, ref), got, "%s", ref)
+				output, err := remoteRef.Output()
+				wantSHA, wantRef := tc.wantRemoteRefs[ref]
+				if wantRef {
+					require.NoError(t, err, "%s", ref)
+					assert.Equal(t, wantSHA, strings.TrimSpace(string(output)), "%s object ID", ref)
+				} else {
+					require.Error(t, err, "%s", ref)
+				}
 			}
 			assert.Equal(t, beforeHeadRefs, localHeadRefs(), "snippet must not mutate refs/heads")
-			_, err := os.Stat(pwnPath)
+			if tc.maliciousFetchDestination {
+				assert.Equal(t, beforePwnSHA, work.RevParse("refs/heads/pwn"), "malicious fetch mapping must not change refs/heads/pwn")
+			}
+			fetchLog, err := os.ReadFile(filepath.Join(work.Path(), ".fetch-invocations"))
+			if err != nil {
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+			gotFetches := strings.Count(string(fetchLog), "\n")
+			assert.Equal(t, tc.wantFetches, gotFetches, "fetch invocation count")
+			_, err = os.Stat(pwnPath)
 			assert.Error(t, err)
 		})
 	}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -1132,6 +1133,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
     esac
   done
   if [ -n "$remote" ]; then
+    git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --end-of-options "$remote" "$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
@@ -1159,6 +1161,43 @@ func reviewBranchRefSnippets(t *testing.T, agent Agent) []string {
 		}
 	}
 	return snippets
+}
+
+type reviewBranchIssueArtifact struct {
+	Body            string `json:"body"`
+	Number          int    `json:"number"`
+	URL             string `json:"url"`
+	ReproductionRef string `json:"-"`
+}
+
+func loadReviewBranchIssueArtifact(t *testing.T) reviewBranchIssueArtifact {
+	t.Helper()
+	artifactPath := os.Getenv("ROBOREV_ISSUE_ARTIFACT")
+	if artifactPath == "" {
+		_, sourcePath, _, ok := runtime.Caller(0)
+		require.True(t, ok)
+		repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(sourcePath)))
+		artifactPath = filepath.Join(repoRoot, "..", ".claude", "pr-sweep", "bodies", "roborev-issue-442.json")
+	}
+
+	content, err := os.ReadFile(artifactPath)
+	require.NoError(t, err, "read issue artifact %s", artifactPath)
+
+	var artifact reviewBranchIssueArtifact
+	require.NoError(t, json.Unmarshal(content, &artifact))
+	require.Equal(t, 442, artifact.Number)
+	require.Equal(t, "https://github.com/kenn-io/roborev/issues/442", artifact.URL)
+
+	refRE := regexp.MustCompile(`git rev-parse --verify -- ([A-Za-z0-9._/-]+)`)
+	var reproductionRef string
+	for _, match := range refRE.FindAllStringSubmatch(artifact.Body, -1) {
+		if len(match) == 2 && match[1] == "upstream/main" {
+			reproductionRef = match[1]
+		}
+	}
+	require.Equal(t, "upstream/main", reproductionRef, "issue artifact must declare the valid upstream/main reproduction")
+	artifact.ReproductionRef = reproductionRef
+	return artifact
 }
 
 func TestReviewBranchSkillsShareOneRefValidationSnippet(t *testing.T) {
@@ -1196,6 +1235,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 		t.Skipf("bash unavailable: %v", err)
 	}
 
+	issueArtifact := loadReviewBranchIssueArtifact(t)
 	upstreamRepo := testutil.InitTestRepo(t)
 	upstreamRepo.CheckoutNewBranch("feature/x")
 	upstreamRepo.CommitFile("nested-feature.txt", "nested feature", "nested feature commit")
@@ -1205,15 +1245,17 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 
 	pwnPath := filepath.Join(t.TempDir(), "pwn")
 	cases := []struct {
-		name           string
-		ref            string
-		wantSuccess    bool
-		wantRun        bool
-		wantRemoteRefs []string
+		name              string
+		ref               string
+		prepareFetchedRef bool
+		wantSuccess       bool
+		wantRun           bool
+		wantRemoteRefs    []string
 	}{
-		{name: "upstream_main", ref: "upstream/main", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/main"}},
+		{name: "upstream_main", ref: issueArtifact.ReproductionRef, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/main"}},
 		{name: "upstream_feature_x", ref: "upstream/feature/x", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/upstream/feature/x"}},
 		{name: "slash_remote_main", ref: "team/upstream/main", wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/team/upstream/main"}},
+		{name: "origin_main_fetched", ref: "origin/main", prepareFetchedRef: true, wantSuccess: true, wantRun: true, wantRemoteRefs: []string{"refs/remotes/origin/main"}},
 		{name: "feat", ref: "feat", wantSuccess: true, wantRun: true},
 		{name: "main", ref: "main", wantSuccess: true, wantRun: true},
 		{name: "develop", ref: "develop"},
@@ -1224,6 +1266,8 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 		{name: "slash_main", ref: "/main"},
 		{name: "exec_id", ref: "--exec=id"},
 		{name: "upload_pack", ref: "origin/--upload-pack=touch " + pwnPath},
+		{name: "malformed_destination", ref: "origin/main:foo"},
+		{name: "malformed_heads_destination", ref: "origin/main:refs/heads/pwn"},
 	}
 
 	for _, tc := range cases {
@@ -1245,6 +1289,18 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 				precondition.Dir = work.Path()
 				require.Error(t, precondition.Run(), "%s must start unfetched", ref)
 			}
+			if tc.prepareFetchedRef {
+				work.RunGit("fetch", "--quiet", "--end-of-options", "origin", "main")
+			}
+
+			localHeadRefs := func() string {
+				cmd := exec.Command("git", "for-each-ref", "--format=%(refname)", "refs/heads")
+				cmd.Dir = work.Path()
+				output, err := cmd.Output()
+				require.NoError(t, err)
+				return string(output)
+			}
+			beforeHeadRefs := localHeadRefs()
 
 			script := strings.Replace(snippets[0], "<branch>", tc.ref, 1)
 			script = strings.Replace(script, "roborev review --branch --wait --base \"$branch\" [--type <type>] [--panel <name>|none]", "echo ROBOREV_WOULD_RUN", 1)
@@ -1271,6 +1327,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 				got := remoteRef.Run() == nil
 				assert.Equal(t, slices.Contains(tc.wantRemoteRefs, ref), got, "%s", ref)
 			}
+			assert.Equal(t, beforeHeadRefs, localHeadRefs(), "snippet must not mutate refs/heads")
 			_, err := os.Stat(pwnPath)
 			assert.Error(t, err)
 		})

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1133,13 +1133,13 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   done
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
-    git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
 roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]`
 
-const wantReviewBranchFetchCommand = `git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1`
+const wantReviewBranchFetchCommand = `git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1`
 
 func reviewBranchRefSnippets(t *testing.T, agent Agent) []string {
 	t.Helper()

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1140,6 +1140,8 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
 fi
 roborev review --branch --wait --base "$branch" [--type <type>] [--panel <name>|none]`
 
+const wantReviewBranchFetchCommand = `git fetch --quiet --refmap= --end-of-options "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1`
+
 func reviewBranchRefSnippets(t *testing.T, agent Agent) []string {
 	t.Helper()
 	spec, ok := lookupAgent(agent)
@@ -1210,6 +1212,7 @@ func TestReviewBranchSkillsShareOneRefValidationSnippet(t *testing.T) {
 			require.Len(t, snippets, wantCounts[agent])
 			for _, snippet := range snippets {
 				assert.Equal(t, wantReviewBranchRefSnippet, snippet)
+				assert.Contains(t, snippet, wantReviewBranchFetchCommand)
 			}
 
 			spec, ok := lookupAgent(agent)

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1134,6 +1134,7 @@ if ! git rev-parse --verify --quiet --end-of-options "$branch" >/dev/null; then
   if [ -n "$remote" ]; then
     git check-ref-format --branch "$remote_branch" >/dev/null || exit 1
     git fetch --quiet --refmap= -- "$remote" "refs/heads/$remote_branch:refs/remotes/$remote/$remote_branch" || exit 1
+    branch="refs/remotes/$remote/$remote_branch"
   fi
   git rev-parse --verify --end-of-options "$branch" >/dev/null || exit 1
 fi
@@ -1239,6 +1240,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 	upstreamRepo.CommitFile("nested-feature.txt", "nested feature", "nested feature commit")
 	upstreamMainSHA := upstreamRepo.RevParse("main")
 	upstreamFeatureSHA := upstreamRepo.HeadSHA()
+	upstreamRepo.RunGit("tag", "upstream/feature/x", upstreamMainSHA)
 
 	snippets := reviewBranchRefSnippets(t, AgentCodex)
 	require.Len(t, snippets, 1)
@@ -1248,6 +1250,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 		name                      string
 		ref                       string
 		prepareFetchedRef         bool
+		localTag                  bool
 		maliciousFetchDestination bool
 		wantSuccess               bool
 		wantRun                   bool
@@ -1261,6 +1264,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 		{name: "malicious_remote_fetch_destination", ref: "origin/main", maliciousFetchDestination: true, wantFetches: 1, wantSuccess: true, wantRun: true, wantRemoteRefs: map[string]string{"refs/remotes/origin/main": upstreamMainSHA}},
 		{name: "feat", ref: "feat", wantSuccess: true, wantRun: true},
 		{name: "main", ref: "main", wantSuccess: true, wantRun: true},
+		{name: "local_tag", ref: "release-v1", localTag: true, wantSuccess: true, wantRun: true},
 		{name: "develop", ref: "develop"},
 		{name: "upstream_ghost", ref: "upstream/ghost", wantFetches: 1},
 		{name: "release_1_2", ref: "release/1.2"},
@@ -1297,6 +1301,9 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 				precondition.Dir = work.Path()
 				require.Error(t, precondition.Run(), "%s must start unfetched", ref)
 			}
+			if tc.localTag {
+				work.RunGit("tag", tc.ref, "main")
+			}
 			if tc.prepareFetchedRef {
 				work.RunGit("fetch", "--quiet", "--", "origin", "main")
 			}
@@ -1322,7 +1329,7 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 				"  command git \"$@\"\n" +
 				"}\n" +
 				strings.Replace(snippets[0], "<branch>", tc.ref, 1)
-			script = strings.Replace(script, "roborev review --branch --wait --base \"$branch\" [--type <type>] [--panel <name>|none]", "echo ROBOREV_WOULD_RUN", 1)
+			script = strings.Replace(script, "roborev review --branch --wait --base \"$branch\" [--type <type>] [--panel <name>|none]", `printf "ROBOREV_WOULD_RUN %s\n" "$branch"; git rev-parse --verify --end-of-options "$branch" > .review-base-sha`, 1)
 			scriptPath := filepath.Join(t.TempDir(), "review-branch.sh")
 			require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
 
@@ -1334,6 +1341,21 @@ func TestReviewBranchSkillRefValidationBehavior(t *testing.T) {
 			runErr := cmd.Run()
 			assert.Equal(t, tc.wantSuccess, runErr == nil, "stderr: %s", stderr.String())
 			assert.Equal(t, tc.wantRun, strings.Contains(stdout.String(), "ROBOREV_WOULD_RUN"), "stdout: %s", stdout.String())
+
+			if tc.wantRun {
+				wantBase := tc.ref
+				if tc.wantFetches > 0 {
+					wantBase = "refs/remotes/" + tc.ref
+				}
+				assert.Equal(t, "ROBOREV_WOULD_RUN "+wantBase+"\n", stdout.String())
+				baseSHA, err := os.ReadFile(filepath.Join(work.Path(), ".review-base-sha"))
+				require.NoError(t, err)
+				assert.Equal(t, work.RevParse(wantBase), strings.TrimSpace(string(baseSHA)))
+			}
+			if tc.name == "upstream_feature_x" {
+				assert.Equal(t, upstreamMainSHA, work.RevParse("refs/tags/upstream/feature/x"))
+				assert.NotEqual(t, upstreamMainSHA, upstreamFeatureSHA)
+			}
 
 			for _, ref := range []string{
 				"refs/remotes/upstream/main",

--- a/internal/skills/testdata/roborev-issue-442.json
+++ b/internal/skills/testdata/roborev-issue-442.json
@@ -1,0 +1,8 @@
+{
+  "body": "The `review-branch` skill's input validation (step 1) runs `git rev-parse --verify -- <branch>` to check that the `--base` ref is valid before proceeding. This fails when the ref is a remote tracking branch that hasn't been fetched locally yet.\n\n```\n$ git rev-parse --verify -- upstream/main\nfatal: Needed a single revision\n```",
+  "number": 442,
+  "reproduction": {
+    "base_ref": "upstream/main"
+  },
+  "url": "https://github.com/kenn-io/roborev/issues/442"
+}


### PR DESCRIPTION
Review-branch validation now fetches a missing remote branch before retrying validation. In a worktree, a base like `upstream/main` may not have been fetched yet, so validation used to abort and leave the agent to improvise a fetch.

## Details

- The bundled Claude, Codex, Droid, and Grok skills use the same recovery snippet. It finds the longest configured remote prefix, supporting remote names and branch names that contain slashes.
- The fetch maps `refs/heads/<branch>` to `refs/remotes/<remote>/<branch>`. An empty `--refmap` prevents configured fetch mappings from redirecting the update into local branches.
- `git rev-parse --verify --end-of-options` validates the supplied ref, and `git check-ref-format --branch` validates the branch portion before fetching. Refs that already resolve skip the fetch. Missing remote matches, fetch failures, and failed revalidation stop the review.

Closes #442
