### PR TITLE
feat(config): add excluded branch patterns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,7 @@ model = "gemini-3-flash-preview"  # Model override for this repo
 review_context_count = 5   # Recent reviews to include as context
 display_name = "backend"   # Custom name shown in TUI (optional)
 excluded_branches = ["wip", "scratch"]  # Branches to skip reviews on
+excluded_branch_patterns = ["worktree-agent-*", "release/*"]  # Branch globs to skip for automatic post-commit reviews
 
 # Legacy levels: fast, standard, thorough, maximum
 # Exact agent efforts: low, medium, high, xhigh, max
@@ -146,6 +147,7 @@ max_chars = 50000
 | `display_name` | string | Custom name shown in TUI |
 | `review_context_count` | int | Number of recent reviews to include as context |
 | `excluded_branches` | array | Branches to skip automatic reviews on |
+| `excluded_branch_patterns` | array | Whole-name branch globs to skip automatic post-commit reviews on |
 | `excluded_commit_patterns` | array | Commit message substrings to skip reviews on (case-insensitive) |
 | `exclude_patterns` | array | Filenames or glob patterns to exclude from review diffs for this repo |
 | `post_commit_review` | string | Post-commit hook behavior: `"commit"` (default) or `"branch"` |
@@ -695,9 +697,19 @@ Skip automatic reviews on work-in-progress branches:
 
 ```toml
 excluded_branches = ["wip", "scratch", "experiment"]
+excluded_branch_patterns = ["worktree-agent-*", "release/*"]
 ```
 
-Reviews triggered manually with `roborev review` still work on these branches.
+`excluded_branches` compares exact branch names. `excluded_branch_patterns` uses
+whole-name [`path.Match`](https://pkg.go.dev/path#Match) globs. For example,
+`worktree-agent-*` matches `worktree-agent-fix-123`. The `*` wildcard does not
+cross a slash, so `release/*` matches `release/1.2` but not `release/team/1.2`.
+Malformed patterns are treated as non-matches, and matching continues with the
+remaining patterns.
+
+Branch patterns apply only to automatic post-commit reviews. Reviews triggered
+manually with `roborev review` still work on matching branches. Exact exclusions
+keep their existing automatic review behavior.
 
 ### Excluded Commit Patterns
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -622,6 +622,7 @@ type RepoConfig struct {
 	JobTimeoutMinutes               int                             `toml:"job_timeout_minutes" comment:"Override the review job timeout in minutes for this repo."`
 	HookTimeoutSeconds              int                             `toml:"hook_timeout_seconds" comment:"Override the post-commit hook request timeout (in seconds) for this repo. Useful for large repos where the enqueue handler's git calls are slow. 0 or negative inherits the global / platform default."`
 	ExcludedBranches                []string                        `toml:"excluded_branches" comment:"Branches that should be skipped for automatic review in this repo."`
+	ExcludedBranchPatterns          []string                        `toml:"excluded_branch_patterns" comment:"Branch glob patterns that should be skipped for automatic post-commit review in this repo."`
 	ExcludedCommitPatterns          []string                        `toml:"excluded_commit_patterns" comment:"Commit message substrings that should skip review for this repo."`
 	DisplayName                     string                          `toml:"display_name" comment:"Display name shown for this repo in the TUI and output."`
 	ReviewReasoning                 string                          `toml:"review_reasoning" comment:"Reasoning for reviews in this repo. Legacy: fast, standard, thorough, maximum. Exact: low, medium, high, xhigh, max."`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -913,6 +913,12 @@ func TestIsBranchExcluded(t *testing.T) {
 			branch:     "my-wip",
 			want:       false,
 		},
+		{
+			name:       "branch patterns do not change exact matching",
+			repoConfig: `excluded_branch_patterns = ["wip-*"]`,
+			branch:     "wip-feature",
+			want:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -920,14 +926,25 @@ func TestIsBranchExcluded(t *testing.T) {
 			tmpDir := newTempRepo(t, tt.repoConfig)
 			// For "no config file", we just don't write anything.
 
-			got := IsBranchExcluded(tmpDir, tt.branch)
-			if got != tt.want {
-				assert.Condition(t, func() bool {
-					return false
-				}, "IsBranchExcluded(%q) = %v, want %v", tt.branch, got, tt.want)
-			}
+			assert.Equal(t, tt.want, IsBranchExcluded(tmpDir, tt.branch))
 		})
 	}
+}
+
+func TestLoadRepoConfigExcludedBranchPatterns(t *testing.T) {
+	tmpDir := newTempRepo(t, `
+excluded_branches = ["wip"]
+excluded_branch_patterns = ["worktree-agent-*", "release/*"]
+`)
+
+	cfg, err := LoadRepoConfig(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, []string{"wip"}, cfg.ExcludedBranches)
+	assert.Equal(t,
+		[]string{"worktree-agent-*", "release/*"},
+		cfg.ExcludedBranchPatterns,
+	)
 }
 
 func TestResolveExcludePatterns(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2601,7 +2601,7 @@ func (s *Server) humaEnqueue(
 		}
 	}
 	if branchToCheck != "" &&
