### PR TITLE
fix(tui): distinguish panel reviewers in queue and detail views

### DIFF
--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -3016,6 +3016,13 @@ func TestQueueShowsPanelMemberNamesWithSameReviewType(t *testing.T) {
 				makeJob(11, withRef("abcdef0"), withPanelMember("R", "bugs", 0)),
 				makeJob(12, withRef("abcdef0"), withPanelMember("R", "maintainability", 1)),
 			}
+			for _, row := range m.visibleQueueRows() {
+				if row.depth == 1 {
+					cells := m.queueFullRowCells(row, true, false)
+					assert.Equal(t, row.job.PanelMemberName, cells[colReviewType])
+					assert.Equal(t, queueTreeSlot(row, false)+"abcdef0", cells[colRef])
+				}
+			}
 			output := stripTestANSI(m.renderQueueView())
 			assert.Contains(t, output, "bugs")
 			assert.Contains(t, output, "maintainability")

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -3006,6 +3006,23 @@ func seededPanelModel(t *testing.T) model {
 	return m
 }
 
+func TestQueueShowsPanelMemberNamesWithSameReviewType(t *testing.T) {
+	for _, width := range []int{120, 180} {
+		t.Run(fmt.Sprintf("width_%d", width), func(t *testing.T) {
+			m := seededPanelModel(t)
+			m.width = width
+			m.expandedPanels[testUUID("R")] = true
+			m.panelMembers[testUUID("R")] = []storage.ReviewJob{
+				makeJob(11, withRef("abcdef0"), withPanelMember("R", "bugs", 0)),
+				makeJob(12, withRef("abcdef0"), withPanelMember("R", "maintainability", 1)),
+			}
+			output := stripTestANSI(m.renderQueueView())
+			assert.Contains(t, output, "bugs")
+			assert.Contains(t, output, "maintainability")
+		})
+	}
+}
+
 func TestSelectedJobResolvesMember(t *testing.T) {
 	m := seededPanelModel(t)
 	m.expandedPanels[testUUID("R")] = true

--- a/cmd/roborev/tui/queue_test.go
+++ b/cmd/roborev/tui/queue_test.go
@@ -3026,6 +3026,11 @@ func TestQueueShowsPanelMemberNamesWithSameReviewType(t *testing.T) {
 			output := stripTestANSI(m.renderQueueView())
 			assert.Contains(t, output, "bugs")
 			assert.Contains(t, output, "maintainability")
+			for _, paneWidth := range []int{48, 58} {
+				pane := stripTestANSI(strings.Join(m.renderQueuePaneBody(paneWidth, 20), "\n"))
+				assert.Contains(t, pane, "bugs")
+				assert.Contains(t, pane, "maintainability")
+			}
 		})
 	}
 }

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -80,15 +80,10 @@ func queueTreeSlot(r queueRow, color bool) string {
 	return disclosureGlyph(r.hasChildren, r.expanded, color) + " "
 }
 
