### PR TITLE
fix(tui): show reasoning effort across TUI review surfaces

### DIFF
--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -583,6 +583,18 @@ func TestTUIJobCellsContent(t *testing.T) {
 		assert.Equal(t, "claude", cells[colAgent-colRef])
 	})
 
+	t.Run("requested model includes reasoning", func(t *testing.T) {
+		job := makeJob(1)
+		job.RequestedModel = "gpt-5.5"
+		job.Reasoning = "xhigh"
+		cells := m.jobCells(job)
+		assert.Equal(t, "gpt-5.5-xhigh", cells[colRequestedModel-colRef])
+
+		job.Reasoning = ""
+		cells = m.jobCells(job)
+		assert.Equal(t, "gpt-5.5-thorough", cells[colRequestedModel-colRef])
+	})
+
 	t.Run("verdict and handled values", func(t *testing.T) {
 		pass := "P"
 		handled := true

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -583,16 +583,19 @@ func TestTUIJobCellsContent(t *testing.T) {
 		assert.Equal(t, "claude", cells[colAgent-colRef])
 	})
 
-	t.Run("requested model includes reasoning", func(t *testing.T) {
+	t.Run("reasoning has its own column", func(t *testing.T) {
 		job := makeJob(1)
 		job.RequestedModel = "gpt-5.5"
 		job.Reasoning = "xhigh"
 		cells := m.jobCells(job)
-		assert.Equal(t, "gpt-5.5-xhigh", cells[colRequestedModel-colRef])
+		assert.Equal(t, "gpt-5.5", cells[colRequestedModel-colRef])
+
+		assert.Equal(t, "xhigh", cells[colReasoning-colRef])
 
 		job.Reasoning = ""
 		cells = m.jobCells(job)
-		assert.Equal(t, "gpt-5.5-thorough", cells[colRequestedModel-colRef])
+		assert.Equal(t, "gpt-5.5", cells[colRequestedModel-colRef])
+		assert.Equal(t, "—", cells[colReasoning-colRef])
 	})
 
 	t.Run("verdict and handled values", func(t *testing.T) {
@@ -2100,7 +2103,8 @@ func TestTUIQueueFlexOvershootHandled(t *testing.T) {
 
 func TestTUIQueueFlexColumnsGetContentWidth(t *testing.T) {
 	m := newModel(localhostEndpoint, withExternalIODisabled())
-	m.width = 120
+	// Leave room for the default-visible Reasoning column.
+	m.width = 130
 	m.height = 20
 	m.jobs = []storage.ReviewJob{
 		makeJob(1,
@@ -2115,15 +2119,7 @@ func TestTUIQueueFlexColumnsGetContentWidth(t *testing.T) {
 
 	output := m.renderQueueView()
 
-	found := false
-	for line := range strings.SplitSeq(output, "\n") {
-		stripped := stripTestANSI(line)
-		if strings.Contains(stripped, "my-project-repo") {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "Repo name 'my-project-repo' was truncated in output")
+	assert.Contains(t, stripTestANSI(output), "my-project-repo")
 }
 
 func TestTUITasksStaleSelectionNoPanic(t *testing.T) {
@@ -3694,4 +3690,22 @@ func TestContentNavParentOmittedFromJobsRecovers(t *testing.T) {
 			assert.Empty(m.flashMessage, "omitted-parent recovery does not flash")
 		})
 	}
+}
+
+func TestQueueReasoningColumn(t *testing.T) {
+	assert := assert.New(t)
+	m := newModel(localhostEndpoint, withExternalIODisabled())
+	m.width, m.height = 200, 20
+	job := makeJob(1, withAgent("test"))
+	job.Reasoning = "xhigh"
+	m.jobs = []storage.ReviewJob{job}
+	m.selectedIdx, m.selectedJobID = 0, 1
+	output := stripTestANSI(m.renderQueueView())
+	assert.Contains(output, "Reasoning")
+	assert.Contains(output, "xhigh")
+
+	m.hiddenColumns = parseHiddenColumns([]string{"reasoning"})
+	output = stripTestANSI(m.renderQueueView())
+	assert.NotContains(output, "Reasoning")
+	assert.NotContains(output, "xhigh")
 }

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -1026,7 +1026,7 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 		sessionID = string(runes[:12])
 	}
 
-	requestedModel := stripControlChars(job.RequestedModel)
+	requestedModel := formatModelWithReasoning(stripControlChars(job.RequestedModel), job.Reasoning)
 	requestedProvider := stripControlChars(job.RequestedProvider)
 
 	cost := m.jobCostCell(job)

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -242,6 +242,7 @@ const (
 	colRequestedModel           // Explicitly requested model
 	colRequestedProvider        // Explicitly requested provider
 	colCost                     // Cost estimate (USD)
+	colReasoning                // Recorded reasoning effort
 	colCount                    // total number of columns
 )
 
@@ -650,7 +651,7 @@ func (m model) renderQueueView() string {
 // so the cached map stays a superset that any pane-specific column subset
 // can safely index into.
 func (m model) queueContentWidths(rows []queueRow, visCols []int, hasAnyPanel, treeColor bool) map[int]int {
-	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Review Type", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
+	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Review Type", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost", "Reasoning"}
 	var contentWidth map[int]int
 	if m.queueColCache.gen == m.queueColGen {
 		contentWidth = m.queueColCache.contentWidths
@@ -681,7 +682,7 @@ func (m model) renderQueueTable(rows []queueRow, width, visibleRows int, visCols
 	compact := m.queueCompact()
 	hasAnyPanel := anyPanelRow(rows)
 	treeColor := queueColorEnabled()
-	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Review Type", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost"}
+	allHeaders := [colCount]string{"", "JobID", "Ref", "Branch", "Repo", "Agent", "Review Type", "Queued", "Elapsed", "Status", "P/F", "Closed", "Session", "Req Model", "Req Provider", "Cost", "Reasoning"}
 
 	visibleSelectedIdx := visibleSelectedRowIndex(rows, m.selectedJobID)
 	start, end := queueWindowStart(len(rows), visibleSelectedIdx, visibleRows)
@@ -717,7 +718,8 @@ func (m model) renderQueueTable(rows []queueRow, width, visibleRows int, visCols
 		colSessionID:         min(max(contentWidth[colSessionID], 7), 12),          // "Session" header = 7, cap at 12
 		colRequestedModel:    min(max(contentWidth[colRequestedModel], 9), 24),     // "Req Model" header = 9
 		colRequestedProvider: min(max(contentWidth[colRequestedProvider], 12), 24), // "Req Provider" header = 12
-		colCost:              max(contentWidth[colCost], 4),                        // "Cost" header = 4
+		colReasoning:         min(max(contentWidth[colReasoning], 9), 16),
+		colCost:              max(contentWidth[colCost], 4), // "Cost" header = 4
 	}
 
 	// Flexible columns absorb excess space
@@ -1026,12 +1028,12 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 		sessionID = string(runes[:12])
 	}
 
-	requestedModel := formatModelWithReasoning(stripControlChars(job.RequestedModel), job.Reasoning)
+	requestedModel := stripControlChars(job.RequestedModel)
 	requestedProvider := stripControlChars(job.RequestedProvider)
 
 	cost := m.jobCostCell(job)
 
-	return []string{ref, branch, repo, agentName, reviewType, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider, cost}
+	return []string{ref, branch, repo, agentName, reviewType, enqueued, elapsed, status, verdict, handled, sessionID, requestedModel, requestedProvider, cost, displayReasoning(job.Reasoning)}
 }
 
 // displayReviewType returns the canonical label shown in the TUI. Synthesis
@@ -1309,7 +1311,7 @@ func migrateColumnConfig(cfg *config.Config) bool {
 
 // toggleableColumns is the ordered list of columns the user can show/hide.
 // colSel and colJobID are always visible and not included here.
-var toggleableColumns = []int{colRef, colBranch, colRepo, colAgent, colReviewType, colQueued, colElapsed, colStatus, colPF, colHandled, colCost, colSessionID, colRequestedModel, colRequestedProvider}
+var toggleableColumns = []int{colRef, colBranch, colRepo, colAgent, colReasoning, colReviewType, colQueued, colElapsed, colStatus, colPF, colHandled, colCost, colSessionID, colRequestedModel, colRequestedProvider}
 
 // columnNames maps column constants to display names.
 var columnNames = map[int]string{
@@ -1327,6 +1329,7 @@ var columnNames = map[int]string{
 	colRequestedModel:    "Req Model",
 	colRequestedProvider: "Req Provider",
 	colCost:              "Cost",
+	colReasoning:         "Reasoning",
 }
 
 // columnConfigNames maps column constants to config file names (lowercase).
@@ -1345,6 +1348,7 @@ var columnConfigNames = map[int]string{
 	colRequestedModel:    "requested_model",
 	colRequestedProvider: "requested_provider",
 	colCost:              "cost",
+	colReasoning:         "reasoning",
 }
 
 // drainFlexOverflow reduces flex column widths to absorb overflow,

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -85,7 +85,7 @@ func (m model) renderReviewView() string {
 		}
 		repoStr := m.getDisplayName(review.Job.RepoPath, defaultName)
 
-		agentStr := formatAgentLabel(review.Agent, review.Job.Model)
+		agentStr := formatAgentLabelWithReasoning(review.Agent, review.Job.Model, review.Job.Reasoning)
 
 		title = fmt.Sprintf("Review %s%s (%s)", idStr, repoStr, agentStr)
 		titleLen = runewidth.StringWidth(title)

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -85,7 +85,7 @@ func (m model) renderReviewView() string {
 		}
 		repoStr := m.getDisplayName(review.Job.RepoPath, defaultName)
 
-		agentStr := formatAgentLabelWithReasoning(review.Agent, review.Job.Model, review.Job.Reasoning)
+		agentStr := formatAgentLabel(review.Agent, review.Job.Model)
 
 		title = fmt.Sprintf("Review %s%s (%s)", idStr, repoStr, agentStr)
 		titleLen = runewidth.StringWidth(title)
@@ -121,6 +121,7 @@ func (m model) renderReviewView() string {
 		}
 		var metadata strings.Builder
 		metadata.WriteString(statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType, review.Job.PanelRole)))
+		metadata.WriteString(statusStyle.Render(" | Reasoning: " + displayReasoning(review.Job.Reasoning)))
 		if hasVerdict {
 			metadata.WriteString(" ")
 			v := *review.Job.Verdict

--- a/cmd/roborev/tui/review_reasoning_label_test.go
+++ b/cmd/roborev/tui/review_reasoning_label_test.go
@@ -1,0 +1,61 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/roborev/internal/storage"
+)
+
+func TestReviewDetailReasoningLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		reasoning string
+		want      string
+		absent    string
+	}{
+		{name: "explicit", model: "gpt-5.5", reasoning: "xhigh", want: "(codex: gpt-5.5-xhigh)", absent: "gpt-5.5)"},
+		{name: "legacy default", model: "gpt-5.5", want: "(codex: gpt-5.5-thorough)", absent: "gpt-5.5-standard"},
+		{name: "case normalization", model: "gpt-5.5", reasoning: "XHigh", want: "(codex: gpt-5.5-xhigh)", absent: "XHigh"},
+		{name: "unknown normalization", model: "gpt-5.5", reasoning: "ultra", want: "(codex: gpt-5.5-standard)", absent: "ultra"},
+		{name: "without model", reasoning: "xhigh", want: "(codex)", absent: "(codex:"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := setupRenderModel(viewReview, &storage.Review{
+				ID:    10,
+				Agent: "codex",
+				Job: &storage.ReviewJob{
+					ID:        1,
+					RepoName:  "myrepo",
+					GitRef:    "abc1234",
+					Model:     tt.model,
+					Reasoning: tt.reasoning,
+				},
+			})
+			fullScreen := stripANSI(m.renderReviewView())
+			pane := stripANSI(strings.Join(m.reviewPaneHeaderLines(88), "\n"))
+			assert.Contains(t, fullScreen, tt.want)
+			assert.Contains(t, pane, tt.want)
+			assert.NotContains(t, fullScreen, tt.absent)
+			assert.NotContains(t, pane, tt.absent)
+		})
+	}
+}
+
+func TestReviewDetailReasoningLabelFitsPane(t *testing.T) {
+	m := setupRenderModel(viewReview, &storage.Review{
+		ID:  10,
+		Job: &storage.ReviewJob{ID: 1, RepoName: "myrepo", GitRef: "abc1234", Agent: "codex", Model: "gpt-5.5", Reasoning: "xhigh"},
+	})
+	lines := m.reviewPaneHeaderLines(24)
+	assert.Len(t, lines, 3)
+	for _, line := range lines {
+		assert.LessOrEqual(t, runewidth.StringWidth(stripANSI(line)), 24)
+	}
+}

--- a/cmd/roborev/tui/review_reasoning_label_test.go
+++ b/cmd/roborev/tui/review_reasoning_label_test.go
@@ -16,13 +16,11 @@ func TestReviewDetailReasoningLabel(t *testing.T) {
 		model     string
 		reasoning string
 		want      string
-		absent    string
 	}{
-		{name: "explicit", model: "gpt-5.5", reasoning: "xhigh", want: "(codex: gpt-5.5-xhigh)", absent: "gpt-5.5)"},
-		{name: "legacy default", model: "gpt-5.5", want: "(codex: gpt-5.5-thorough)", absent: "gpt-5.5-standard"},
-		{name: "case normalization", model: "gpt-5.5", reasoning: "XHigh", want: "(codex: gpt-5.5-xhigh)", absent: "XHigh"},
-		{name: "unknown normalization", model: "gpt-5.5", reasoning: "ultra", want: "(codex: gpt-5.5-standard)", absent: "ultra"},
-		{name: "without model", reasoning: "xhigh", want: "(codex)", absent: "(codex:"},
+		{name: "explicit", model: "gpt-5.5", reasoning: "xhigh", want: "xhigh"},
+		{name: "missing", model: "gpt-5.5", want: "—"},
+		{name: "recorded value", model: "gpt-5.5", reasoning: "ultra", want: "ultra"},
+		{name: "without model", reasoning: "xhigh", want: "xhigh"},
 	}
 
 	for _, tt := range tests {
@@ -40,10 +38,15 @@ func TestReviewDetailReasoningLabel(t *testing.T) {
 			})
 			fullScreen := stripANSI(m.renderReviewView())
 			pane := stripANSI(strings.Join(m.reviewPaneHeaderLines(88), "\n"))
-			assert.Contains(t, fullScreen, tt.want)
-			assert.Contains(t, pane, tt.want)
-			assert.NotContains(t, fullScreen, tt.absent)
-			assert.NotContains(t, pane, tt.absent)
+			assert := assert.New(t)
+			label := "(codex)"
+			if tt.model != "" {
+				label = "(codex: " + tt.model + ")"
+			}
+			assert.Contains(fullScreen, label)
+			assert.Contains(pane, label)
+			assert.Contains(fullScreen, "Reasoning: "+tt.want)
+			assert.Contains(pane, "Reasoning: "+tt.want)
 		})
 	}
 }

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -83,7 +83,7 @@ func TestTUIRenderViews(t *testing.T) {
 					Model:    "o3",
 				},
 			},
