### PR TITLE
fix(agent): bind Antigravity reviews to worktree

### DIFF
--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -254,6 +254,11 @@ func (a *GeminiAgent) runAntigravity(ctx context.Context, repoPath, prompt strin
 		return "", "", err
 	}
 
+	// Antigravity tools need an explicit workspace root. cmd.Dir controls the
+	// process cwd, but the CLI resolves its tool workspace separately and can
+	// fall back to its scratch directory for ephemeral worktrees.
+	args = append(append([]string(nil), args...), "--add-dir", repoPath)
+
 	// Choose the prompt-carrying flag by agy version: >= 1.1.1 takes the prompt
 	// as the value of --prompt (stdin is ignored when a prompt flag is present);
 	// older agy reads it from stdin with a bare --print. A bare --print on new

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -187,6 +187,40 @@ echo "Review after settings merge"
 	assert.NotContains(t, argsOut, "--dangerously-skip-permissions\n")
 }
 
+func TestGeminiAntigravityReviewAddsRepositoryWorkspace(t *testing.T) {
+	skipIfWindows(t)
+
+	repoPath := filepath.Join(t.TempDir(), "ci-worktree")
+	require.NoError(t, os.Mkdir(repoPath, 0o755))
+	argsFile := filepath.Join(t.TempDir(), "args")
+	pwdFile := filepath.Join(t.TempDir(), "pwd")
+	t.Setenv("ARGS_FILE", argsFile)
+	t.Setenv("PWD_FILE", pwdFile)
+
+	scriptPath := writeTempCommand(t, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo "1.1.1"; exit 0; fi
+pwd > "$PWD_FILE"
+printf '%s\n' "$@" > "$ARGS_FILE"
+echo "Workspace review"
+`)
+	a := NewGeminiAgent(filepath.Join(filepath.Dir(scriptPath), "agy"))
+	require.NoError(t, os.Rename(scriptPath, a.Command))
+
+	res, err := a.Review(context.Background(), repoPath, "sha", "prompt", &bytes.Buffer{})
+	require.NoError(t, err)
+	assert.Equal(t, "Workspace review", res)
+
+	argsBytes, readErr := os.ReadFile(argsFile)
+	require.NoError(t, readErr)
+	args := strings.Split(strings.TrimSpace(string(argsBytes)), "\n")
+	assertFlagValue(t, args, "--add-dir", repoPath)
+	assert.NotContains(t, args, "--project")
+
+	pwdBytes, readErr := os.ReadFile(pwdFile)
+	require.NoError(t, readErr)
+	assert.Equal(t, repoPath+"\n", string(pwdBytes))
+}
+
 func TestGeminiAntigravityReviewStopsWhenSettingsLockCanceled(t *testing.T) {
 	skipIfWindows(t)
 


### PR DESCRIPTION
## Summary
Antigravity review jobs now register the exact review worktree with `--add-dir`, so provider tools resolve the isolated job workspace while the existing child working directory remains unchanged. A focused test verifies the workspace argument, preserves the child cwd, and ensures no persistent project selector is introduced.

### Tracker linkage
- Linear: none — no tracker was supplied for this RoboRev adapter fix.
- Bead: none — this fork has no Beads database.

## Before / after

| Flow | Before | After |
| --- | --- | --- |
| Antigravity review in an isolated worktree | The process cwd was set, but the provider workspace was implicit. | The exact worktree is passed through `--add-dir` and remains the process cwd. |

## Breaking and irreversible changes

- **Behavioral:** Antigravity tools receive the review worktree as an explicit workspace root.
- **Compile-time:** No public API or type changes.
- **Durable state and rollback:** No persisted state or migration. Reverting the commit restores the prior invocation behavior.

## Deliberate boundaries

This change does not select a persistent Antigravity project, alter model/provider routing, change cancellation, or modify global workspace trust configuration.

## Verification

- `go test ./internal/agent -run '^TestGeminiAntigravityReviewAddsRepositoryWorkspace$' -count=1`
- `go test ./internal/agent -count=1`
- `go test ./...`
- `go vet ./internal/agent`
- `git diff --check main...HEAD`