-// decorateRefCell prefixes the ref cell with the tree slot and member name,
-// or appends the live/terminal panel status for a parent. Names and summary
-// text are sanitized for the single-line cell.
+// decorateRefCell prefixes the ref cell with the tree slot and, for a panel
+// parent, appends the live/terminal panel status cell. The summary text is
+// sanitized so it cannot inject terminal escapes into the single-line cell.
 func decorateRefCell(ref string, r queueRow, color bool) string {
-	if r.depth == 1 {
-		if name := stripControlChars(r.job.PanelMemberName); name != "" {
-			ref = name + "  " + ref
-		}
-	}
 	ref = queueTreeSlot(r, color) + ref
 	if r.depth == 0 && r.hasChildren {
 		if cell := stripControlChars(panelStatusCell(r.job)); cell != "" {
@@ -1037,6 +1032,11 @@ func (m model) jobCells(job storage.ReviewJob) []string {
 		agentName = "claude"
 	}
 	reviewType := displayReviewType(job.ReviewType, job.PanelRole)
+	if job.PanelRole == storage.PanelRoleMember {
+		if name := stripControlChars(job.PanelMemberName); name != "" {
+			reviewType = name
+		}
+	}
 
 	enqueued := job.EnqueuedAt.Local().Format("Jan 02 15:04")
 

--- a/cmd/roborev/tui/render_queue.go
+++ b/cmd/roborev/tui/render_queue.go
@@ -80,10 +80,15 @@ func queueTreeSlot(r queueRow, color bool) string {
 	return disclosureGlyph(r.hasChildren, r.expanded, color) + " "
 }
 
-// decorateRefCell prefixes the ref cell with the tree slot and, for a panel
-// parent, appends the live/terminal panel status cell. The summary text is
-// sanitized so it cannot inject terminal escapes into the single-line cell.
+// decorateRefCell prefixes the ref cell with the tree slot and member name,
+// or appends the live/terminal panel status for a parent. Names and summary
+// text are sanitized for the single-line cell.
 func decorateRefCell(ref string, r queueRow, color bool) string {
+	if r.depth == 1 {
+		if name := stripControlChars(r.job.PanelMemberName); name != "" {
+			ref = name + "  " + ref
+		}
+	}
 	ref = queueTreeSlot(r, color) + ref
 	if r.depth == 0 && r.hasChildren {
 		if cell := stripControlChars(panelStatusCell(r.job)); cell != "" {

--- a/cmd/roborev/tui/render_review.go
+++ b/cmd/roborev/tui/render_review.go
@@ -66,6 +66,16 @@ func (m model) reviewContentString(review *storage.Review) string {
 	return content.String()
 }
 
+func reviewTypeMetadata(job storage.ReviewJob) string {
+	label := "Review type: " + displayReviewType(job.ReviewType, job.PanelRole)
+	if job.PanelRole == storage.PanelRoleMember {
+		if name := stripControlChars(job.PanelMemberName); name != "" {
+			label = "Reviewer: " + name + " | " + label
+		}
+	}
+	return label
+}
+
 func (m model) renderReviewView() string {
 	var b strings.Builder
 
@@ -120,7 +130,7 @@ func (m model) renderReviewView() string {
 			tokenSummary = tu.FormatSummary()
 		}
 		var metadata strings.Builder
-		metadata.WriteString(statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType, review.Job.PanelRole)))
+		metadata.WriteString(statusStyle.Render(reviewTypeMetadata(*review.Job)))
 		metadata.WriteString(statusStyle.Render(" | Reasoning: " + displayReasoning(review.Job.Reasoning)))
 		if hasVerdict {
 			metadata.WriteString(" ")

--- a/cmd/roborev/tui/review_render_test.go
+++ b/cmd/roborev/tui/review_render_test.go
@@ -445,6 +445,23 @@ func TestRenderReviewShowsReviewType(t *testing.T) {
 	assert.Contains(t, out, "Review type: project-conventions")
 }
 
+func TestReviewDetailsIdentifyPanelMember(t *testing.T) {
+	for _, name := range []string{"bugs", "maintainability"} {
+		t.Run(name, func(t *testing.T) {
+			job := makeJob(42, withPanelMember("R", name, 0), withReviewType("default"))
+			m := setupRenderModel(viewReview, makeReview(1, &job, withReviewOutput("Review output")))
+			for _, output := range []string{
+				m.renderReviewView(),
+				strings.Join(m.reviewPaneHeaderLines(120), "\n"),
+				strings.Join(m.renderJobStatusCard(job, 120), "\n"),
+			} {
+				assert.Contains(t, stripANSI(output), "Reviewer: "+name)
+				assert.Contains(t, stripANSI(output), "Review type: default")
+			}
+		})
+	}
+}
+
 func TestRenderReviewMetadataFitsTerminalWidth(t *testing.T) {
 	reviewType := strings.Repeat("a", 64)
 	verdict := "P"

--- a/cmd/roborev/tui/split_detail_pane.go
+++ b/cmd/roborev/tui/split_detail_pane.go
@@ -36,7 +36,7 @@ func (m model) reviewPaneHeaderLines(innerW int) []string {
 	out = append(out, xansi.Truncate(titleStyle.Render(title), innerW, ""))
 
 	verdictParts := []string{
-		statusStyle.Render("Review type: " + displayReviewType(review.Job.ReviewType, review.Job.PanelRole)),
+		statusStyle.Render(reviewTypeMetadata(*review.Job)),
 		statusStyle.Render("| Reasoning: " + displayReasoning(review.Job.Reasoning)),
 	}
 	if review.Job.Verdict != nil && *review.Job.Verdict != "" && !review.Job.IsFixJob() {
@@ -318,6 +318,9 @@ func (m model) renderJobStatusCard(job storage.ReviewJob, innerW int) []string {
 	add("Ref", shortJobRef(job))
 	add("Branch", m.getBranchForJob(job))
 	add("Agent", formatAgentLabel(job.Agent, job.Model))
+	if job.PanelRole == storage.PanelRoleMember {
+		add("Reviewer", stripControlChars(job.PanelMemberName))
+	}
 	add("Review type", displayReviewType(job.ReviewType, job.PanelRole))
 	if job.StartedAt != nil {
 		add("Elapsed", m.jobElapsedCell(job))

--- a/cmd/roborev/tui/split_queue_pane.go
+++ b/cmd/roborev/tui/split_queue_pane.go
@@ -3,12 +3,19 @@ package tui
 // queuePaneColumns returns the visible queue columns that fit paneW,
 // dropping from the end of the user's configured column order (rightmost-
 // configured drops first). colSel, colJobID, and colRef always survive.
+// Expanded panel members also retain colReviewType to identify each reviewer.
 // Estimation: fixed columns use their minimum fixed widths; flex columns
 // (ref/branch/repo) count a floor of min(content, 12); +1 spacing per
 // non-first column. This mirrors renderQueueTable's sizing closely enough
 // to decide fit; renderQueueTable does the exact layout afterward.
 func (m model) queuePaneColumns(paneW int, contentWidth map[int]int) []int {
 	core := map[int]bool{colSel: true, colJobID: true, colRef: true}
+	for _, row := range m.visibleQueueRows() {
+		if row.depth == 1 {
+			core[colReviewType] = true
+			break
+		}
+	}
 	estimate := func(c int) int {
 		w := contentWidth[c]
 		switch c {

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -79,6 +79,11 @@ state. Normal job lists and `roborev list` show the synthesis parent as the
 actionable review. The TUI can expand that parent row to inspect individual
 reviewers.
 
+Expanded member rows show the configured reviewer name before the ref. The
+Review Type column shows the base review type, so members with different
+additional instructions can both show `default`. Use the reviewer names to tell
+them apart, and press `p` on a member to inspect its prompt.
+
 The parent review is what you close, fix, cancel, rerun, and wait on. Member
 jobs are implementation details for the panel run. Rerunning the parent starts a
 fresh panel run; member rows cannot be rerun directly.

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -82,7 +82,8 @@ reviewers.
 For expanded panel members, the Review Type column shows the configured reviewer
 name so members with different instructions are distinguishable even when they
 share a base review type. Standalone reviews show their review type as usual.
-Press `p` on a member to inspect its prompt.
+Press `p` on a member to inspect its prompt. The review detail view, split pane,
+and job status card also show the reviewer name alongside the base review type.
 
 The parent review is what you close, fix, cancel, rerun, and wait on. Member
 jobs are implementation details for the panel run. Rerunning the parent starts a

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -79,10 +79,10 @@ state. Normal job lists and `roborev list` show the synthesis parent as the
 actionable review. The TUI can expand that parent row to inspect individual
 reviewers.
 
-Expanded member rows show the configured reviewer name before the ref. The
-Review Type column shows the base review type, so members with different
-additional instructions can both show `default`. Use the reviewer names to tell
-them apart, and press `p` on a member to inspect its prompt.
+For expanded panel members, the Review Type column shows the configured reviewer
+name so members with different instructions are distinguishable even when they
+share a base review type. Standalone reviews show their review type as usual.
+Press `p` on a member to inspect its prompt.
 
 The parent review is what you close, fix, cancel, rerun, and wait on. Member
 jobs are implementation details for the panel run. Rerunning the parent starts a

--- a/docs/integrations/tui.md
+++ b/docs/integrations/tui.md
@@ -238,9 +238,11 @@ separately from the model. It is visible by default. Jobs with no recorded
 reasoning show `—`.
 
 The Review Type column identifies standard reviews as `default` and shows the
-configured name for specialized or custom reviews. The review detail view shows
-the same value in its metadata header. Panel synthesis rows show `panel`, while
-expanded panel members show their configured review types.
+configured name for specialized or custom reviews. Panel synthesis rows show
+`panel`, while expanded panel members show their configured reviewer names. This
+column stays visible during automatic narrowing while panel members are
+expanded. Review details show the base review type and a separate `Reviewer:`
+label for panel members.
 
 The queue displays two separate status columns:
 


### PR DESCRIPTION
Panel members with different instructions could both appear as `default` in the TUI, making them difficult to distinguish even after opening their reviews.

Expanded member rows now show the configured reviewer name in the Review Type column. Full review details, split-pane details, and job status cards show a `Reviewer:` label alongside the underlying review type. This uses existing job metadata and does not change prompt selection.