-			wantContains: []string{"(codex: o3)"},
+			wantContains: []string{"(codex: o3-thorough)"},
 			wantAbsent:   []string{"Daemon:"},
 		},
 		{

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -83,7 +83,7 @@ func TestTUIRenderViews(t *testing.T) {
 					Model:    "o3",
 				},
 			},
-			wantContains: []string{"(codex: o3-thorough)"},
+			wantContains: []string{"(codex: o3)"},
 			wantAbsent:   []string{"Daemon:"},
 		},
 		{

--- a/cmd/roborev/tui/split_detail_pane.go
+++ b/cmd/roborev/tui/split_detail_pane.go
@@ -32,7 +32,7 @@ func (m model) reviewPaneHeaderLines(innerW int) []string {
 	var out []string
 	title := fmt.Sprintf("Review #%d %s (%s)", review.Job.ID,
 		m.getDisplayName(review.Job.RepoPath, review.Job.RepoName),
-		formatAgentLabel(review.Agent, review.Job.Model))
+		formatAgentLabelWithReasoning(review.Agent, review.Job.Model, review.Job.Reasoning))
 	out = append(out, xansi.Truncate(titleStyle.Render(title), innerW, ""))
 
 	verdictParts := []string{

--- a/cmd/roborev/tui/split_detail_pane.go
+++ b/cmd/roborev/tui/split_detail_pane.go
@@ -32,11 +32,12 @@ func (m model) reviewPaneHeaderLines(innerW int) []string {
 	var out []string
 	title := fmt.Sprintf("Review #%d %s (%s)", review.Job.ID,
 		m.getDisplayName(review.Job.RepoPath, review.Job.RepoName),
-		formatAgentLabelWithReasoning(review.Agent, review.Job.Model, review.Job.Reasoning))
+		formatAgentLabel(review.Agent, review.Job.Model))
 	out = append(out, xansi.Truncate(titleStyle.Render(title), innerW, ""))
 
 	verdictParts := []string{
 		statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType, review.Job.PanelRole)),
+		statusStyle.Render("| Reasoning: " + displayReasoning(review.Job.Reasoning)),
 	}
 	if review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob() {
 		if *review.Job.Verdict == "P" {

--- a/cmd/roborev/tui/split_queue_pane.go
+++ b/cmd/roborev/tui/split_queue_pane.go
@@ -16,6 +16,8 @@ func (m model) queuePaneColumns(paneW int, contentWidth map[int]int) []int {
 			return 2
 		case colRef, colBranch, colRepo:
 			return min(max(w, 4), 12)
+		case colReasoning:
+			return min(max(w, 9), 16)
 		case colReviewType:
 			return min(max(w, 11), 20)
 		default:

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -46,7 +46,14 @@ func formatAgentLabelWithReasoning(agentName, model, reasoning string) string {
 	if model == "" {
 		return formatAgentLabel(agentName, model)
 	}
-	return fmt.Sprintf("%s: %s-%s", agentName, model, effectiveReasoningLabel(reasoning))
+	return fmt.Sprintf("%s: %s", agentName, formatModelWithReasoning(model, reasoning))
+}
+
+func formatModelWithReasoning(model, reasoning string) string {
+	if model == "" {
+		return ""
+	}
+	return model + "-" + effectiveReasoningLabel(reasoning)
 }
 
 // detachedBranchLabel formats a placeholder branch label for a review job

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -6,6 +6,7 @@ import (
 
 	gitrepo "go.kenn.io/kit/git/repo"
 
+	"go.kenn.io/roborev/internal/agent"
 	internalgit "go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -31,6 +32,21 @@ func formatAgentLabel(agent string, model string) string {
 		return fmt.Sprintf("%s: %s", agent, model)
 	}
 	return agent
+}
+
+func effectiveReasoningLabel(reasoning string) string {
+	reasoning = strings.ToLower(strings.TrimSpace(reasoning))
+	if reasoning == "" {
+		reasoning = "thorough"
+	}
+	return string(agent.ParseReasoningLevel(reasoning))
+}
+
+func formatAgentLabelWithReasoning(agentName, model, reasoning string) string {
+	if model == "" {
+		return formatAgentLabel(agentName, model)
+	}
+	return fmt.Sprintf("%s: %s-%s", agentName, model, effectiveReasoningLabel(reasoning))
 }
 
 // detachedBranchLabel formats a placeholder branch label for a review job

--- a/cmd/roborev/tui/util.go
+++ b/cmd/roborev/tui/util.go
@@ -6,7 +6,6 @@ import (
 
 	gitrepo "go.kenn.io/kit/git/repo"
 
-	"go.kenn.io/roborev/internal/agent"
 	internalgit "go.kenn.io/roborev/internal/git"
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -34,26 +33,12 @@ func formatAgentLabel(agent string, model string) string {
 	return agent
 }
 
-func effectiveReasoningLabel(reasoning string) string {
-	reasoning = strings.ToLower(strings.TrimSpace(reasoning))
+func displayReasoning(reasoning string) string {
+	reasoning = strings.TrimSpace(stripControlChars(reasoning))
 	if reasoning == "" {
-		reasoning = "thorough"
+		return "—"
 	}
-	return string(agent.ParseReasoningLevel(reasoning))
-}
-
-func formatAgentLabelWithReasoning(agentName, model, reasoning string) string {
-	if model == "" {
-		return formatAgentLabel(agentName, model)
-	}
-	return fmt.Sprintf("%s: %s", agentName, formatModelWithReasoning(model, reasoning))
-}
-
-func formatModelWithReasoning(model, reasoning string) string {
-	if model == "" {
-		return ""
-	}
-	return model + "-" + effectiveReasoningLabel(reasoning)
+	return reasoning
 }
 
 // detachedBranchLabel formats a placeholder branch label for a review job

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -373,8 +373,8 @@ Review #42 myrepo (codex: gpt-5.5-xhigh)
 Verdict: Pass [CLOSED]
 ```
 
-- **Line 1**: Review identity: job ID, repo name, agent, model, and reasoning
-    (if explicitly configured)
+- **Line 1**: Review identity: job ID, repo name, agent, model, and configured
+    or default reasoning
 - **Line 2**: Location: repo path, git ref, branch
 - **Line 3**: Status: verdict and closed state
 

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -368,13 +368,13 @@ available shortcuts for the current view.
 The review detail view shows:
 
 ```
-Review #42 myrepo (codex: gpt-5.5)
+Review #42 myrepo (codex: gpt-5.5-xhigh)
 /path/to/repo abc1234 on feature-branch
 Verdict: Pass [CLOSED]
 ```
 
-- **Line 1**: Review identity: job ID, repo name, agent and model (if explicitly
-    configured)
+- **Line 1**: Review identity: job ID, repo name, agent, model, and reasoning
+    (if explicitly configured)
 - **Line 2**: Location: repo path, git ref, branch
 - **Line 3**: Status: verdict and closed state
 

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -219,9 +219,14 @@ Custom column order is saved to `column_order` (queue) and `task_column_order`
 (tasks) in `~/.roborev/config.toml`. Hidden columns are saved to
 `hidden_columns`, which accepts these names: `ref`, `branch`, `repo`, `agent`,
 `review_type`, `queued`, `elapsed`, `status`, `pf`, `closed`, `session_id`,
-`requested_model`, `requested_provider`, `cost`. When `hidden_columns` is not
-set, the Session, Req Model, and Req Provider columns are hidden by default. To
-show separator lines between columns, set `column_borders = true`.
+`requested_model`, `requested_provider`, `cost`, `reasoning`. When
+`hidden_columns` is not set, the Session, Req Model, and Req Provider columns
+are hidden by default. To show separator lines between columns, set
+`column_borders = true`.
+
+The Reasoning column shows the recorded reasoning effort, such as `xhigh`,
+separately from the model. It is visible by default. Jobs with no recorded
+reasoning show `—`.
 
 The Review Type column identifies standard reviews as `default` and shows the
 configured name for specialized or custom reviews. The review detail view shows
@@ -368,15 +373,16 @@ available shortcuts for the current view.
 The review detail view shows:
 
 ```
-Review #42 myrepo (codex: gpt-5.5-xhigh)
+Review #42 myrepo (codex: gpt-5.5)
 /path/to/repo abc1234 on feature-branch
-Verdict: Pass [CLOSED]
+Review type: default | Reasoning: xhigh Verdict: Pass [CLOSED]
 ```
 
-- **Line 1**: Review identity: job ID, repo name, agent, model, and configured
-    or default reasoning
+- **Line 1**: Review identity: job ID, repo name, agent and model (if explicitly
+    configured)
 - **Line 2**: Location: repo path, git ref, branch
-- **Line 3**: Status: verdict and closed state
+- **Line 3**: Review type, recorded reasoning, verdict and closed state. Missing
+    reasoning displays as `—`.
 
 ## Verdicts
 


### PR DESCRIPTION
The TUI shows recorded reasoning effort in a separate, default-visible `Reasoning` queue column. Users can hide or reorder it through the existing column options. Model names retain their original text.

Full-screen and split review details show `Reasoning: xhigh` alongside review metadata. Jobs without recorded reasoning show `—`, rather than implying a known effort from today's default.

Closes #706