-		config.IsBranchExcluded(checkoutRoot, branchToCheck) {
+		isBranchExcluded(checkoutRoot, repoCfg, branchToCheck, req.Source) {
 		return rawJSONOutput(http.StatusOK, EnqueueSkippedResponse{
 			Skipped: true,
 			Reason: fmt.Sprintf(
@@ -2688,7 +2688,9 @@ func (s *Server) humaEnqueue(
 		if inferred := git.InferBranchForCommit(
 			ctx, checkoutRoot, descriptor.sessionSHA,
 		); inferred != "" {
-			if config.IsBranchExcluded(checkoutRoot, inferred) {
+			if isBranchExcluded(
+				checkoutRoot, repoCfg, inferred, req.Source,
+			) {
 				return rawJSONOutput(http.StatusOK, EnqueueSkippedResponse{
 					Skipped: true,
 					Reason: fmt.Sprintf(
@@ -2782,6 +2784,19 @@ func (s *Server) humaEnqueue(
 		reasoning:      reasoning,
 		requestedModel: requestedModel,
 	})
+}
+
+func isBranchExcluded(
+	repoPath string, repoCfg *config.RepoConfig, branch, source string,
+) bool {
+	if config.IsBranchExcluded(repoPath, branch) {
+		return true
+	}
+	if source != storage.JobSourcePostCommit || repoCfg == nil ||
+		len(repoCfg.ExcludedBranchPatterns) == 0 {
+		return false
+	}
+	return matchBranch(repoCfg.ExcludedBranchPatterns, branch)
 }
 
 // singleAgentInputs groups the inputs threaded from humaEnqueue into the

--- a/internal/daemon/server_jobs_test.go
+++ b/internal/daemon/server_jobs_test.go
@@ -383,6 +383,162 @@ func TestHandleEnqueueUsesExplicitBranchForExclusion(t *testing.T) {
 	}
 }
 
+func TestHandleEnqueueExcludedBranchPatterns(t *testing.T) {
+	const skippedPanelConfig = `
+excluded_branch_patterns = ["worktree-agent-*"]
+
+[review]
+hook_review_panel = "solo"
+
+[review.subagents.bug]
+agent = "test"
+review_type = "default"
+
+[review.panels.solo]
+members = ["bug"]
+synthesis_agent = "test"
+`
+	tests := []struct {
+		name          string
+		config        string
+		currentBranch string
+		targetBranch  string
+		source        string
+		wantStatus    int
+		wantBranch    string
+	}{
+		{
+			name:          "post-commit current branch matches issue glob",
+			config:        `excluded_branch_patterns = ["worktree-agent-*"]`,
+			currentBranch: "worktree-agent-fix-662",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "base branch remains allowed",
+			config:        `excluded_branch_patterns = ["worktree-agent-*"]`,
+			currentBranch: "main",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusCreated,
+			wantBranch:    "main",
+		},
+		{
+			name:          "nonmatching adjacent branch remains allowed",
+			config:        `excluded_branch_patterns = ["worktree-agent-*"]`,
+			currentBranch: "worktree-worker-fix-662",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusCreated,
+			wantBranch:    "worktree-worker-fix-662",
+		},
+		{
+			name:          "empty patterns remain allowed",
+			config:        `excluded_branch_patterns = []`,
+			currentBranch: "worktree-agent-fix-662",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusCreated,
+			wantBranch:    "worktree-agent-fix-662",
+		},
+		{
+			name:          "malformed pattern is a non-match",
+			config:        `excluded_branch_patterns = ["["]`,
+			currentBranch: "worktree-agent-fix-662",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusCreated,
+			wantBranch:    "worktree-agent-fix-662",
+		},
+		{
+			name:          "valid pattern after malformed pattern matches",
+			config:        `excluded_branch_patterns = ["[", "worktree-agent-*"]`,
+			currentBranch: "worktree-agent-fix-662",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "glob does not cross slash boundary",
+			config:        `excluded_branch_patterns = ["feature/*"]`,
+			currentBranch: "feature/team/topic",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusCreated,
+			wantBranch:    "feature/team/topic",
+		},
+		{
+			name:          "foreground explicit target matching glob remains allowed",
+			config:        `excluded_branch_patterns = ["worktree-agent-*"]`,
+			currentBranch: "main",
+			targetBranch:  "worktree-agent-fix-662",
+			wantStatus:    http.StatusCreated,
+			wantBranch:    "worktree-agent-fix-662",
+		},
+		{
+			name:          "explicit post-commit target takes precedence",
+			config:        `excluded_branch_patterns = ["worktree-agent-*"]`,
+			currentBranch: "main",
+			targetBranch:  "worktree-agent-fix-662",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusOK,
+		},
+		{
+			name:          "allowed explicit post-commit target overrides matching checkout",
+			config:        `excluded_branch_patterns = ["worktree-agent-*"]`,
+			currentBranch: "worktree-agent-fix-662",
+			targetBranch:  "main",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusCreated,
+			wantBranch:    "main",
+		},
+		{
+			name:          "post-commit panel matching glob is skipped before fanout",
+			config:        skippedPanelConfig,
+			currentBranch: "worktree-agent-panel",
+			source:        storage.JobSourcePostCommit,
+			wantStatus:    http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, db, tmpDir := newTestServer(t)
+			repoDir := filepath.Join(tmpDir, "testrepo")
+			repo := testutil.InitTestGitRepo(t, repoDir)
+			if tt.currentBranch != repo.RevParse("--abbrev-ref", "HEAD") {
+				repo.CheckoutNewBranch(tt.currentBranch)
+			}
+			require.NoError(t, os.WriteFile(
+				filepath.Join(repoDir, ".roborev.toml"),
+				[]byte(tt.config), 0o644,
+			))
+
+			req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue",
+				EnqueueRequest{
+					RepoPath: repoDir,
+					GitRef:   "HEAD",
+					Branch:   tt.targetBranch,
+					Agent:    "test",
+					Source:   tt.source,
+				},
+			)
+			w := httptest.NewRecorder()
+			server.httpServer.Handler.ServeHTTP(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code, w.Body.String())
+			queued, _, _, _, _, _, _, _, _ := db.GetJobCounts()
+			if tt.wantStatus == http.StatusOK {
+				assert.Zero(t, queued)
+				var response EnqueueSkippedResponse
+				testutil.DecodeJSON(t, w, &response)
+				assert.True(t, response.Skipped)
+				assert.Contains(t, response.Reason, "excluded from reviews")
+				return
+			}
+
+			assert.Equal(t, 1, queued)
+			var job storage.ReviewJob
+			testutil.DecodeJSON(t, w, &job)
+			assert.Equal(t, tt.wantBranch, job.Branch)
+		})
+	}
+}
+
 func TestBuildTargetDescriptorExcludedCommitPattern(t *testing.T) {
 	t.Parallel()
 	server, db, tmpDir := newTestServer(t)
@@ -2992,9 +3148,14 @@ func TestHandleEnqueueDetachedHeadInfersBranch(t *testing.T) {
 		repo.RunGit("branch", "feature-b")
 		repo.CheckoutDetached()
 		repo.CommitFile("g.txt", "content", "detached commit")
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, ".roborev.toml"),
+			[]byte(`excluded_branch_patterns = ["feature-*"]`), 0o644,
+		))
 
 		w := enqueue(t, server, EnqueueRequest{
 			RepoPath: repoDir, GitRef: "HEAD", Agent: "test",
+			Source: storage.JobSourcePostCommit,
 		})
 		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
 
@@ -3053,6 +3214,35 @@ func TestHandleEnqueueDetachedHeadInfersBranch(t *testing.T) {
 
 		queued, _, _, _, _, _, _, _, _ := db.GetJobCounts()
 		assert.Zero(t, queued, "no job should be enqueued for excluded inferred branch")
+	})
+
+	t.Run("post-commit inferred branch matches exclusion glob", func(t *testing.T) {
+		server, db, tmpDir := newTestServer(t)
+		repoDir := filepath.Join(tmpDir, "testrepo")
+		repo := testutil.InitTestGitRepo(t, repoDir)
+
+		repo.CheckoutNewBranch("worktree-agent-fix-662")
+		repo.CommitFile("f.txt", "content", "feature commit")
+		repo.CheckoutDetached()
+		repo.CommitFile("g.txt", "content", "detached commit")
+		require.NoError(t, os.WriteFile(
+			filepath.Join(repoDir, ".roborev.toml"),
+			[]byte(`excluded_branch_patterns = ["worktree-agent-*"]`), 0o644,
+		))
+
+		w := enqueue(t, server, EnqueueRequest{
+			RepoPath: repoDir, GitRef: "HEAD", Agent: "test",
+			Source: storage.JobSourcePostCommit,
+		})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		var response EnqueueSkippedResponse
+		testutil.DecodeJSON(t, w, &response)
+		assert.True(t, response.Skipped)
+		assert.Contains(t, response.Reason, "worktree-agent-fix-662")
+
+		queued, _, _, _, _, _, _, _, _ := db.GetJobCounts()
+		assert.Zero(t, queued)
 	})
 
 	t.Run("client-sent branch wins over inference", func(t *testing.T) {


### PR DESCRIPTION
Automatic post-commit review exclusion now accepts `excluded_branch_patterns` path globs alongside exact `excluded_branches` entries. Repositories can skip transient branch families such as `worktree-agent-*` without listing each generated branch.

Previously, branch exclusion compared exact names only, so the workaround required adding every generated branch to `excluded_branches`. Pattern matching uses the daemon's existing `path.Match` rules, including its slash boundaries and malformed-pattern handling.

The change is limited to repository config decoding, daemon enqueue filtering, and configuration documentation. Exact exclusions, foreground review routing, explicit post-commit branch selection, detached-head inference, API payloads, and storage remain unchanged.

Closes #662
