### PR TITLE
feat(tui): select agent for job reruns

### DIFF
--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -209,10 +209,14 @@ func (m model) callPauseAPI(paused bool) error {
 // rerunJob sends a rerun request to the server for failed/canceled jobs.
 func (m model) rerunJob(snap rerunSnapshot) tea.Cmd {
 	return func() tea.Msg {
+		body := &daemonclient.RerunJobRequest{JobID: snap.jobID}
+		if snap.agent != "" {
+			body.Agent = &snap.agent
+		}
 		resp, err := m.api.RerunJobWithResponse(
 			m.apiContext(),
 			&daemonclient.RerunJobRequestOptions{
-				Body: &daemonclient.RerunJobRequest{JobID: snap.jobID},
+				Body: body,
 			},
 		)
 		if resp != nil && resp.StatusCode != http.StatusOK {
@@ -220,6 +224,8 @@ func (m model) rerunJob(snap rerunSnapshot) tea.Cmd {
 		}
 		return rerunResultMsg{
 			jobID:         snap.jobID,
+			agent:         snap.agent,
+			oldAgent:      snap.oldAgent,
 			oldState:      snap.oldStatus,
 			oldStartedAt:  snap.oldStartedAt,
 			oldFinishedAt: snap.oldFinishedAt,
@@ -236,6 +242,8 @@ func (m model) rerunJob(snap rerunSnapshot) tea.Cmd {
 // update so it can be rolled back if the server request fails.
 type rerunSnapshot struct {
 	jobID         int64
+	agent         string
+	oldAgent      string
 	oldStatus     storage.JobStatus
 	oldStartedAt  *time.Time
 	oldFinishedAt *time.Time

--- a/cmd/roborev/tui/actions.go
+++ b/cmd/roborev/tui/actions.go
@@ -206,6 +206,32 @@ func (m model) callPauseAPI(paused bool) error {
 	return err
 }
 
+// startRerun captures rollback state and updates the queue before sending the request.
+func (m *model) startRerun(job *storage.ReviewJob, selectedAgent string) tea.Cmd {
+	snap := rerunSnapshot{
+		jobID: job.ID, agent: selectedAgent, oldAgent: job.Agent,
+		oldStatus: job.Status, oldStartedAt: job.StartedAt,
+		oldFinishedAt: job.FinishedAt, oldError: job.Error,
+		oldClosed: job.Closed, oldVerdict: job.Verdict,
+		spawnsNewRun: job.IsSynthesisJob(),
+	}
+	if snap.spawnsNewRun {
+		// Panel reruns create a new run; the original row remains history.
+		m.markPanelRerunInFlight(job.ID)
+	} else {
+		if selectedAgent != "" {
+			job.Agent = selectedAgent
+		}
+		job.Status = storage.JobStatusQueued
+		job.StartedAt = nil
+		job.FinishedAt = nil
+		job.Error = ""
+		job.Closed = nil
+		job.Verdict = nil
+	}
+	return m.rerunJob(snap)
+}
+
 // rerunJob sends a rerun request to the server for failed/canceled jobs.
 func (m model) rerunJob(snap rerunSnapshot) tea.Cmd {
 	return func() tea.Msg {

--- a/cmd/roborev/tui/control_handlers.go
+++ b/cmd/roborev/tui/control_handlers.go
@@ -645,6 +645,7 @@ func (m model) handleCtrlRerunJob(
 
 	snap := rerunSnapshot{
 		jobID:         job.ID,
+		oldAgent:      job.Agent,
 		oldStatus:     job.Status,
 		oldStartedAt:  job.StartedAt,
 		oldFinishedAt: job.FinishedAt,

--- a/cmd/roborev/tui/control_handlers.go
+++ b/cmd/roborev/tui/control_handlers.go
@@ -643,40 +643,8 @@ func (m model) handleCtrlRerunJob(
 		}, nil
 	}
 
-	snap := rerunSnapshot{
-		jobID:         job.ID,
-		oldAgent:      job.Agent,
-		oldStatus:     job.Status,
-		oldStartedAt:  job.StartedAt,
-		oldFinishedAt: job.FinishedAt,
-		oldError:      job.Error,
-		oldClosed:     job.Closed,
-		oldVerdict:    job.Verdict,
-		// Same as the keyboard path: a synthesis parent's rerun spawns a
-		// new panel run with new job IDs, not a new attempt of this job.
-		spawnsNewRun: job.IsSynthesisJob(),
-	}
-	// Same gate as the keyboard path: this optimistic
-	// re-queue is only consistent with what the daemon will do when the
-	// daemon really re-runs THIS row. A synthesis parent's rerun enqueues a
-	// separate run and leaves this row -- and its review -- exactly as they
-	// are, so the mutation would be wrong from the instant it was made.
-	if !snap.spawnsNewRun {
-		job.Status = storage.JobStatusQueued
-		job.StartedAt = nil
-		job.FinishedAt = nil
-		job.Error = ""
-		// Clear review-derived fields so the rerun job is visible
-		// under hideClosed and doesn't expose stale verdict data.
-		// For an ordinary rerun the daemon deletes the review row, so this
-		// keeps the local optimistic state consistent until the next fetch.
-		job.Closed = nil
-		job.Verdict = nil
-	} else {
-		m.markPanelRerunInFlight(job.ID)
-	}
-
-	return m, controlResponse{OK: true}, m.rerunJob(snap)
+	cmd := m.startRerun(job, "")
+	return m, controlResponse{OK: true}, cmd
 }
 
 func (m model) handleCtrlQuit() (model, controlResponse, tea.Cmd) {

--- a/cmd/roborev/tui/control_test.go
+++ b/cmd/roborev/tui/control_test.go
@@ -32,6 +32,7 @@ func TestViewKindString(t *testing.T) {
 		{viewLog, "log"},
 		{viewFilter, "filter"},
 		{viewPatch, "patch"},
+		{viewRerunAgent, "rerun-agent"},
 		{viewKind(999), "unknown"},
 	}
 	for _, tt := range tests {

--- a/cmd/roborev/tui/control_types.go
+++ b/cmd/roborev/tui/control_types.go
@@ -106,6 +106,8 @@ func (v viewKind) String() string {
 		return "column-options"
 	case viewReleaseNotes:
 		return "release-notes"
+	case viewRerunAgent:
+		return "rerun-agent"
 	default:
 		return "unknown"
 	}

--- a/cmd/roborev/tui/handlers.go
+++ b/cmd/roborev/tui/handlers.go
@@ -36,6 +36,8 @@ func (m model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleColumnOptionsInput(msg)
 	case viewReleaseNotes:
 		return m.handleReleaseNotesKey(msg)
+	case viewRerunAgent:
+		return m.handleRerunAgentPickerKey(msg)
 	}
 
 	// Review-scoped actions must not fire against a review the detail pane
@@ -222,6 +224,8 @@ func (m model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleCancelKey()
 	case "r":
 		return m.handleRerunKey()
+	case "R":
+		return m.handleRerunAgentKey()
 	case "l", "t":
 		return m.handleLogKey2()
 	case "f":

--- a/cmd/roborev/tui/handlers_msg.go
+++ b/cmd/roborev/tui/handlers_msg.go
@@ -1820,6 +1820,9 @@ func (m model) handleRerunResultMsg(
 			m.setJobFinishedAt(msg.jobID, msg.oldFinishedAt)
 			m.setJobError(msg.jobID, msg.oldError)
 			m.mutateJob(msg.jobID, func(job *storage.ReviewJob) {
+				if msg.agent != "" {
+					job.Agent = msg.oldAgent
+				}
 				job.Closed = msg.oldClosed
 				job.Verdict = msg.oldVerdict
 			})
@@ -1871,6 +1874,11 @@ func (m model) handleRerunResultMsg(
 			3*time.Second, m.currentView,
 		)
 		return m, nil
+	}
+	if msg.agent != "" {
+		m.mutateJob(msg.jobID, func(job *storage.ReviewJob) {
+			job.Agent = msg.agent
+		})
 	}
 	// Rerun confirmed: a rerun reuses the same job ID, so once the job
 	// finishes again `currentReview.JobID == job.ID` would keep matching

--- a/cmd/roborev/tui/handlers_review.go
+++ b/cmd/roborev/tui/handlers_review.go
@@ -1,13 +1,17 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
 	gitrepo "go.kenn.io/kit/git/repo"
 
+	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -193,6 +197,7 @@ func (m model) handleRerunKey() (tea.Model, tea.Cmd) {
 		}
 		snap := rerunSnapshot{
 			jobID:         job.ID,
+			oldAgent:      job.Agent,
 			oldStatus:     job.Status,
 			oldStartedAt:  job.StartedAt,
 			oldFinishedAt: job.FinishedAt,
@@ -229,6 +234,192 @@ func (m model) handleRerunKey() (tea.Model, tea.Cmd) {
 		return m, m.rerunJob(snap)
 	}
 	return m, nil
+}
+
+func rerunAgentEligible(job *storage.ReviewJob) bool {
+	if job == nil || job.PanelRole != "" || job.IsSynthesisJob() || len(job.Experiments) > 0 {
+		return false
+	}
+	if job.Status == storage.JobStatusCanceled && job.WorkerID != "" {
+		return false
+	}
+	return job.Status == storage.JobStatusDone ||
+		job.Status == storage.JobStatusFailed ||
+		job.Status == storage.JobStatusCanceled ||
+		job.Status == storage.JobStatusSkipped
+}
+
+func (m model) rerunAgentConfig(
+	job *storage.ReviewJob,
+) (*config.RepoConfig, *config.Config, error) {
+	repoPath := job.RepoPath
+	if job.WorktreePath != "" {
+		repoPath = job.WorktreePath
+	}
+	repoCfg, err := config.LoadRepoConfig(repoPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load repo config: %w", err)
+	}
+	globalCfg := m.globalCfg
+	if globalCfg == nil {
+		globalCfg = config.DefaultConfig()
+	}
+	return repoCfg, globalCfg, nil
+}
+
+func rerunAgentStorageName(
+	name string, repoCfg *config.RepoConfig, globalCfg *config.Config,
+) string {
+	return agent.StorageNameFromConfig(
+		agent.CanonicalName(name), repoCfg, globalCfg,
+	)
+}
+
+func validateRerunAgentChoice(
+	job *storage.ReviewJob,
+	name string,
+	repoCfg *config.RepoConfig,
+	globalCfg *config.Config,
+) error {
+	selected, err := agent.GetAvailableExactWithConfigFromConfig(
+		repoCfg, name, globalCfg,
+	)
+	if err != nil {
+		return err
+	}
+	if err := agent.ValidateStructuredReviewSelection(job.ReviewType, selected); err != nil {
+		return err
+	}
+	if rerunAgentStorageName(name, repoCfg, globalCfg) ==
+		rerunAgentStorageName(job.Agent, repoCfg, globalCfg) {
+		return errors.New("selected agent is already assigned to this job")
+	}
+	return nil
+}
+
+func (m model) availableRerunAgents(job *storage.ReviewJob) ([]string, error) {
+	repoCfg, globalCfg, err := m.rerunAgentConfig(job)
+	if err != nil {
+		return nil, err
+	}
+	names := agent.AvailableNamesFromConfig(repoCfg, globalCfg)
+	available := make([]string, 0, len(names))
+	for _, name := range names {
+		if strings.TrimSpace(name) == "test" {
+			continue
+		}
+		if validateRerunAgentChoice(job, name, repoCfg, globalCfg) == nil {
+			available = append(available, name)
+		}
+	}
+	return available, nil
+}
+
+func (m model) handleRerunAgentKey() (tea.Model, tea.Cmd) {
+	job, ok := m.selectedJob()
+	if m.currentView != viewQueue || !ok || !rerunAgentEligible(job) {
+		return m, nil
+	}
+	options, err := m.availableRerunAgents(job)
+	if err != nil {
+		m.setWarningFlash(
+			fmt.Sprintf("Cannot load rerun agents: %v", err),
+			4*time.Second, viewQueue,
+		)
+		return m, nil
+	}
+	if len(options) == 0 {
+		m.setFlash("No alternate agents available", 3*time.Second, viewQueue)
+		return m, nil
+	}
+	m.rerunAgentJobID = job.ID
+	m.rerunAgentOptions = options
+	m.rerunAgentSelected = 0
+	m.currentView = viewRerunAgent
+	return m, nil
+}
+
+func (m *model) closeRerunAgentPicker() {
+	m.currentView = viewQueue
+	m.rerunAgentJobID = 0
+	m.rerunAgentOptions = nil
+	m.rerunAgentSelected = 0
+}
+
+func (m model) handleRerunAgentPickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.closeRerunAgentPicker()
+		return m, nil
+	case "up", "k":
+		if m.rerunAgentSelected > 0 {
+			m.rerunAgentSelected--
+		}
+		return m, nil
+	case "down", "j":
+		if m.rerunAgentSelected < len(m.rerunAgentOptions)-1 {
+			m.rerunAgentSelected++
+		}
+		return m, nil
+	case "enter":
+		return m.submitRerunAgentChoice()
+	default:
+		return m, nil
+	}
+}
+
+func (m model) submitRerunAgentChoice() (tea.Model, tea.Cmd) {
+	if m.rerunAgentSelected < 0 || m.rerunAgentSelected >= len(m.rerunAgentOptions) {
+		m.closeRerunAgentPicker()
+		return m, nil
+	}
+	var job *storage.ReviewJob
+	for i := range m.jobs {
+		if m.jobs[i].ID == m.rerunAgentJobID {
+			job = &m.jobs[i]
+			break
+		}
+	}
+	if !rerunAgentEligible(job) {
+		m.closeRerunAgentPicker()
+		m.setWarningFlash("Job is no longer eligible for an alternate-agent rerun", 4*time.Second, viewQueue)
+		return m, nil
+	}
+	selectedAgent := m.rerunAgentOptions[m.rerunAgentSelected]
+	repoCfg, globalCfg, err := m.rerunAgentConfig(job)
+	if err == nil {
+		err = validateRerunAgentChoice(job, selectedAgent, repoCfg, globalCfg)
+	}
+	if err != nil {
+		m.closeRerunAgentPicker()
+		m.setWarningFlash(
+			fmt.Sprintf("Agent is no longer available: %v", err),
+			4*time.Second, viewQueue,
+		)
+		return m, nil
+	}
+	snap := rerunSnapshot{
+		jobID:         job.ID,
+		agent:         selectedAgent,
+		oldAgent:      job.Agent,
+		oldStatus:     job.Status,
+		oldStartedAt:  job.StartedAt,
+		oldFinishedAt: job.FinishedAt,
+		oldError:      job.Error,
+		oldClosed:     job.Closed,
+		oldVerdict:    job.Verdict,
+	}
+	job.Agent = selectedAgent
+	job.Status = storage.JobStatusQueued
+	job.StartedAt = nil
+	job.FinishedAt = nil
+	job.Error = ""
+	job.Closed = nil
+	job.Verdict = nil
+	m.closeRerunAgentPicker()
+	return m, m.rerunJob(snap)
 }
 
 func (m model) handleLogKey2() (tea.Model, tea.Cmd) {

--- a/cmd/roborev/tui/handlers_review.go
+++ b/cmd/roborev/tui/handlers_review.go
@@ -287,6 +287,9 @@ func validateRerunAgentChoice(
 	if err != nil {
 		return err
 	}
+	if job.JobType == storage.JobTypeClassify && !agent.IsSchemaAgent(selected) {
+		return errors.New("classifier reruns require a SchemaAgent")
+	}
 	if err := agent.ValidateStructuredReviewSelection(job.ReviewType, selected); err != nil {
 		return err
 	}

--- a/cmd/roborev/tui/handlers_review.go
+++ b/cmd/roborev/tui/handlers_review.go
@@ -1,9 +1,7 @@
 package tui
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 	"time"
 	"unicode"
 
@@ -195,43 +193,8 @@ func (m model) handleRerunKey() (tea.Model, tea.Cmd) {
 			)
 			return m, nil
 		}
-		snap := rerunSnapshot{
-			jobID:         job.ID,
-			oldAgent:      job.Agent,
-			oldStatus:     job.Status,
-			oldStartedAt:  job.StartedAt,
-			oldFinishedAt: job.FinishedAt,
-			oldError:      job.Error,
-			oldClosed:     job.Closed,
-			oldVerdict:    job.Verdict,
-			// 'r' is allowed on a panel SYNTHESIS parent (only members
-			// are blocked above), and the daemon answers that with a
-			// whole new panel run rather than a new attempt of this job
-			// -- record it now, while the job is in hand.
-			spawnsNewRun: job.IsSynthesisJob(),
-		}
-		// The optimistic re-queue is correct ONLY when the daemon really
-		// will re-run THIS row. For a synthesis parent it will not
-		// (rerunPanelRun enqueues a separate run and leaves this row and
-		// its review untouched), so writing it here would be wrong the
-		// moment it is written, not merely wrong if the request fails --
-		// and not only cosmetically: a fake queued status makes
-		// panelInProgressFlash (handlers_queue.go) refuse to open the
-		// parent's still-current review on Enter, flashing "Panel still
-		// synthesizing" with counts from the run that already finished.
-		// Clearing Closed would also flip the row's visibility under
-		// hideClosed. See handleRerunResultMsg's spawnsNewRun branch.
-		if !snap.spawnsNewRun {
-			job.Status = storage.JobStatusQueued
-			job.StartedAt = nil
-			job.FinishedAt = nil
-			job.Error = ""
-			job.Closed = nil
-			job.Verdict = nil
-		} else {
-			m.markPanelRerunInFlight(job.ID)
-		}
-		return m, m.rerunJob(snap)
+		cmd := m.startRerun(job, "")
+		return m, cmd
 	}
 	return m, nil
 }
@@ -249,69 +212,30 @@ func rerunAgentEligible(job *storage.ReviewJob) bool {
 		job.Status == storage.JobStatusSkipped
 }
 
-func (m model) rerunAgentConfig(
-	job *storage.ReviewJob,
-) (*config.RepoConfig, *config.Config, error) {
+func (m model) availableRerunAgents(job *storage.ReviewJob) ([]string, error) {
 	repoPath := job.RepoPath
 	if job.WorktreePath != "" {
 		repoPath = job.WorktreePath
 	}
 	repoCfg, err := config.LoadRepoConfig(repoPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load repo config: %w", err)
-	}
-	globalCfg := m.globalCfg
-	if globalCfg == nil {
-		globalCfg = config.DefaultConfig()
-	}
-	return repoCfg, globalCfg, nil
-}
-
-func rerunAgentStorageName(
-	name string, repoCfg *config.RepoConfig, globalCfg *config.Config,
-) string {
-	return agent.StorageNameFromConfig(
-		agent.CanonicalName(name), repoCfg, globalCfg,
-	)
-}
-
-func validateRerunAgentChoice(
-	job *storage.ReviewJob,
-	name string,
-	repoCfg *config.RepoConfig,
-	globalCfg *config.Config,
-) error {
-	selected, err := agent.GetAvailableExactWithConfigFromConfig(
-		repoCfg, name, globalCfg,
-	)
-	if err != nil {
-		return err
-	}
-	if job.JobType == storage.JobTypeClassify && !agent.IsSchemaAgent(selected) {
-		return errors.New("classifier reruns require a SchemaAgent")
-	}
-	if err := agent.ValidateStructuredReviewSelection(job.ReviewType, selected); err != nil {
-		return err
-	}
-	if rerunAgentStorageName(name, repoCfg, globalCfg) ==
-		rerunAgentStorageName(job.Agent, repoCfg, globalCfg) {
-		return errors.New("selected agent is already assigned to this job")
-	}
-	return nil
-}
-
-func (m model) availableRerunAgents(job *storage.ReviewJob) ([]string, error) {
-	repoCfg, globalCfg, err := m.rerunAgentConfig(job)
-	if err != nil {
 		return nil, err
 	}
-	names := agent.AvailableNamesFromConfig(repoCfg, globalCfg)
-	available := make([]string, 0, len(names))
-	for _, name := range names {
-		if strings.TrimSpace(name) == "test" {
+	cfg := m.globalCfg
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	current := agent.StorageNameFromConfig(agent.CanonicalName(job.Agent), repoCfg, cfg)
+	var available []string
+	for _, name := range agent.AvailableNamesFromConfig(repoCfg, cfg) {
+		if name == "test" || agent.StorageNameFromConfig(agent.CanonicalName(name), repoCfg, cfg) == current {
 			continue
 		}
-		if validateRerunAgentChoice(job, name, repoCfg, globalCfg) == nil {
+		selected, err := agent.GetAvailableExactWithConfigFromConfig(repoCfg, name, cfg)
+		if err != nil || (job.JobType == storage.JobTypeClassify && !agent.IsSchemaAgent(selected)) {
+			continue
+		}
+		if agent.ValidateStructuredReviewSelection(job.ReviewType, selected) == nil {
 			available = append(available, name)
 		}
 	}
@@ -391,38 +315,9 @@ func (m model) submitRerunAgentChoice() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	selectedAgent := m.rerunAgentOptions[m.rerunAgentSelected]
-	repoCfg, globalCfg, err := m.rerunAgentConfig(job)
-	if err == nil {
-		err = validateRerunAgentChoice(job, selectedAgent, repoCfg, globalCfg)
-	}
-	if err != nil {
-		m.closeRerunAgentPicker()
-		m.setWarningFlash(
-			fmt.Sprintf("Agent is no longer available: %v", err),
-			4*time.Second, viewQueue,
-		)
-		return m, nil
-	}
-	snap := rerunSnapshot{
-		jobID:         job.ID,
-		agent:         selectedAgent,
-		oldAgent:      job.Agent,
-		oldStatus:     job.Status,
-		oldStartedAt:  job.StartedAt,
-		oldFinishedAt: job.FinishedAt,
-		oldError:      job.Error,
-		oldClosed:     job.Closed,
-		oldVerdict:    job.Verdict,
-	}
-	job.Agent = selectedAgent
-	job.Status = storage.JobStatusQueued
-	job.StartedAt = nil
-	job.FinishedAt = nil
-	job.Error = ""
-	job.Closed = nil
-	job.Verdict = nil
 	m.closeRerunAgentPicker()
-	return m, m.rerunJob(snap)
+	cmd := m.startRerun(job, selectedAgent)
+	return m, cmd
 }
 
 func (m model) handleLogKey2() (tea.Model, tea.Cmd) {

--- a/cmd/roborev/tui/helpers_test.go
+++ b/cmd/roborev/tui/helpers_test.go
@@ -559,6 +559,19 @@ func TestQueueHelpRowsTasksWorkflowToggle(t *testing.T) {
 	assert.False(t, !foundF || !foundT)
 }
 
+func TestQueueHelpRowsDistinguishesRerunActions(t *testing.T) {
+	rows := newModel(testEndpoint, withExternalIODisabled()).queueHelpRows()
+	labels := make(map[string]string)
+	for _, row := range rows {
+		for _, item := range row {
+			labels[item.key] = item.desc
+		}
+	}
+
+	assert.Equal(t, "rerun", labels["r"])
+	assert.Equal(t, "rerun new agent", labels["R"])
+}
+
 func TestHelpLinesShowDisabledTasksShortcuts(t *testing.T) {
 	disabled := strings.Join(helpLines(false, false), "\n")
 	assert.Contains(t, stripTestANSI(disabled), "Trigger fix for selected review (disabled)")

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -3321,18 +3321,22 @@ func TestExpandHintOnlyWhenParentSelected(t *testing.T) {
 // TestQueueHelpLinesAccountForExpandHint proves the help-height reservation
 // (queueHelpLines) counts the same rows renderQueueView draws: the base rows
 // when a non-parent is selected, and the rows plus the "space — expand" hint
-// when a panel parent is selected. width=110 is chosen because the hint reflows
-// the help onto one more line there (base 2 lines vs hinted 3) — the case the
-// off-by-one bug bit; width=120 (the seeded default) is the no-reflow case where
-// the two counts coincide.
+// when a panel parent is selected. Cover widths with and without an extra
+// reflow line so adding a shortcut does not invalidate the test's fixture.
 func TestQueueHelpLinesAccountForExpandHint(t *testing.T) {
-	for _, w := range []int{110, 120} {
+	var extraLineWidths, sameHeightWidths int
+	for w := 80; w <= 160; w++ {
 		t.Run(fmt.Sprintf("width=%d", w), func(t *testing.T) {
 			m := seededPanelModel(t) // jobs = [20 standalone, 10 parent]
 			m.width = w
 
 			base := len(reflowHelpRows(m.queueHelpRows(), w))
 			hinted := len(reflowHelpRows(withExpandHint(m.queueHelpRows()), w))
+			if hinted > base {
+				extraLineWidths++
+			} else if hinted == base {
+				sameHeightWidths++
+			}
 
 			// Non-parent selected: reservation must equal the base help height.
 			m.selectedJobID, m.selectedIdx = 20, 0
@@ -3347,13 +3351,8 @@ func TestQueueHelpLinesAccountForExpandHint(t *testing.T) {
 		})
 	}
 
-	// At width=110 the hint genuinely costs an extra reflowed line, so the two
-	// reservations differ — this is the regression the fix addresses.
-	m := seededPanelModel(t)
-	m.width = 110
-	assert.Less(t, len(reflowHelpRows(m.queueHelpRows(), 110)),
-		len(reflowHelpRows(withExpandHint(m.queueHelpRows()), 110)),
-		"width=110 must be a width where the expand hint adds a reflow line")
+	assert.Positive(t, extraLineWidths, "exercise widths where the expand hint adds a line")
+	assert.Positive(t, sameHeightWidths, "exercise widths where the expand hint fits")
 }
 
 func TestEnterOnInProgressParentFlashesProgress(t *testing.T) {

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -110,6 +110,7 @@ func (m model) queueHelpRows() [][]helpItem {
 	row1 := []helpItem{
 		{"x", "cancel"},
 		{"r", "rerun"},
+		{"R", "rerun agent"},
 		{"l", "log"},
 		{"p", "prompt"},
 		{"c", "comment"},
@@ -146,6 +147,35 @@ func (m model) queueHelpRows() [][]helpItem {
 		row2 = append(row2, helpItem{"q", "quit"})
 	}
 	return [][]helpItem{row1, row2}
+}
+
+func (m model) renderRerunAgentView() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s\x1b[K\n\x1b[K\n",
+		titleStyle.Render(fmt.Sprintf("Rerun job #%d with agent", m.rerunAgentJobID)))
+	visibleRows := max(m.height-5, 0)
+	start := 0
+	if m.rerunAgentSelected >= visibleRows && visibleRows > 0 {
+		start = m.rerunAgentSelected - visibleRows + 1
+	}
+	end := min(start+visibleRows, len(m.rerunAgentOptions))
+	for i := start; i < end; i++ {
+		line := "  " + sanitizeForDisplay(m.rerunAgentOptions[i])
+		if i == m.rerunAgentSelected {
+			line = selectedStyle.Render("> " + sanitizeForDisplay(m.rerunAgentOptions[i]))
+		}
+		b.WriteString(line)
+		b.WriteString("\x1b[K\n")
+	}
+	for i := end - start; i < visibleRows; i++ {
+		b.WriteString("\x1b[K\n")
+	}
+	b.WriteString(renderHelpTable([][]helpItem{{
+		{"Up/Down", "navigate"}, {"Enter", "rerun"}, {"Esc", "cancel"},
+	}}, m.width))
+	b.WriteString("\x1b[K\x1b[J")
+	return b.String()
 }
 
 // selectedRowHasChildren reports whether the currently selected visible row is

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -110,7 +110,7 @@ func (m model) queueHelpRows() [][]helpItem {
 	row1 := []helpItem{
 		{"x", "cancel"},
 		{"r", "rerun"},
-		{"R", "rerun agent"},
+		{"R", "rerun new agent"},
 		{"l", "log"},
 		{"p", "prompt"},
 		{"c", "comment"},

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -7296,13 +7296,11 @@ func TestRerunAgentPickerTransitionsAndOptions(t *testing.T) {
 	require.Nil(t, cmd)
 	require.Equal(t, viewRerunAgent, got.currentView)
 	assert.Equal(t, int64(42), got.rerunAgentJobID)
-	assert.True(t, slices.IsSorted(got.rerunAgentOptions))
 	assert.Contains(t, got.rerunAgentOptions, "picker-alpha")
 	assert.Contains(t, got.rerunAgentOptions, "picker-zeta")
 	assert.NotContains(t, got.rerunAgentOptions, "picker-current")
 	assert.NotContains(t, got.rerunAgentOptions, "test")
 	assert.NotContains(t, got.rerunAgentOptions, "acp.picker-unavailable")
-	assert.Contains(t, got.renderRerunAgentView(), "Rerun job #42 with agent")
 
 	start := got.rerunAgentSelected
 	res, _ = got.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyDown})
@@ -7330,82 +7328,32 @@ func TestRerunAgentPickerFiltersNonSchemaClassifierAgents(t *testing.T) {
 	assert.NotContains(t, got.rerunAgentOptions, "picker-non-schema")
 }
 
-func TestRerunAgentPickerRejectsIneligibleRows(t *testing.T) {
-	registerRerunPickerAgent(t, "picker-ineligible-alternate")
-	tests := []struct {
-		name string
-		job  *storage.ReviewJob
+func TestRerunAgentPickerEligibility(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-alternate")
+	for _, tt := range []struct {
+		name     string
+		job      storage.ReviewJob
+		wantView viewKind
 	}{
-		{
-			name: "panel member",
-			job: &storage.ReviewJob{
-				ID: 1, Agent: "test", Status: storage.JobStatusDone,
-				PanelRole: storage.PanelRoleMember, RepoPath: t.TempDir(),
-			},
-		},
-		{
-			name: "synthesis parent",
-			job: &storage.ReviewJob{
-				ID: 2, Agent: "test", Status: storage.JobStatusDone,
-				PanelRole: storage.PanelRoleSynthesis, RepoPath: t.TempDir(),
-			},
-		},
-		{
-			name: "running",
-			job: &storage.ReviewJob{
-				ID: 3, Agent: "test", Status: storage.JobStatusRunning,
-				RepoPath: t.TempDir(),
-			},
-		},
-		{
-			name: "canceled worker still stopping",
-			job: &storage.ReviewJob{
-				ID: 4, Agent: "test", Status: storage.JobStatusCanceled,
-				WorkerID: "worker", RepoPath: t.TempDir(),
-			},
-		},
-		{
-			name: "experiment attributed",
-			job: &storage.ReviewJob{
-				ID: 5, Agent: "test", Status: storage.JobStatusDone,
-				RepoPath:    t.TempDir(),
-				Experiments: []storage.ExperimentAssignment{{ID: "experiment"}},
-			},
-		},
-	}
-	for _, tt := range tests {
+		{name: "done", job: storage.ReviewJob{Status: storage.JobStatusDone}, wantView: viewRerunAgent},
+		{name: "failed", job: storage.ReviewJob{Status: storage.JobStatusFailed}, wantView: viewRerunAgent},
+		{name: "skipped", job: storage.ReviewJob{Status: storage.JobStatusSkipped}, wantView: viewRerunAgent},
+		{name: "canceled", job: storage.ReviewJob{Status: storage.JobStatusCanceled}, wantView: viewRerunAgent},
+		{name: "member", job: storage.ReviewJob{Status: storage.JobStatusDone, PanelRole: storage.PanelRoleMember}},
+		{name: "synthesis", job: storage.ReviewJob{Status: storage.JobStatusDone, PanelRole: storage.PanelRoleSynthesis}},
+		{name: "running", job: storage.ReviewJob{Status: storage.JobStatusRunning}},
+		{name: "stopping", job: storage.ReviewJob{Status: storage.JobStatusCanceled, WorkerID: "worker"}},
+		{name: "experiment", job: storage.ReviewJob{Status: storage.JobStatusDone, Experiments: []storage.ExperimentAssignment{{ID: "experiment"}}}},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			m := initTestModel(
-				withCurrentView(viewQueue), withTestJobs(*tt.job),
-				withSelection(0, tt.job.ID),
-			)
-			m.globalCfg = config.DefaultConfig()
+			m := rerunPickerModel(t, rerunOKHandler)
+			tt.job.ID, tt.job.RepoPath = m.jobs[0].ID, m.jobs[0].RepoPath
+			m.jobs[0] = tt.job
 			res, cmd := m.handleRerunAgentKey()
-			got := res.(model)
 			assert.Nil(t, cmd)
-			assert.Equal(t, viewQueue, got.currentView)
-			assert.Empty(t, got.rerunAgentOptions)
+			assert.Equal(t, tt.wantView, res.(model).currentView)
 		})
 	}
-}
-
-func TestRerunAgentPickerAcceptsSkippedRows(t *testing.T) {
-	registerRerunPickerAgent(t, "picker-skipped-alternate")
-	m := initTestModel(
-		withCurrentView(viewQueue),
-		withTestJobs(storage.ReviewJob{
-			ID: 6, Agent: "test", Status: storage.JobStatusSkipped,
-			RepoPath: t.TempDir(),
-		}),
-		withSelection(0, 6),
-	)
-	m.globalCfg = config.DefaultConfig()
-
-	res, cmd := m.handleRerunAgentKey()
-	got := res.(model)
-	assert.Nil(t, cmd)
-	assert.Equal(t, viewRerunAgent, got.currentView)
-	assert.Contains(t, got.rerunAgentOptions, "picker-skipped-alternate")
 }
 
 func TestRerunAgentPickerRechecksJobBeforeEnter(t *testing.T) {
@@ -7425,62 +7373,49 @@ func TestRerunAgentPickerRechecksJobBeforeEnter(t *testing.T) {
 	assert.Equal(t, "picker-current", got.jobs[0].Agent)
 }
 
-func TestRerunAgentPickerSubmitsSelectedAgent(t *testing.T) {
+func TestRerunAgentPickerSubmission(t *testing.T) {
 	registerRerunPickerAgent(t, "picker-current")
 	registerRerunPickerAgent(t, "picker-selected")
-	var request struct {
-		JobID int64  `json:"job_id"`
-		Agent string `json:"agent"`
+	for _, tt := range []struct {
+		status     int
+		wantAgent  string
+		wantStatus storage.JobStatus
+	}{
+		{http.StatusOK, "picker-selected", storage.JobStatusQueued},
+		{http.StatusBadRequest, "picker-current", storage.JobStatusDone},
+	} {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			var request struct {
+				JobID int64  `json:"job_id"`
+				Agent string `json:"agent"`
+			}
+			m := rerunPickerModel(t, func(w http.ResponseWriter, r *http.Request) {
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+				if tt.status == http.StatusBadRequest {
+					http.Error(w, "agent unavailable", tt.status)
+					return
+				}
+				rerunOKHandler(w, r)
+			})
+			res, _ := m.handleRerunAgentKey()
+			m = res.(model)
+			m.rerunAgentSelected = slices.Index(m.rerunAgentOptions, "picker-selected")
+			require.GreaterOrEqual(t, m.rerunAgentSelected, 0)
+			res, cmd := m.handleRerunAgentPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+			m = res.(model)
+			require.NotNil(t, cmd)
+			assert.Equal(t, viewQueue, m.currentView)
+			assert.Equal(t, storage.JobStatusQueued, m.jobs[0].Status)
+			assert.Equal(t, "picker-selected", m.jobs[0].Agent)
+
+			res, _ = m.Update(cmd())
+			m = res.(model)
+			assert.Equal(t, int64(42), request.JobID)
+			assert.Equal(t, "picker-selected", request.Agent)
+			assert.Equal(t, tt.wantAgent, m.jobs[0].Agent)
+			assert.Equal(t, tt.wantStatus, m.jobs[0].Status)
+		})
 	}
-	m := rerunPickerModel(t, func(w http.ResponseWriter, r *http.Request) {
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&request))
-		rerunOKHandler(w, r)
-	})
-
-	res, _ := m.handleRerunAgentKey()
-	m = res.(model)
-	m.rerunAgentSelected = slices.Index(m.rerunAgentOptions, "picker-selected")
-	require.GreaterOrEqual(t, m.rerunAgentSelected, 0)
-	res, cmd := m.handleRerunAgentPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
-	optimistic := res.(model)
-	require.NotNil(t, cmd)
-	assert.Equal(t, viewQueue, optimistic.currentView)
-	assert.Equal(t, storage.JobStatusQueued, optimistic.jobs[0].Status)
-	assert.Equal(t, "picker-selected", optimistic.jobs[0].Agent)
-
-	msg, ok := cmd().(rerunResultMsg)
-	require.True(t, ok)
-	require.NoError(t, msg.err)
-	assert.Equal(t, int64(42), request.JobID)
-	assert.Equal(t, "picker-selected", request.Agent)
-	assert.Equal(t, "picker-selected", msg.agent)
-	res, _ = optimistic.handleRerunResultMsg(msg)
-	assert.Equal(t, "picker-selected", res.(model).jobs[0].Agent)
-}
-
-func TestRerunAgentPickerRollsBackFailedOptimisticRequest(t *testing.T) {
-	registerRerunPickerAgent(t, "picker-current")
-	registerRerunPickerAgent(t, "picker-rejected")
-	m := rerunPickerModel(t, func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "agent unavailable", http.StatusBadRequest)
-	})
-
-	res, _ := m.handleRerunAgentKey()
-	m = res.(model)
-	m.rerunAgentSelected = slices.Index(m.rerunAgentOptions, "picker-rejected")
-	require.GreaterOrEqual(t, m.rerunAgentSelected, 0)
-	res, cmd := m.handleRerunAgentPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
-	optimistic := res.(model)
-	require.NotNil(t, cmd)
-	assert.Equal(t, "picker-rejected", optimistic.jobs[0].Agent)
-
-	msg, ok := cmd().(rerunResultMsg)
-	require.True(t, ok)
-	require.Error(t, msg.err)
-	res, _ = optimistic.handleRerunResultMsg(msg)
-	rolledBack := res.(model)
-	assert.Equal(t, "picker-current", rolledBack.jobs[0].Agent)
-	assert.Equal(t, storage.JobStatusDone, rolledBack.jobs[0].Status)
 }
 
 func TestDefaultAndControlRerunsOmitAgent(t *testing.T) {

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -7249,6 +7251,24 @@ func registerRerunPickerAgent(t *testing.T, name string) {
 	t.Cleanup(func() { agent.Unregister(name) })
 }
 
+type rerunPickerSchemaAgent struct {
+	*agent.FakeAgent
+}
+
+func (a *rerunPickerSchemaAgent) ClassifyWithSchema(
+	context.Context, string, string, string, json.RawMessage, io.Writer,
+) (json.RawMessage, error) {
+	return nil, nil
+}
+
+func registerRerunPickerSchemaAgent(t *testing.T, name string) {
+	t.Helper()
+	agent.Register(&rerunPickerSchemaAgent{
+		FakeAgent: &agent.FakeAgent{NameStr: name},
+	})
+	t.Cleanup(func() { agent.Unregister(name) })
+}
+
 func rerunPickerModel(t *testing.T, handler http.HandlerFunc) model {
 	t.Helper()
 	_, m := mockServerModel(t, handler)
@@ -7292,6 +7312,22 @@ func TestRerunAgentPickerTransitionsAndOptions(t *testing.T) {
 	got = res.(model)
 	assert.Equal(t, viewQueue, got.currentView)
 	assert.Empty(t, got.rerunAgentOptions)
+}
+
+func TestRerunAgentPickerFiltersNonSchemaClassifierAgents(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-current")
+	registerRerunPickerAgent(t, "picker-non-schema")
+	registerRerunPickerSchemaAgent(t, "picker-schema")
+	m := rerunPickerModel(t, rerunOKHandler)
+	m.jobs[0].JobType = storage.JobTypeClassify
+	m.jobs[0].ReviewType = "design"
+
+	res, cmd := m.handleRerunAgentKey()
+	got := res.(model)
+	assert.Nil(t, cmd)
+	assert.Equal(t, viewRerunAgent, got.currentView)
+	assert.Contains(t, got.rerunAgentOptions, "picker-schema")
+	assert.NotContains(t, got.rerunAgentOptions, "picker-non-schema")
 }
 
 func TestRerunAgentPickerRejectsIneligibleRows(t *testing.T) {

--- a/cmd/roborev/tui/split_test.go
+++ b/cmd/roborev/tui/split_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
 )
 
@@ -7238,6 +7241,236 @@ func TestRerunKeyStillShowsOptimisticQueueForOrdinaryJobs(t *testing.T) {
 	assert.Nil(got.jobs[1].Verdict, "and still clears the stale verdict")
 	assert.Nil(got.jobs[1].Closed)
 	assert.Nil(got.jobs[1].FinishedAt)
+}
+
+func registerRerunPickerAgent(t *testing.T, name string) {
+	t.Helper()
+	agent.Register(&agent.FakeAgent{NameStr: name})
+	t.Cleanup(func() { agent.Unregister(name) })
+}
+
+func rerunPickerModel(t *testing.T, handler http.HandlerFunc) model {
+	t.Helper()
+	_, m := mockServerModel(t, handler)
+	m.currentView = viewQueue
+	m.globalCfg = config.DefaultConfig()
+	m.jobs = []storage.ReviewJob{{
+		ID: 42, Agent: "picker-current", Status: storage.JobStatusDone,
+		RepoPath: t.TempDir(),
+	}}
+	m.selectedIdx, m.selectedJobID = 0, 42
+	return m
+}
+
+func TestRerunAgentPickerTransitionsAndOptions(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-current")
+	registerRerunPickerAgent(t, "picker-alpha")
+	registerRerunPickerAgent(t, "picker-zeta")
+	m := rerunPickerModel(t, rerunOKHandler)
+	m.globalCfg.ACP = config.ACPAgentConfigs{
+		"picker-unavailable": {Command: "roborev-command-that-does-not-exist"},
+	}
+
+	res, cmd := m.handleKeyMsg(keyPressMsg('R'))
+	got := res.(model)
+	require.Nil(t, cmd)
+	require.Equal(t, viewRerunAgent, got.currentView)
+	assert.Equal(t, int64(42), got.rerunAgentJobID)
+	assert.True(t, slices.IsSorted(got.rerunAgentOptions))
+	assert.Contains(t, got.rerunAgentOptions, "picker-alpha")
+	assert.Contains(t, got.rerunAgentOptions, "picker-zeta")
+	assert.NotContains(t, got.rerunAgentOptions, "picker-current")
+	assert.NotContains(t, got.rerunAgentOptions, "test")
+	assert.NotContains(t, got.rerunAgentOptions, "acp.picker-unavailable")
+	assert.Contains(t, got.renderRerunAgentView(), "Rerun job #42 with agent")
+
+	start := got.rerunAgentSelected
+	res, _ = got.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	got = res.(model)
+	assert.Equal(t, start+1, got.rerunAgentSelected)
+	res, _ = got.handleKeyMsg(tea.KeyPressMsg{Code: tea.KeyEscape})
+	got = res.(model)
+	assert.Equal(t, viewQueue, got.currentView)
+	assert.Empty(t, got.rerunAgentOptions)
+}
+
+func TestRerunAgentPickerRejectsIneligibleRows(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-ineligible-alternate")
+	tests := []struct {
+		name string
+		job  *storage.ReviewJob
+	}{
+		{
+			name: "panel member",
+			job: &storage.ReviewJob{
+				ID: 1, Agent: "test", Status: storage.JobStatusDone,
+				PanelRole: storage.PanelRoleMember, RepoPath: t.TempDir(),
+			},
+		},
+		{
+			name: "synthesis parent",
+			job: &storage.ReviewJob{
+				ID: 2, Agent: "test", Status: storage.JobStatusDone,
+				PanelRole: storage.PanelRoleSynthesis, RepoPath: t.TempDir(),
+			},
+		},
+		{
+			name: "running",
+			job: &storage.ReviewJob{
+				ID: 3, Agent: "test", Status: storage.JobStatusRunning,
+				RepoPath: t.TempDir(),
+			},
+		},
+		{
+			name: "canceled worker still stopping",
+			job: &storage.ReviewJob{
+				ID: 4, Agent: "test", Status: storage.JobStatusCanceled,
+				WorkerID: "worker", RepoPath: t.TempDir(),
+			},
+		},
+		{
+			name: "experiment attributed",
+			job: &storage.ReviewJob{
+				ID: 5, Agent: "test", Status: storage.JobStatusDone,
+				RepoPath:    t.TempDir(),
+				Experiments: []storage.ExperimentAssignment{{ID: "experiment"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := initTestModel(
+				withCurrentView(viewQueue), withTestJobs(*tt.job),
+				withSelection(0, tt.job.ID),
+			)
+			m.globalCfg = config.DefaultConfig()
+			res, cmd := m.handleRerunAgentKey()
+			got := res.(model)
+			assert.Nil(t, cmd)
+			assert.Equal(t, viewQueue, got.currentView)
+			assert.Empty(t, got.rerunAgentOptions)
+		})
+	}
+}
+
+func TestRerunAgentPickerAcceptsSkippedRows(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-skipped-alternate")
+	m := initTestModel(
+		withCurrentView(viewQueue),
+		withTestJobs(storage.ReviewJob{
+			ID: 6, Agent: "test", Status: storage.JobStatusSkipped,
+			RepoPath: t.TempDir(),
+		}),
+		withSelection(0, 6),
+	)
+	m.globalCfg = config.DefaultConfig()
+
+	res, cmd := m.handleRerunAgentKey()
+	got := res.(model)
+	assert.Nil(t, cmd)
+	assert.Equal(t, viewRerunAgent, got.currentView)
+	assert.Contains(t, got.rerunAgentOptions, "picker-skipped-alternate")
+}
+
+func TestRerunAgentPickerRechecksJobBeforeEnter(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-current")
+	registerRerunPickerAgent(t, "picker-recheck")
+	m := rerunPickerModel(t, rerunOKHandler)
+	res, _ := m.handleRerunAgentKey()
+	m = res.(model)
+	require.Equal(t, viewRerunAgent, m.currentView)
+	m.jobs[0].Status = storage.JobStatusRunning
+
+	res, cmd := m.handleRerunAgentPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	got := res.(model)
+	assert.Nil(t, cmd)
+	assert.Equal(t, viewQueue, got.currentView)
+	assert.Contains(t, got.flashMessage, "no longer eligible")
+	assert.Equal(t, "picker-current", got.jobs[0].Agent)
+}
+
+func TestRerunAgentPickerSubmitsSelectedAgent(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-current")
+	registerRerunPickerAgent(t, "picker-selected")
+	var request struct {
+		JobID int64  `json:"job_id"`
+		Agent string `json:"agent"`
+	}
+	m := rerunPickerModel(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		rerunOKHandler(w, r)
+	})
+
+	res, _ := m.handleRerunAgentKey()
+	m = res.(model)
+	m.rerunAgentSelected = slices.Index(m.rerunAgentOptions, "picker-selected")
+	require.GreaterOrEqual(t, m.rerunAgentSelected, 0)
+	res, cmd := m.handleRerunAgentPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	optimistic := res.(model)
+	require.NotNil(t, cmd)
+	assert.Equal(t, viewQueue, optimistic.currentView)
+	assert.Equal(t, storage.JobStatusQueued, optimistic.jobs[0].Status)
+	assert.Equal(t, "picker-selected", optimistic.jobs[0].Agent)
+
+	msg, ok := cmd().(rerunResultMsg)
+	require.True(t, ok)
+	require.NoError(t, msg.err)
+	assert.Equal(t, int64(42), request.JobID)
+	assert.Equal(t, "picker-selected", request.Agent)
+	assert.Equal(t, "picker-selected", msg.agent)
+	res, _ = optimistic.handleRerunResultMsg(msg)
+	assert.Equal(t, "picker-selected", res.(model).jobs[0].Agent)
+}
+
+func TestRerunAgentPickerRollsBackFailedOptimisticRequest(t *testing.T) {
+	registerRerunPickerAgent(t, "picker-current")
+	registerRerunPickerAgent(t, "picker-rejected")
+	m := rerunPickerModel(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "agent unavailable", http.StatusBadRequest)
+	})
+
+	res, _ := m.handleRerunAgentKey()
+	m = res.(model)
+	m.rerunAgentSelected = slices.Index(m.rerunAgentOptions, "picker-rejected")
+	require.GreaterOrEqual(t, m.rerunAgentSelected, 0)
+	res, cmd := m.handleRerunAgentPickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	optimistic := res.(model)
+	require.NotNil(t, cmd)
+	assert.Equal(t, "picker-rejected", optimistic.jobs[0].Agent)
+
+	msg, ok := cmd().(rerunResultMsg)
+	require.True(t, ok)
+	require.Error(t, msg.err)
+	res, _ = optimistic.handleRerunResultMsg(msg)
+	rolledBack := res.(model)
+	assert.Equal(t, "picker-current", rolledBack.jobs[0].Agent)
+	assert.Equal(t, storage.JobStatusDone, rolledBack.jobs[0].Status)
+}
+
+func TestDefaultAndControlRerunsOmitAgent(t *testing.T) {
+	var requests []map[string]any
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		requests = append(requests, body)
+		rerunOKHandler(w, r)
+	}
+
+	m := rerunPickerModel(t, handler)
+	_, cmd := m.handleRerunKey()
+	require.NotNil(t, cmd)
+	require.IsType(t, rerunResultMsg{}, cmd())
+
+	m = rerunPickerModel(t, handler)
+	_, response, cmd := m.handleCtrlRerunJob(json.RawMessage(`{"job_id":42}`))
+	require.True(t, response.OK)
+	require.NotNil(t, cmd)
+	require.IsType(t, rerunResultMsg{}, cmd())
+
+	require.Len(t, requests, 2)
+	for _, request := range requests {
+		assert.NotContains(t, request, "agent")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -273,6 +273,9 @@ type model struct {
 	expandedPanels       map[uuid.UUID]bool                // panel_run_uuid -> expanded
 	panelMembers         map[uuid.UUID][]storage.ReviewJob // panel_run_uuid -> side-fetched members
 	currentView          viewKind
+	rerunAgentJobID      int64
+	rerunAgentOptions    []string
+	rerunAgentSelected   int
 	currentReview        *storage.Review
 	currentResponses     []storage.Response // Responses for current review (fetched with review)
 	currentBranch        string             // Cached branch name for current review (computed on load)
@@ -1389,6 +1392,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) viewContent() string {
+	if m.currentView == viewRerunAgent {
+		return m.renderRerunAgentView()
+	}
 	if m.currentView == viewReleaseNotes {
 		return m.renderReleaseNotesView()
 	}

--- a/cmd/roborev/tui/types.go
+++ b/cmd/roborev/tui/types.go
@@ -31,6 +31,7 @@ const (
 	viewPatch               // Patch viewer for fix jobs
 	viewColumnOptions       // Column toggle modal
 	viewReleaseNotes        // Recent Roborev release notes
+	viewRerunAgent          // Agent picker for an ordinary job rerun
 )
 
 // queuePrefetchBuffer is the number of extra rows to fetch beyond what's visible,
@@ -326,6 +327,8 @@ type pauseResultMsg struct {
 }
 type rerunResultMsg struct {
 	jobID         int64
+	agent         string
+	oldAgent      string
 	oldState      storage.JobStatus
 	oldStartedAt  *time.Time
 	oldFinishedAt *time.Time

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -71,6 +71,11 @@ branch.
 | `Ctrl-D` | Quit |
 | `q` | Quit |
 
+Choosing another agent with `R` uses its configured model and provider defaults
+instead of the original request's explicit overrides. The job keeps the original
+request for reference. The rerun reuses the job and replaces its previous
+review.
+
 Panel reviews appear as one synthesis parent row by default. The parent row
 shows live progress while member reviewers run and a compact member summary
 after completion. Expand the row to inspect individual member jobs. Close,

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -53,7 +53,8 @@ branch.
 | `c` | Add comment |
 | `y` | Copy review to clipboard |
 | `x` | Cancel running/queued job |
-| `r` | Rerun completed/failed/canceled job |
+| `r` | Rerun completed/failed/canceled job with its stored agent |
+| `R` | Choose another available agent, then rerun an ordinary terminal job |
 | `F` | Launch fix job (requires [`advanced.tasks_enabled`](/docs/advanced/background-tasks/)) |
 | `T` | Switch to Tasks view (requires [`advanced.tasks_enabled`](/docs/advanced/background-tasks/)) |
 | `o` | Column options (reorder, toggle visibility) |
@@ -74,6 +75,9 @@ Panel reviews appear as one synthesis parent row by default. The parent row
 shows live progress while member reviewers run and a compact member summary
 after completion. Expand the row to inspect individual member jobs. Close,
 cancel, rerun, or fix the panel from the parent row, not from a member row.
+Panel reruns keep their configured members, so use `r` on the synthesis parent.
+The alternate-agent picker does not open for panel rows or experiment-attributed
+jobs.
 
 When a newer Roborev version is available, the queue banner points to the
 release-notes viewer. Press `u` at any time to open it. The viewer renders the
@@ -283,7 +287,7 @@ Press `Enter` on a job to view its review.
 | `c` | Add comment |
 | `y` | Copy review to clipboard |
 | `x` | Cancel running/queued job |
-| `r` | Rerun completed/failed/canceled job |
+| `r` | Rerun completed/failed/canceled job with its stored agent |
 | `F` | Open inline fix panel (requires [`advanced.tasks_enabled`](/docs/advanced/background-tasks/)) |
 | `l` | View job log |
 | `p` | Switch between review/prompt |
@@ -480,7 +484,7 @@ read this file to discover running TUI instances.
 | `set-view` | Switch between `queue` and `tasks` views |
 | `close-review` | Toggle closed state for a job |
 | `cancel-job` | Cancel a running or queued job |
-| `rerun-job` | Rerun a completed, failed, or canceled job |
+| `rerun-job` | Rerun a completed, failed, or canceled job with its stored agent |
 | `quit` | Terminate the TUI (works even with `--no-quit`) |
 
 ### Protocol
@@ -492,6 +496,9 @@ Send a request as a single JSON line:
 {"command": "set-filter", "params": {"repo": "myrepo", "branch": "main"}}
 {"command": "close-review", "params": {"job_id": 42}}
 ```
+
+The control socket's `rerun-job` command does not accept an agent override. It
+uses the same default rerun path as lowercase `r`.
 
 Responses include an `ok` field, optional `error`, and optional `data`:
 

--- a/internal/daemon/rerun_panel_test.go
+++ b/internal/daemon/rerun_panel_test.go
@@ -101,6 +101,24 @@ func TestRerunSynthesisRejectsNonTerminal(t *testing.T) {
 	assert.NotEmpty(t, runUUID)
 }
 
+func TestRerunPanelRejectsSelectedAgent(t *testing.T) {
+	server, db, _ := newTestServer(t)
+	runUUID, _, synth := enqueueServerPanelRun(t, db, 2)
+	markPanelMembersStatus(t, db, runUUID, storage.JobStatusDone)
+	markJobStatus(t, db, synth.ID, storage.JobStatusDone)
+
+	_, err := server.humaRerunJob(context.Background(), &RerunJobInput{
+		Body: RerunJobRequest{JobID: synth.ID, Agent: "test"},
+	})
+	require.ErrorContains(t, err, "panel synthesis jobs cannot change agents")
+
+	var count int
+	require.NoError(t, db.QueryRow(
+		"SELECT COUNT(DISTINCT panel_run_uuid) FROM review_jobs WHERE panel_run_uuid != ''",
+	).Scan(&count))
+	assert.Equal(t, 1, count)
+}
+
 func TestRerunPanelRejectsMemberStillStopping(t *testing.T) {
 	server, db, _ := newTestServer(t)
 	runUUID, members, synth := enqueueServerPanelRun(t, db, 2)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -968,9 +968,8 @@ func resolveRerunOpts(
 			model = config.ResolveClassifyModel("", resolutionPath, cfg)
 		}
 		return storage.ReenqueueOpts{
-			Agent:        storageName,
-			Model:        model,
-			ReplaceAgent: true,
+			Agent: storageName,
+			Model: model,
 		}, nil
 	}
 
@@ -2360,11 +2359,6 @@ func (s *Server) humaRerunJob(
 			fmt.Sprintf("load experiment assignment: %v", err),
 		)
 	}
-	if selectedAgent != "" && assignment != nil {
-		return nil, huma.Error400BadRequest(
-			"frozen experiment jobs cannot change agents on rerun",
-		)
-	}
 	rerunOpts, err := resolveRerunOpts(
 		job, s.configWatcher.Config(), assignment, selectedAgent,
 	)
@@ -2386,7 +2380,7 @@ func (s *Server) humaRerunJob(
 		)
 	}
 	if !replayed {
-		if rerunOpts.ReplaceAgent {
+		if selectedAgent != "" {
 			job.Agent = rerunOpts.Agent
 		}
 		s.broadcastRerunEnqueued(resultJobID, job.UUID, job)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -961,19 +961,15 @@ func resolveRerunOpts(
 		storageName := agent.StorageNameFromConfig(
 			agent.CanonicalName(selectedAgent), resolution.RepoConfig, cfg,
 		)
-		model := resolution.ModelForSelectedAgent(
-			storageName, strings.TrimSpace(job.RequestedModel),
-		)
+		// Keep the original request as provenance, but do not carry its
+		// model or provider override into a different agent's execution.
+		model := resolution.ModelForSelectedAgent(storageName, "")
 		if job.JobType == storage.JobTypeClassify {
 			model = config.ResolveClassifyModel("", resolutionPath, cfg)
-			if requestedModel := strings.TrimSpace(job.RequestedModel); requestedModel != "" {
-				model = requestedModel
-			}
 		}
 		return storage.ReenqueueOpts{
 			Agent:        storageName,
 			Model:        model,
-			Provider:     strings.TrimSpace(job.RequestedProvider),
 			ReplaceAgent: true,
 		}, nil
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -950,17 +950,29 @@ func resolveRerunOpts(
 				"resolve selected agent %q: %w", selectedAgent, err,
 			)
 		}
+		if job.JobType == storage.JobTypeClassify && !agent.IsSchemaAgent(selected) {
+			return storage.ReenqueueOpts{}, fmt.Errorf(
+				"classifier reruns require a SchemaAgent, got %q", selectedAgent,
+			)
+		}
 		if err := agent.ValidateStructuredReviewSelection(job.ReviewType, selected); err != nil {
 			return storage.ReenqueueOpts{}, err
 		}
 		storageName := agent.StorageNameFromConfig(
 			agent.CanonicalName(selectedAgent), resolution.RepoConfig, cfg,
 		)
+		model := resolution.ModelForSelectedAgent(
+			storageName, strings.TrimSpace(job.RequestedModel),
+		)
+		if job.JobType == storage.JobTypeClassify {
+			model = config.ResolveClassifyModel("", resolutionPath, cfg)
+			if requestedModel := strings.TrimSpace(job.RequestedModel); requestedModel != "" {
+				model = requestedModel
+			}
+		}
 		return storage.ReenqueueOpts{
-			Agent: storageName,
-			Model: resolution.ModelForSelectedAgent(
-				storageName, strings.TrimSpace(job.RequestedModel),
-			),
+			Agent:        storageName,
+			Model:        model,
 			Provider:     strings.TrimSpace(job.RequestedProvider),
 			ReplaceAgent: true,
 		}, nil

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -891,6 +891,7 @@ func resolveRerunOpts(
 	job *storage.ReviewJob,
 	cfg *config.Config,
 	assignment *storage.ExperimentAssignmentInput,
+	selectedAgent string,
 ) (storage.ReenqueueOpts, error) {
 	resolutionPath := job.RepoPath
 	if job.WorktreePath != "" {
@@ -905,6 +906,9 @@ func resolveRerunOpts(
 		return storage.ReenqueueOpts{}, fmt.Errorf("resolve workflow config: %w", err)
 	}
 	if assignment != nil {
+		if strings.TrimSpace(selectedAgent) != "" {
+			return storage.ReenqueueOpts{}, errors.New("frozen experiment jobs cannot change agents on rerun")
+		}
 		var plan experimentJobPlan
 		if err := json.Unmarshal([]byte(assignment.EffectiveConfigJSON), &plan); err != nil {
 			return storage.ReenqueueOpts{}, fmt.Errorf("decode frozen experiment plan: %w", err)
@@ -936,6 +940,31 @@ func resolveRerunOpts(
 	if err != nil {
 		return storage.ReenqueueOpts{}, fmt.Errorf("resolve workflow config: %w", err)
 	}
+	selectedAgent = strings.TrimSpace(selectedAgent)
+	if selectedAgent != "" {
+		selected, err := agent.GetAvailableExactWithConfigFromConfig(
+			resolution.RepoConfig, selectedAgent, cfg,
+		)
+		if err != nil {
+			return storage.ReenqueueOpts{}, fmt.Errorf(
+				"resolve selected agent %q: %w", selectedAgent, err,
+			)
+		}
+		if err := agent.ValidateStructuredReviewSelection(job.ReviewType, selected); err != nil {
+			return storage.ReenqueueOpts{}, err
+		}
+		storageName := agent.StorageNameFromConfig(
+			agent.CanonicalName(selectedAgent), resolution.RepoConfig, cfg,
+		)
+		return storage.ReenqueueOpts{
+			Agent: storageName,
+			Model: resolution.ModelForSelectedAgent(
+				storageName, strings.TrimSpace(job.RequestedModel),
+			),
+			Provider:     strings.TrimSpace(job.RequestedProvider),
+			ReplaceAgent: true,
+		}, nil
+	}
 
 	backupAgent := resolution.BackupAgent
 	if strings.TrimSpace(job.BackupAgent) != "" {
@@ -955,7 +984,7 @@ func resolveRerunOpts(
 }
 
 func resolveRerunModelProvider(job *storage.ReviewJob, cfg *config.Config) (string, string, error) {
-	opts, err := resolveRerunOpts(job, cfg, nil)
+	opts, err := resolveRerunOpts(job, cfg, nil, "")
 	return opts.Model, opts.Provider, err
 }
 
@@ -2293,12 +2322,18 @@ func (s *Server) humaRerunJob(
 	if job.Status == storage.JobStatusCanceled && job.WorkerID != "" {
 		return nil, huma.Error409Conflict("canceled job is still stopping")
 	}
+	selectedAgent := strings.TrimSpace(input.Body.Agent)
 
 	// Rerunning a panel synthesis parent spawns a brand-new panel run (fresh
 	// members + a re-blocked synthesis) rather than re-queueing the parent in
 	// place, so the new run gets fresh member reviews to synthesize.
 	// rerunPanelRun enforces the terminal-state guard.
 	if job.IsSynthesisJob() {
+		if selectedAgent != "" {
+			return nil, huma.Error400BadRequest(
+				"panel synthesis jobs cannot change agents on rerun",
+			)
+		}
 		return s.rerunPanelRun(job, requestID)
 	}
 	if job.PanelRole == storage.PanelRoleMember {
@@ -2317,7 +2352,14 @@ func (s *Server) humaRerunJob(
 			fmt.Sprintf("load experiment assignment: %v", err),
 		)
 	}
-	rerunOpts, err := resolveRerunOpts(job, s.configWatcher.Config(), assignment)
+	if selectedAgent != "" && assignment != nil {
+		return nil, huma.Error400BadRequest(
+			"frozen experiment jobs cannot change agents on rerun",
+		)
+	}
+	rerunOpts, err := resolveRerunOpts(
+		job, s.configWatcher.Config(), assignment, selectedAgent,
+	)
 	if err != nil {
 		return nil, huma.Error400BadRequest(err.Error())
 	}
@@ -2336,6 +2378,9 @@ func (s *Server) humaRerunJob(
 		)
 	}
 	if !replayed {
+		if rerunOpts.ReplaceAgent {
+			job.Agent = rerunOpts.Agent
+		}
 		s.broadcastRerunEnqueued(resultJobID, job.UUID, job)
 	}
 

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -617,8 +617,8 @@ func TestHandleRerunJob(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, storage.JobStatusQueued, updated.Status)
 		assert.Equal(t, selectedAgent, updated.Agent)
-		assert.Equal(t, "requested-model", updated.Model)
-		assert.Equal(t, "requested-provider", updated.Provider)
+		assert.Empty(t, updated.Model, "the selected agent should use its default model")
+		assert.Empty(t, updated.Provider, "the selected agent should use its default provider")
 		assert.Equal(t, "requested-model", updated.RequestedModel)
 		assert.Equal(t, "requested-provider", updated.RequestedProvider)
 		assert.Equal(t, "backup-agent", updated.BackupAgent)
@@ -973,7 +973,29 @@ func TestResolveRerunClassifierModelUsesClassifierConfig(t *testing.T) {
 	job.RequestedModel = "requested-model"
 	opts, err = resolveRerunOpts(job, config.DefaultConfig(), nil, selectedAgent)
 	require.NoError(t, err)
-	assert.Equal(t, "requested-model", opts.Model)
+	assert.Equal(t, "classify-model", opts.Model)
+}
+
+func TestResolveRerunAgentUsesConfiguredDefaults(t *testing.T) {
+	const selectedAgent = "rerun-configured-agent"
+	agent.Register(&agent.FakeAgent{NameStr: selectedAgent})
+	t.Cleanup(func() { agent.Unregister(selectedAgent) })
+	cfg := config.DefaultConfig()
+	cfg.DefaultAgent = selectedAgent
+	cfg.DefaultModel = "selected-default-model"
+	job := &storage.ReviewJob{
+		Agent: "test", RepoPath: t.TempDir(),
+		JobType: storage.JobTypeReview, ReviewType: config.ReviewTypeDefault,
+		RequestedModel: "original-model", RequestedProvider: "original-provider",
+	}
+
+	opts, err := resolveRerunOpts(job, cfg, nil, selectedAgent)
+	require.NoError(t, err)
+	assert := assert.New(t)
+	assert.Equal("selected-default-model", opts.Model)
+	assert.Empty(opts.Provider)
+	assert.Equal("original-model", job.RequestedModel)
+	assert.Equal("original-provider", job.RequestedProvider)
 }
 
 func TestWorkflowForJobFixType(t *testing.T) {

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -585,6 +585,200 @@ func TestHandleRerunJob(t *testing.T) {
 		assert.Empty(t, updated.Model, "rerun should recompute implicit model instead of preserving stale effective value")
 	})
 
+	t.Run("rerun with exact agent replaces only effective execution identity", func(t *testing.T) {
+		const selectedAgent = "rerun-selected-agent"
+		agent.Register(&agent.FakeAgent{NameStr: selectedAgent})
+		t.Cleanup(func() { agent.Unregister(selectedAgent) })
+
+		commit, err := db.GetOrCreateCommit(
+			repo.ID, "rerun-selected-agent", "Author", "Subject", time.Now(),
+		)
+		require.NoError(t, err)
+		job, err := db.EnqueueJob(storage.EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-selected-agent", Agent: "test",
+			Model: "old-effective", Provider: "old-provider",
+			RequestedModel: "requested-model", RequestedProvider: "requested-provider",
+			BackupAgent: "backup-agent", BackupModel: "backup-model",
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CancelJob(job.ID))
+		subscriberID, events := server.broadcaster.Subscribe("")
+		defer server.broadcaster.Unsubscribe(subscriberID)
+
+		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+			JobID: job.ID, Agent: selectedAgent,
+		})
+		w := httptest.NewRecorder()
+		server.httpServer.Handler.ServeHTTP(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		updated, err := db.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, storage.JobStatusQueued, updated.Status)
+		assert.Equal(t, selectedAgent, updated.Agent)
+		assert.Equal(t, "requested-model", updated.Model)
+		assert.Equal(t, "requested-provider", updated.Provider)
+		assert.Equal(t, "requested-model", updated.RequestedModel)
+		assert.Equal(t, "requested-provider", updated.RequestedProvider)
+		assert.Equal(t, "backup-agent", updated.BackupAgent)
+		assert.Equal(t, "backup-model", updated.BackupModel)
+		require.Len(t, events, 1)
+		assert.Equal(t, selectedAgent, (<-events).Agent)
+	})
+
+	t.Run("rerun rejects unknown selected agent", func(t *testing.T) {
+		commit, err := db.GetOrCreateCommit(
+			repo.ID, "rerun-unknown-agent", "Author", "Subject", time.Now(),
+		)
+		require.NoError(t, err)
+		job, err := db.EnqueueJob(storage.EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-unknown-agent", Agent: "test",
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CancelJob(job.ID))
+
+		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+			JobID: job.ID, Agent: "missing-rerun-agent",
+		})
+		w := httptest.NewRecorder()
+		server.httpServer.Handler.ServeHTTP(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
+		assert.Contains(t, w.Body.String(), "unknown agent")
+
+		updated, err := db.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
+		assert.Equal(t, "test", updated.Agent)
+	})
+
+	t.Run("rerun rejects unavailable selected agent without fallback", func(t *testing.T) {
+		const unavailableAgent = "rerun-unavailable-agent"
+		agent.Register(&commandTestAgent{
+			name: unavailableAgent, command: "roborev-command-that-does-not-exist",
+		})
+		t.Cleanup(func() { agent.Unregister(unavailableAgent) })
+
+		commit, err := db.GetOrCreateCommit(
+			repo.ID, "rerun-unavailable-agent", "Author", "Subject", time.Now(),
+		)
+		require.NoError(t, err)
+		job, err := db.EnqueueJob(storage.EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-unavailable-agent", Agent: "test",
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CancelJob(job.ID))
+
+		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+			JobID: job.ID, Agent: unavailableAgent,
+		})
+		w := httptest.NewRecorder()
+		server.httpServer.Handler.ServeHTTP(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
+		assert.Contains(t, w.Body.String(), "unavailable")
+
+		updated, err := db.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
+		assert.Equal(t, "test", updated.Agent)
+	})
+
+	t.Run("rerun rejects selected agent incompatible with structured review", func(t *testing.T) {
+		const selectedAgent = "rerun-unstructured-agent"
+		agent.Register(&agent.FakeAgent{NameStr: selectedAgent})
+		t.Cleanup(func() { agent.Unregister(selectedAgent) })
+
+		commit, err := db.GetOrCreateCommit(
+			repo.ID, "rerun-unstructured-agent", "Author", "Subject", time.Now(),
+		)
+		require.NoError(t, err)
+		job, err := db.EnqueueJob(storage.EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-unstructured-agent", Agent: "test", ReviewType: "custom",
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CancelJob(job.ID))
+
+		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+			JobID: job.ID, Agent: selectedAgent,
+		})
+		w := httptest.NewRecorder()
+		server.httpServer.Handler.ServeHTTP(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
+		assert.Contains(t, w.Body.String(), "schema-constrained reviews")
+
+		updated, err := db.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
+		assert.Equal(t, "test", updated.Agent)
+	})
+
+	t.Run("rerun stores configured ACP identity", func(t *testing.T) {
+		isolatedDB, isolatedDir := testutil.OpenTestDBWithDir(t)
+		cfg := config.DefaultConfig()
+		cfg.ACP = config.ACPAgentConfigs{
+			"rerun-acp": {Command: "go", Model: "acp-model"},
+		}
+		isolatedServer := NewServer(isolatedDB, cfg, "")
+		t.Cleanup(func() { require.NoError(t, isolatedServer.Close()) })
+		repo, err := isolatedDB.GetOrCreateRepo(isolatedDir)
+		require.NoError(t, err)
+		commit, err := isolatedDB.GetOrCreateCommit(
+			repo.ID, "rerun-acp-agent", "Author", "Subject", time.Now(),
+		)
+		require.NoError(t, err)
+		job, err := isolatedDB.EnqueueJob(storage.EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-acp-agent", Agent: "test",
+		})
+		require.NoError(t, err)
+		require.NoError(t, isolatedDB.CancelJob(job.ID))
+
+		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+			JobID: job.ID, Agent: "acp.rerun-acp",
+		})
+		w := httptest.NewRecorder()
+		isolatedServer.httpServer.Handler.ServeHTTP(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusOK)
+
+		updated, err := isolatedDB.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "acp.rerun-acp", updated.Agent)
+		assert.Equal(t, "acp-model", updated.Model)
+	})
+
+	t.Run("rerun rejects selected agent for frozen experiment", func(t *testing.T) {
+		commit, err := db.GetOrCreateCommit(
+			repo.ID, "rerun-frozen-experiment", "Author", "Subject", time.Now(),
+		)
+		require.NoError(t, err)
+		job, err := db.EnqueueJob(storage.EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-frozen-experiment", Agent: "test",
+			Experiment: &storage.ExperimentAssignmentInput{
+				ExperimentID: "rerun-agent", DefinitionHash: "definition",
+				DefinitionJSON: `{}`, Arm: "experiment", SubjectHash: "subject",
+				EffectiveConfigHash: "effective", EffectiveConfigJSON: `{}`,
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CancelJob(job.ID))
+
+		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+			JobID: job.ID, Agent: "test",
+		})
+		w := httptest.NewRecorder()
+		server.httpServer.Handler.ServeHTTP(w, req)
+		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
+		assert.Contains(t, w.Body.String(), "frozen experiment")
+
+		updated, err := db.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
+	})
+
 	t.Run("rerun queued job fails", func(t *testing.T) {
 		commit, _ := db.GetOrCreateCommit(repo.ID, "rerun-queued", "Author", "Subject", time.Now())
 		job, _ := db.EnqueueJob(storage.EnqueueOpts{RepoID: repo.ID, CommitID: commit.ID, GitRef: "rerun-queued", Agent: "test"})

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -915,6 +915,67 @@ func TestRerunJobBroadcastsOnlyAcceptedRequest(t *testing.T) {
 	assert.Empty(t, events, "idempotent replay must not broadcast again")
 }
 
+func TestRerunClassifierRequiresSchemaAgent(t *testing.T) {
+	server, db, tempDir := newTestServer(t)
+	const selectedAgent = "rerun-classifier-unstructured"
+	agent.Register(&commandTestAgent{name: selectedAgent, command: "go"})
+	t.Cleanup(func() { agent.Unregister(selectedAgent) })
+
+	repo, err := db.GetOrCreateRepo(tempDir)
+	require.NoError(t, err)
+	commit, err := db.GetOrCreateCommit(
+		repo.ID, "rerun-classifier-unstructured", "Author", "Subject", time.Now(),
+	)
+	require.NoError(t, err)
+	job, err := db.EnqueueJob(storage.EnqueueOpts{
+		RepoID: repo.ID, CommitID: commit.ID,
+		GitRef:  "rerun-classifier-unstructured",
+		Agent:   storage.AutoDesignAgentSentinel,
+		JobType: storage.JobTypeClassify, ReviewType: "design",
+		Source: storage.JobSourceAutoDesign,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.CancelJob(job.ID))
+
+	req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+		JobID: job.ID, Agent: selectedAgent,
+	})
+	w := httptest.NewRecorder()
+	server.httpServer.Handler.ServeHTTP(w, req)
+
+	testutil.AssertStatusCode(t, w, http.StatusBadRequest)
+	assert.Contains(t, w.Body.String(), "SchemaAgent")
+	updated, err := db.GetJobByID(job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, storage.JobStatusCanceled, updated.Status)
+	assert.Equal(t, storage.AutoDesignAgentSentinel, updated.Agent)
+}
+
+func TestResolveRerunClassifierModelUsesClassifierConfig(t *testing.T) {
+	repoPath := t.TempDir()
+	testutil.InitTestGitRepo(t, repoPath)
+	require.NoError(t, os.WriteFile(filepath.Join(repoPath, ".roborev.toml"), []byte(
+		"classify_model = \"classify-model\"\ndesign_model = \"design-model\"\n",
+	), 0o644))
+
+	const selectedAgent = "rerun-classifier-model"
+	agent.Register(&fakeSchemaAgent{name: selectedAgent})
+	t.Cleanup(func() { agent.Unregister(selectedAgent) })
+
+	job := &storage.ReviewJob{
+		Agent: selectedAgent, JobType: storage.JobTypeClassify,
+		ReviewType: "design", Reasoning: "fast", RepoPath: repoPath,
+	}
+	opts, err := resolveRerunOpts(job, config.DefaultConfig(), nil, selectedAgent)
+	require.NoError(t, err)
+	assert.Equal(t, "classify-model", opts.Model)
+
+	job.RequestedModel = "requested-model"
+	opts, err = resolveRerunOpts(job, config.DefaultConfig(), nil, selectedAgent)
+	require.NoError(t, err)
+	assert.Equal(t, "requested-model", opts.Model)
+}
+
 func TestWorkflowForJobFixType(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal("fix", workflowForJob(storage.JobTypeFix, config.ReviewTypeDefault))

--- a/internal/daemon/server_actions_test.go
+++ b/internal/daemon/server_actions_test.go
@@ -627,92 +627,46 @@ func TestHandleRerunJob(t *testing.T) {
 		assert.Equal(t, selectedAgent, (<-events).Agent)
 	})
 
-	t.Run("rerun rejects unknown selected agent", func(t *testing.T) {
-		commit, err := db.GetOrCreateCommit(
-			repo.ID, "rerun-unknown-agent", "Author", "Subject", time.Now(),
-		)
-		require.NoError(t, err)
-		job, err := db.EnqueueJob(storage.EnqueueOpts{
-			RepoID: repo.ID, CommitID: commit.ID,
-			GitRef: "rerun-unknown-agent", Agent: "test",
+	t.Run("rerun rejects invalid agent changes without mutating the job", func(t *testing.T) {
+		agent.Register(&agent.FakeAgent{NameStr: "rerun-unstructured"})
+		agent.Register(&commandTestAgent{name: "rerun-unavailable", command: "roborev-command-that-does-not-exist"})
+		t.Cleanup(func() {
+			agent.Unregister("rerun-unstructured")
+			agent.Unregister("rerun-unavailable")
 		})
-		require.NoError(t, err)
-		require.NoError(t, db.CancelJob(job.ID))
-
-		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
-			JobID: job.ID, Agent: "missing-rerun-agent",
-		})
-		w := httptest.NewRecorder()
-		server.httpServer.Handler.ServeHTTP(w, req)
-		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
-		assert.Contains(t, w.Body.String(), "unknown agent")
-
-		updated, err := db.GetJobByID(job.ID)
-		require.NoError(t, err)
-		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
-		assert.Equal(t, "test", updated.Agent)
-	})
-
-	t.Run("rerun rejects unavailable selected agent without fallback", func(t *testing.T) {
-		const unavailableAgent = "rerun-unavailable-agent"
-		agent.Register(&commandTestAgent{
-			name: unavailableAgent, command: "roborev-command-that-does-not-exist",
-		})
-		t.Cleanup(func() { agent.Unregister(unavailableAgent) })
-
-		commit, err := db.GetOrCreateCommit(
-			repo.ID, "rerun-unavailable-agent", "Author", "Subject", time.Now(),
-		)
-		require.NoError(t, err)
-		job, err := db.EnqueueJob(storage.EnqueueOpts{
-			RepoID: repo.ID, CommitID: commit.ID,
-			GitRef: "rerun-unavailable-agent", Agent: "test",
-		})
-		require.NoError(t, err)
-		require.NoError(t, db.CancelJob(job.ID))
-
-		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
-			JobID: job.ID, Agent: unavailableAgent,
-		})
-		w := httptest.NewRecorder()
-		server.httpServer.Handler.ServeHTTP(w, req)
-		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
-		assert.Contains(t, w.Body.String(), "unavailable")
-
-		updated, err := db.GetJobByID(job.ID)
-		require.NoError(t, err)
-		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
-		assert.Equal(t, "test", updated.Agent)
-	})
-
-	t.Run("rerun rejects selected agent incompatible with structured review", func(t *testing.T) {
-		const selectedAgent = "rerun-unstructured-agent"
-		agent.Register(&agent.FakeAgent{NameStr: selectedAgent})
-		t.Cleanup(func() { agent.Unregister(selectedAgent) })
-
-		commit, err := db.GetOrCreateCommit(
-			repo.ID, "rerun-unstructured-agent", "Author", "Subject", time.Now(),
-		)
-		require.NoError(t, err)
-		job, err := db.EnqueueJob(storage.EnqueueOpts{
-			RepoID: repo.ID, CommitID: commit.ID,
-			GitRef: "rerun-unstructured-agent", Agent: "test", ReviewType: "custom",
-		})
-		require.NoError(t, err)
-		require.NoError(t, db.CancelJob(job.ID))
-
-		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
-			JobID: job.ID, Agent: selectedAgent,
-		})
-		w := httptest.NewRecorder()
-		server.httpServer.Handler.ServeHTTP(w, req)
-		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
-		assert.Contains(t, w.Body.String(), "schema-constrained reviews")
-
-		updated, err := db.GetJobByID(job.ID)
-		require.NoError(t, err)
-		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
-		assert.Equal(t, "test", updated.Agent)
+		for _, tt := range []struct {
+			name, selected, reviewType, jobType, wantError string
+			experiment                                     *storage.ExperimentAssignmentInput
+		}{
+			{name: "unknown", selected: "missing-rerun-agent", wantError: "unknown agent"},
+			{name: "unavailable", selected: "rerun-unavailable", wantError: "unavailable"},
+			{name: "structured", selected: "rerun-unstructured", reviewType: "custom", wantError: "schema-constrained reviews"},
+			{name: "classifier", selected: "rerun-unstructured", reviewType: "design", jobType: storage.JobTypeClassify, wantError: "SchemaAgent"},
+			{name: "experiment", selected: "test", wantError: "frozen experiment", experiment: &storage.ExperimentAssignmentInput{
+				ExperimentID: "rerun-agent", DefinitionHash: "definition", DefinitionJSON: `{}`,
+				Arm: "experiment", SubjectHash: "subject", EffectiveConfigHash: "effective", EffectiveConfigJSON: `{}`,
+			}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				job, err := db.EnqueueJob(storage.EnqueueOpts{
+					RepoID: repo.ID, GitRef: "rerun-" + tt.name, Agent: "test",
+					ReviewType: tt.reviewType, JobType: tt.jobType, Experiment: tt.experiment,
+				})
+				require.NoError(t, err)
+				require.NoError(t, db.CancelJob(job.ID))
+				req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
+					JobID: job.ID, Agent: tt.selected,
+				})
+				w := httptest.NewRecorder()
+				server.httpServer.Handler.ServeHTTP(w, req)
+				testutil.AssertStatusCode(t, w, http.StatusBadRequest)
+				assert.Contains(t, w.Body.String(), tt.wantError)
+				updated, err := db.GetJobByID(job.ID)
+				require.NoError(t, err)
+				assert.Equal(t, storage.JobStatusCanceled, updated.Status)
+				assert.Equal(t, "test", updated.Agent)
+			})
+		}
 	})
 
 	t.Run("rerun stores configured ACP identity", func(t *testing.T) {
@@ -732,6 +686,7 @@ func TestHandleRerunJob(t *testing.T) {
 		job, err := isolatedDB.EnqueueJob(storage.EnqueueOpts{
 			RepoID: repo.ID, CommitID: commit.ID,
 			GitRef: "rerun-acp-agent", Agent: "test",
+			RequestedModel: "original-model", RequestedProvider: "original-provider",
 		})
 		require.NoError(t, err)
 		require.NoError(t, isolatedDB.CancelJob(job.ID))
@@ -747,36 +702,6 @@ func TestHandleRerunJob(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "acp.rerun-acp", updated.Agent)
 		assert.Equal(t, "acp-model", updated.Model)
-	})
-
-	t.Run("rerun rejects selected agent for frozen experiment", func(t *testing.T) {
-		commit, err := db.GetOrCreateCommit(
-			repo.ID, "rerun-frozen-experiment", "Author", "Subject", time.Now(),
-		)
-		require.NoError(t, err)
-		job, err := db.EnqueueJob(storage.EnqueueOpts{
-			RepoID: repo.ID, CommitID: commit.ID,
-			GitRef: "rerun-frozen-experiment", Agent: "test",
-			Experiment: &storage.ExperimentAssignmentInput{
-				ExperimentID: "rerun-agent", DefinitionHash: "definition",
-				DefinitionJSON: `{}`, Arm: "experiment", SubjectHash: "subject",
-				EffectiveConfigHash: "effective", EffectiveConfigJSON: `{}`,
-			},
-		})
-		require.NoError(t, err)
-		require.NoError(t, db.CancelJob(job.ID))
-
-		req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
-			JobID: job.ID, Agent: "test",
-		})
-		w := httptest.NewRecorder()
-		server.httpServer.Handler.ServeHTTP(w, req)
-		testutil.AssertStatusCode(t, w, http.StatusBadRequest)
-		assert.Contains(t, w.Body.String(), "frozen experiment")
-
-		updated, err := db.GetJobByID(job.ID)
-		require.NoError(t, err)
-		assert.Equal(t, storage.JobStatusCanceled, updated.Status)
 	})
 
 	t.Run("rerun queued job fails", func(t *testing.T) {
@@ -915,42 +840,6 @@ func TestRerunJobBroadcastsOnlyAcceptedRequest(t *testing.T) {
 	assert.Empty(t, events, "idempotent replay must not broadcast again")
 }
 
-func TestRerunClassifierRequiresSchemaAgent(t *testing.T) {
-	server, db, tempDir := newTestServer(t)
-	const selectedAgent = "rerun-classifier-unstructured"
-	agent.Register(&commandTestAgent{name: selectedAgent, command: "go"})
-	t.Cleanup(func() { agent.Unregister(selectedAgent) })
-
-	repo, err := db.GetOrCreateRepo(tempDir)
-	require.NoError(t, err)
-	commit, err := db.GetOrCreateCommit(
-		repo.ID, "rerun-classifier-unstructured", "Author", "Subject", time.Now(),
-	)
-	require.NoError(t, err)
-	job, err := db.EnqueueJob(storage.EnqueueOpts{
-		RepoID: repo.ID, CommitID: commit.ID,
-		GitRef:  "rerun-classifier-unstructured",
-		Agent:   storage.AutoDesignAgentSentinel,
-		JobType: storage.JobTypeClassify, ReviewType: "design",
-		Source: storage.JobSourceAutoDesign,
-	})
-	require.NoError(t, err)
-	require.NoError(t, db.CancelJob(job.ID))
-
-	req := testutil.MakeJSONRequest(t, http.MethodPost, "/api/job/rerun", RerunJobRequest{
-		JobID: job.ID, Agent: selectedAgent,
-	})
-	w := httptest.NewRecorder()
-	server.httpServer.Handler.ServeHTTP(w, req)
-
-	testutil.AssertStatusCode(t, w, http.StatusBadRequest)
-	assert.Contains(t, w.Body.String(), "SchemaAgent")
-	updated, err := db.GetJobByID(job.ID)
-	require.NoError(t, err)
-	assert.Equal(t, storage.JobStatusCanceled, updated.Status)
-	assert.Equal(t, storage.AutoDesignAgentSentinel, updated.Agent)
-}
-
 func TestResolveRerunClassifierModelUsesClassifierConfig(t *testing.T) {
 	repoPath := t.TempDir()
 	testutil.InitTestGitRepo(t, repoPath)
@@ -974,28 +863,6 @@ func TestResolveRerunClassifierModelUsesClassifierConfig(t *testing.T) {
 	opts, err = resolveRerunOpts(job, config.DefaultConfig(), nil, selectedAgent)
 	require.NoError(t, err)
 	assert.Equal(t, "classify-model", opts.Model)
-}
-
-func TestResolveRerunAgentUsesConfiguredDefaults(t *testing.T) {
-	const selectedAgent = "rerun-configured-agent"
-	agent.Register(&agent.FakeAgent{NameStr: selectedAgent})
-	t.Cleanup(func() { agent.Unregister(selectedAgent) })
-	cfg := config.DefaultConfig()
-	cfg.DefaultAgent = selectedAgent
-	cfg.DefaultModel = "selected-default-model"
-	job := &storage.ReviewJob{
-		Agent: "test", RepoPath: t.TempDir(),
-		JobType: storage.JobTypeReview, ReviewType: config.ReviewTypeDefault,
-		RequestedModel: "original-model", RequestedProvider: "original-provider",
-	}
-
-	opts, err := resolveRerunOpts(job, cfg, nil, selectedAgent)
-	require.NoError(t, err)
-	assert := assert.New(t)
-	assert.Equal("selected-default-model", opts.Model)
-	assert.Empty(opts.Provider)
-	assert.Equal("original-model", job.RequestedModel)
-	assert.Equal("original-provider", job.RequestedProvider)
 }
 
 func TestWorkflowForJobFixType(t *testing.T) {

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -247,6 +247,7 @@ type CancelJobRequest struct {
 type RerunJobRequest struct {
 	JobID     int64      `json:"job_id"`
 	RequestID *uuid.UUID `json:"request_id,omitempty" format:"uuid"`
+	Agent     string     `json:"agent,omitempty"`
 }
 
 // AddCommentRequest is the JSON body for POST /api/comment.

--- a/internal/daemon/worker_classify.go
+++ b/internal/daemon/worker_classify.go
@@ -118,14 +118,23 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 		ChangedFiles: changedFilesForJob(job),
 	}
 
-	primary, err := config.ResolveClassifyAgent("", job.RepoPath, cfg)
-	if err != nil {
-		log.Printf("[%s] classifier config error for job %d: %v", workerID, job.ID, err)
-		closeJobLog()
-		wp.completeClassifyAsSkipContext(ctx, workerID, job, "classifier unavailable", err.Error())
-		return
+	storedAgent := strings.TrimSpace(job.Agent)
+	jobHasExplicitAgent := storedAgent != "" &&
+		storedAgent != storage.AutoDesignAgentSentinel
+	var primary string
+	var err error
+	if jobHasExplicitAgent {
+		primary = storedAgent
+	} else {
+		primary, err = config.ResolveClassifyAgent("", job.RepoPath, cfg)
+		if err != nil {
+			log.Printf("[%s] classifier config error for job %d: %v", workerID, job.ID, err)
+			closeJobLog()
+			wp.completeClassifyAsSkipContext(ctx, workerID, job, "classifier unavailable", err.Error())
+			return
+		}
 	}
-	defaultedPrimary := classifyAgentDefaulted(job.RepoPath, cfg)
+	defaultedPrimary := !jobHasExplicitAgent && classifyAgentDefaulted(job.RepoPath, cfg)
 	backup, backupErr := config.ResolveBackupClassifyAgent(job.RepoPath, cfg)
 	if backupErr != nil {
 		log.Printf("[%s] classifier backup agent invalid (%v); ignoring", workerID, backupErr)
@@ -181,6 +190,9 @@ func (wp *WorkerPool) processClassifyJob(ctx context.Context, workerID string, j
 	}
 
 	primaryModel := config.ResolveClassifyModel("", job.RepoPath, cfg)
+	if jobHasExplicitAgent {
+		primaryModel = strings.TrimSpace(job.Model)
+	}
 	yes, reason, selected, err := tryAgent(primary, primaryModel)
 	if err != nil && wp.handleUpdateInterruption(ctx, workerID, job) {
 		closeJobLog()

--- a/internal/daemon/worker_classify_test.go
+++ b/internal/daemon/worker_classify_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -248,6 +249,62 @@ func TestProcessClassifyJob_WritesStandardLogAndCommandLine(t *testing.T) {
 	event, ok := waitForEvent(t, events, time.Second)
 	require.True(t, ok)
 	assert.Equal(t, "fake-schema", event.Agent)
+}
+
+func TestProcessClassifyJobUsesStoredAgent(t *testing.T) {
+	setupTestEnv(t)
+	tc := newWorkerTestContext(t, 1)
+
+	var configuredCalls, selectedCalls int
+	configured := &fakeSchemaAgent{
+		name: "configured-classifier",
+		classifyFn: func(context.Context) (json.RawMessage, error) {
+			configuredCalls++
+			return []byte(`{"design_review": false, "reason": "configured"}`), nil
+		},
+	}
+	selected := &fakeSchemaAgent{
+		name: "selected-classifier",
+		classifyFn: func(context.Context) (json.RawMessage, error) {
+			selectedCalls++
+			return []byte(`{"design_review": false, "reason": "selected"}`), nil
+		},
+	}
+	agent.Register(configured)
+	agent.Register(selected)
+	t.Cleanup(func() {
+		agent.Unregister(configured.Name())
+		agent.Unregister(selected.Name())
+	})
+
+	cfg := config.DefaultConfig()
+	cfg.ClassifyAgent = configured.Name()
+	tc.Pool.cfgGetter = NewStaticConfig(cfg)
+
+	_, err := tc.DB.GetOrCreateCommit(tc.Repo.ID, "stored-agent", "Author", "s", time.Now())
+	require.NoError(t, err)
+	jobID, err := tc.DB.EnqueueAutoDesignJob(storage.EnqueueOpts{
+		RepoID:     tc.Repo.ID,
+		GitRef:     "stored-agent",
+		Agent:      selected.Name(),
+		Model:      "selected-model",
+		JobType:    storage.JobTypeClassify,
+		ReviewType: "design",
+	})
+	require.NoError(t, err)
+	claimed, err := tc.DB.ClaimJob("worker-stored-agent")
+	require.NoError(t, err)
+	require.Equal(t, jobID, claimed.ID)
+
+	tc.Pool.processClassifyJob(context.Background(), "worker-stored-agent", claimed)
+
+	assert.Equal(t, 0, configuredCalls)
+	assert.Equal(t, 1, selectedCalls)
+	got, err := tc.DB.GetJobByID(jobID)
+	require.NoError(t, err)
+	assert.Equal(t, selected.Name(), got.Agent)
+	assert.Equal(t, "selected-model", got.Model)
+	assert.Equal(t, "selected", got.SkipReason)
 }
 
 // waitForEvent reads one event from ch within timeout.

--- a/internal/daemon/worker_update_interrupt_test.go
+++ b/internal/daemon/worker_update_interrupt_test.go
@@ -272,9 +272,20 @@ func TestUpdateInterruptionPreemptsClassifierBackup(t *testing.T) {
 	cfg.ClassifyAgent = primaryName
 	cfg.ClassifyBackupAgent = backupName
 	tc.Pool.cfgGetter = NewStaticConfig(cfg)
-	job := tc.createAndClaimClassifyJob(
-		t, "update-classifier-backup", "subject", "+diff\n",
-	)
+	jobID, err := tc.DB.EnqueueAutoDesignJob(storage.EnqueueOpts{
+		RepoID:      tc.Repo.ID,
+		GitRef:      "update-classifier-backup",
+		Agent:       storage.AutoDesignAgentSentinel,
+		JobType:     storage.JobTypeClassify,
+		ReviewType:  "design",
+		DiffContent: "+diff\n",
+		Prompt:      "subject",
+	})
+	require.NoError(t, err)
+	job, err := tc.DB.ClaimJob(testWorkerID)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	require.Equal(t, jobID, job.ID)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -1369,6 +1369,62 @@ func TestReenqueueJob(t *testing.T) {
 		assert.Equal(t, "anthropic", updated.RequestedProvider)
 	})
 
+	t.Run("replacement requires a non-empty agent", func(t *testing.T) {
+		err := db.ReenqueueJob(99999, ReenqueueOpts{ReplaceAgent: true})
+		require.EqualError(t, err, "replacement agent is required")
+	})
+
+	t.Run("agent changes only for a marked replacement", func(t *testing.T) {
+		isolatedDB := openTestDB(t)
+		defer isolatedDB.Close()
+
+		repo := createRepo(t, isolatedDB, "/tmp/rerun-replace-agent-gate")
+		commit := createCommit(t, isolatedDB, repo.ID, "rerun-replace-agent-gate-sha")
+		job, err := isolatedDB.EnqueueJob(EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-replace-agent-gate-sha", Agent: "codex",
+		})
+		require.NoError(t, err)
+		require.NoError(t, isolatedDB.CancelJob(job.ID))
+
+		require.NoError(t, isolatedDB.ReenqueueJob(job.ID, ReenqueueOpts{Agent: "claude-code"}))
+		updated, err := isolatedDB.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "codex", updated.Agent)
+	})
+
+	t.Run("marked replacement preserves provenance and backups", func(t *testing.T) {
+		isolatedDB := openTestDB(t)
+		defer isolatedDB.Close()
+
+		repo := createRepo(t, isolatedDB, "/tmp/rerun-replace-agent")
+		commit := createCommit(t, isolatedDB, repo.ID, "rerun-replace-agent-sha")
+		job, err := isolatedDB.EnqueueJob(EnqueueOpts{
+			RepoID: repo.ID, CommitID: commit.ID,
+			GitRef: "rerun-replace-agent-sha", Agent: "codex",
+			Model: "old-effective", Provider: "old-provider",
+			RequestedModel: "requested-model", RequestedProvider: "requested-provider",
+			BackupAgent: "backup-agent", BackupModel: "backup-model",
+		})
+		require.NoError(t, err)
+		require.NoError(t, isolatedDB.CancelJob(job.ID))
+
+		err = isolatedDB.ReenqueueJob(job.ID, ReenqueueOpts{
+			Agent: "claude-code", Model: "new-effective", Provider: "requested-provider",
+			ReplaceAgent: true,
+		})
+		require.NoError(t, err)
+		updated, err := isolatedDB.GetJobByID(job.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "claude-code", updated.Agent)
+		assert.Equal(t, "new-effective", updated.Model)
+		assert.Equal(t, "requested-provider", updated.Provider)
+		assert.Equal(t, "requested-model", updated.RequestedModel)
+		assert.Equal(t, "requested-provider", updated.RequestedProvider)
+		assert.Equal(t, "backup-agent", updated.BackupAgent)
+		assert.Equal(t, "backup-model", updated.BackupModel)
+	})
+
 	t.Run("rerun restores empty non-nullable experiment plan fields", func(t *testing.T) {
 		isolatedDB := openTestDB(t)
 		defer isolatedDB.Close()

--- a/internal/storage/db_job_test.go
+++ b/internal/storage/db_job_test.go
@@ -1369,62 +1369,6 @@ func TestReenqueueJob(t *testing.T) {
 		assert.Equal(t, "anthropic", updated.RequestedProvider)
 	})
 
-	t.Run("replacement requires a non-empty agent", func(t *testing.T) {
-		err := db.ReenqueueJob(99999, ReenqueueOpts{ReplaceAgent: true})
-		require.EqualError(t, err, "replacement agent is required")
-	})
-
-	t.Run("agent changes only for a marked replacement", func(t *testing.T) {
-		isolatedDB := openTestDB(t)
-		defer isolatedDB.Close()
-
-		repo := createRepo(t, isolatedDB, "/tmp/rerun-replace-agent-gate")
-		commit := createCommit(t, isolatedDB, repo.ID, "rerun-replace-agent-gate-sha")
-		job, err := isolatedDB.EnqueueJob(EnqueueOpts{
-			RepoID: repo.ID, CommitID: commit.ID,
-			GitRef: "rerun-replace-agent-gate-sha", Agent: "codex",
-		})
-		require.NoError(t, err)
-		require.NoError(t, isolatedDB.CancelJob(job.ID))
-
-		require.NoError(t, isolatedDB.ReenqueueJob(job.ID, ReenqueueOpts{Agent: "claude-code"}))
-		updated, err := isolatedDB.GetJobByID(job.ID)
-		require.NoError(t, err)
-		assert.Equal(t, "codex", updated.Agent)
-	})
-
-	t.Run("marked replacement preserves provenance and backups", func(t *testing.T) {
-		isolatedDB := openTestDB(t)
-		defer isolatedDB.Close()
-
-		repo := createRepo(t, isolatedDB, "/tmp/rerun-replace-agent")
-		commit := createCommit(t, isolatedDB, repo.ID, "rerun-replace-agent-sha")
-		job, err := isolatedDB.EnqueueJob(EnqueueOpts{
-			RepoID: repo.ID, CommitID: commit.ID,
-			GitRef: "rerun-replace-agent-sha", Agent: "codex",
-			Model: "old-effective", Provider: "old-provider",
-			RequestedModel: "requested-model", RequestedProvider: "requested-provider",
-			BackupAgent: "backup-agent", BackupModel: "backup-model",
-		})
-		require.NoError(t, err)
-		require.NoError(t, isolatedDB.CancelJob(job.ID))
-
-		err = isolatedDB.ReenqueueJob(job.ID, ReenqueueOpts{
-			Agent: "claude-code", Model: "new-effective", Provider: "requested-provider",
-			ReplaceAgent: true,
-		})
-		require.NoError(t, err)
-		updated, err := isolatedDB.GetJobByID(job.ID)
-		require.NoError(t, err)
-		assert.Equal(t, "claude-code", updated.Agent)
-		assert.Equal(t, "new-effective", updated.Model)
-		assert.Equal(t, "requested-provider", updated.Provider)
-		assert.Equal(t, "requested-model", updated.RequestedModel)
-		assert.Equal(t, "requested-provider", updated.RequestedProvider)
-		assert.Equal(t, "backup-agent", updated.BackupAgent)
-		assert.Equal(t, "backup-model", updated.BackupModel)
-	})
-
 	t.Run("rerun restores empty non-nullable experiment plan fields", func(t *testing.T) {
 		isolatedDB := openTestDB(t)
 		defer isolatedDB.Close()

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1343,15 +1343,16 @@ func (db *DB) MarkJobRebased(jobID int64) error {
 }
 
 type ReenqueueOpts struct {
-	Agent       string
-	Model       string
-	Provider    string
-	Reasoning   string
-	ReviewType  string
-	MinSeverity string
-	BackupAgent string
-	BackupModel string
-	RestorePlan bool
+	Agent        string
+	Model        string
+	Provider     string
+	Reasoning    string
+	ReviewType   string
+	MinSeverity  string
+	BackupAgent  string
+	BackupModel  string
+	RestorePlan  bool
+	ReplaceAgent bool
 }
 
 // ReenqueueJob resets a completed, failed, or canceled job back to queued status.
@@ -1399,6 +1400,9 @@ func (db *DB) ReenqueueJobWithRequest(
 			return result.JobID, true, nil
 		}
 	}
+	if opts.ReplaceAgent && strings.TrimSpace(opts.Agent) == "" {
+		return 0, false, errors.New("replacement agent is required")
+	}
 
 	// Delete any existing review for this job (for done jobs being rerun)
 	_, err = conn.ExecContext(ctx, `DELETE FROM reviews WHERE job_id = ?`, jobID)
@@ -1444,7 +1448,7 @@ func (db *DB) ReenqueueJobWithRequest(
 		    OR (status = 'canceled' AND worker_id IS NULL)
 		  )
 	`, enqueuedAt,
-		opts.RestorePlan, opts.Agent,
+		opts.RestorePlan || opts.ReplaceAgent, opts.Agent,
 		nullString(opts.Model), nullString(opts.Provider),
 		opts.RestorePlan, opts.Reasoning,
 		opts.RestorePlan, opts.ReviewType,

--- a/internal/storage/jobs.go
+++ b/internal/storage/jobs.go
@@ -1343,16 +1343,15 @@ func (db *DB) MarkJobRebased(jobID int64) error {
 }
 
 type ReenqueueOpts struct {
-	Agent        string
-	Model        string
-	Provider     string
-	Reasoning    string
-	ReviewType   string
-	MinSeverity  string
-	BackupAgent  string
-	BackupModel  string
-	RestorePlan  bool
-	ReplaceAgent bool
+	Agent       string
+	Model       string
+	Provider    string
+	Reasoning   string
+	ReviewType  string
+	MinSeverity string
+	BackupAgent string
+	BackupModel string
+	RestorePlan bool
 }
 
 // ReenqueueJob resets a completed, failed, or canceled job back to queued status.
@@ -1400,9 +1399,6 @@ func (db *DB) ReenqueueJobWithRequest(
 			return result.JobID, true, nil
 		}
 	}
-	if opts.ReplaceAgent && strings.TrimSpace(opts.Agent) == "" {
-		return 0, false, errors.New("replacement agent is required")
-	}
 
 	// Delete any existing review for this job (for done jobs being rerun)
 	_, err = conn.ExecContext(ctx, `DELETE FROM reviews WHERE job_id = ?`, jobID)
@@ -1448,7 +1444,7 @@ func (db *DB) ReenqueueJobWithRequest(
 		    OR (status = 'canceled' AND worker_id IS NULL)
 		  )
 	`, enqueuedAt,
-		opts.RestorePlan || opts.ReplaceAgent, opts.Agent,
+		opts.RestorePlan || opts.Agent != "", opts.Agent,
 		nullString(opts.Model), nullString(opts.Provider),
 		opts.RestorePlan, opts.Reasoning,
 		opts.RestorePlan, opts.ReviewType,

--- a/packages/roborev-ui/src/generated/rerunJobRequest.ts
+++ b/packages/roborev-ui/src/generated/rerunJobRequest.ts
@@ -5,6 +5,7 @@
 export interface RerunJobRequest {
   /** A URL to the JSON Schema for this object. */
   readonly $schema?: string;
+  agent?: string;
   job_id: number;
   request_id?: string;
 }

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -2025,6 +2025,7 @@ func (r RerunJobOutputBody) Validate() error {
 type RerunJobRequest struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema    *string    `json:"$schema,omitempty"`
+	Agent     *string    `json:"agent,omitempty"`
 	JobID     int64      `json:"job_id"`
 	RequestID *uuid.UUID `json:"request_id,omitempty"`
 }

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2401,6 +2401,8 @@ components:
           format: uri
           readOnly: true
           type: string
+        agent:
+          type: string
         job_id:
           format: int64
           type: integer

--- a/web/src/lib/api/generated/models/rerunJobRequest.ts
+++ b/web/src/lib/api/generated/models/rerunJobRequest.ts
@@ -5,6 +5,7 @@
 export interface RerunJobRequest {
   /** A URL to the JSON Schema for this object. */
   readonly $schema?: string;
+  agent?: string;
   job_id: number;
   request_id?: string;
 }


### PR DESCRIPTION
Pressing `R` on a finished job in the TUI opens a picker for another available agent. This lets users recover a failed review without leaving the TUI to queue it again from the CLI. Lowercase `r` keeps the existing immediate rerun behavior.

## Details

- The picker resolves agents from repository and global configuration, excluding the current agent and agents incompatible with the review type. It checks job eligibility again when the user submits the selection.
- `RerunJobRequest` accepts an optional `agent`. The daemon validates availability and review capabilities before changing the job, then resolves the selected agent's model and provider defaults. The original request's explicit overrides remain stored as provenance.
- Requeueing updates the existing job and replaces its previous review. The TUI immediately displays the queued state and restores the previous agent, status, and review fields if the request fails.
- Classifier reruns require `SchemaAgent` support and resolve the classifier-specific model. The classifier worker honors the agent and model stored on the rerun job.

Panel and experiment-attributed jobs cannot change agents this way. Panel reruns continue to use `r` and create a new panel run.

Closes #578
