### PR TITLE
Select review and panel models by project remote

### DIFF
--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -234,7 +234,7 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 	// Load configs (warn on error, don't fail). Repository configuration and
 	// its relative custom-review files come from the trusted side of the
 	// reviewed range, never from the checkout under review.
-	globalCfg := loadCIGlobalConfig(root)
+	globalCfg := loadCIGlobalConfig(root).ForRepo(root)
 	repoCfgRef, refErr := trustedCIRepoConfigRef(root, gitRef)
 	if refErr != nil {
 		// Preserve the flag-validation diagnostic when a plainly unknown type

--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -352,6 +352,7 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 	comment, synthErr := review.Synthesize(
 		ctx, results, review.SynthesizeOpts{
 			Agent:        synthAgent,
+			Model:        config.ResolveCISynthesisModel(globalCfg),
 			MinSeverity:  ciMinSev,
 			RepoPath:     root,
 			GitRef:       gitRef,

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -46,7 +46,7 @@ func TestCIReviewSynthesisModel(t *testing.T) {
 			require.NoError(t, os.WriteFile(scriptPath, []byte(`#!/bin/sh
 for arg in "$@"; do
   if [ "$arg" = "--help" ]; then
-    printf '%s\n' '--sandbox --output-schema --ignore-user-config'
+    printf '%s\n' '--sandbox --output-schema --ignore-user-config --dangerously-bypass-approvals-and-sandbox'
     exit 0
   fi
 done

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,8 +18,75 @@ import (
 	"go.kenn.io/roborev/internal/config"
 	glpkg "go.kenn.io/roborev/internal/gitlab"
 	"go.kenn.io/roborev/internal/review"
+	"go.kenn.io/roborev/internal/testenv"
 	"go.kenn.io/roborev/internal/testutil"
 )
+
+func TestCIReviewSynthesisModel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("synthetic synthesis agent uses a POSIX shell script")
+	}
+	for _, tt := range []struct {
+		name, host, globalModel, projectModel, want string
+	}{
+		{"agent default", "github.com", "", "", ""},
+		{"global CI model", "github.com", "ci-synthesis", "", "ci-synthesis"},
+		{"GitHub project model", "github.com", "ci-synthesis", "project-synthesis", "project-synthesis"},
+		{"GitLab project model", "gitlab.example.com", "ci-synthesis", "project-synthesis", "project-synthesis"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clearForgeCIEnv(t)
+			dataDir := testenv.SetDataDir(t)
+			repo := testutil.NewTestRepoWithCommit(t)
+			repo.AddRemote("origin", "https://"+tt.host+"/example/project-a.git")
+			t.Chdir(repo.Path())
+			modelPath := filepath.Join(dataDir, "synthesis-model")
+			t.Setenv("TEST_CI_SYNTHESIS_MODEL", modelPath)
+			scriptPath := filepath.Join(dataDir, "codex-fixture")
+			require.NoError(t, os.WriteFile(scriptPath, []byte(`#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "--help" ]; then
+    printf '%s\n' '--sandbox --output-schema --ignore-user-config'
+    exit 0
+  fi
+done
+model=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-m" ]; then
+    shift
+    model="$1"
+  fi
+  shift
+done
+printf '%s' "$model" > "$TEST_CI_SYNTHESIS_MODEL"
+cat > /dev/null
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"schema_version\":2,\"summary\":\"Combined test reviews\",\"verdict\":\"pass\",\"findings\":[]}"}}'
+`), 0o755))
+			cfg := fmt.Sprintf(`
+default_model = "unrelated-review-model"
+codex_cmd = %q
+[ci]
+synthesis_model = %q
+[projects.%q]
+synthesis_model = %q
+`, scriptPath, tt.globalModel, tt.host+"/example/project-a", tt.projectModel)
+			require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte(cfg), 0o600))
+			args := []string{"review", "--ref", "HEAD", "--agent", "test", "--review-types", "default,security", "--synthesis-agent", "codex"}
+			if tt.host == "gitlab.example.com" {
+				args = append(args, "--gl-repo", "example/project-a")
+			} else {
+				args = append(args, "--gh-repo", "example/project-a")
+			}
+			cmd := ciCmd()
+			cmd.SetArgs(args)
+			output := captureOutput(t, cmd.Execute)
+			assert.Contains(t, output, "Combined test reviews")
+			model, err := os.ReadFile(modelPath)
+			require.NoError(t, err, "synthesis must invoke the agent")
+			assert.Equal(t, tt.want, string(model))
+		})
+	}
+}
 
 func installFakeGHAuthToken(t *testing.T, token string) {
 	t.Helper()

--- a/cmd/roborev/tui/fetch.go
+++ b/cmd/roborev/tui/fetch.go
@@ -435,7 +435,7 @@ func (m model) fetchRepoNames() tea.Cmd {
 		names := make(map[string][]string)
 		identities := make(map[string][]string)
 		for _, r := range result.Repos {
-			displayName := config.GetDisplayName(r.RootPath)
+			displayName := config.GetDisplayName(r.RootPath, m.globalCfg)
 			if displayName == "" {
 				displayName = r.Name
 			}
@@ -462,7 +462,7 @@ func (m model) fetchRepos() tea.Cmd {
 		identities := make(map[string][]string)
 		var displayNameOrder []string // Preserve order for stable display
 		for _, r := range reposResult.Repos {
-			displayName := config.GetDisplayName(r.RootPath)
+			displayName := config.GetDisplayName(r.RootPath, m.globalCfg)
 			if displayName == "" {
 				displayName = r.Name
 			}

--- a/cmd/roborev/tui/filter.go
+++ b/cmd/roborev/tui/filter.go
@@ -238,7 +238,7 @@ func (m *model) reconcileAutoRepoFilter() bool {
 		rootPaths = m.repoIdentities[m.cwdRepoIdentity]
 	}
 	if len(rootPaths) == 0 {
-		displayName := config.GetDisplayName(m.cwdRepoRoot)
+		displayName := config.GetDisplayName(m.cwdRepoRoot, m.globalCfg)
 		if displayName == "" {
 			displayName = filepath.Base(m.cwdRepoRoot)
 		}

--- a/cmd/roborev/tui/project_names_test.go
+++ b/cmd/roborev/tui/project_names_test.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
+)
+
+func TestProjectDisplayNameGroupsBareWorktrees(t *testing.T) {
+	assert := assert.New(t)
+	repo := testutil.NewTestRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "project.git")
+	repo.Run("clone", "--bare", repo.Path(), bare)
+	repo.Run("-C", bare, "remote", "set-url", "origin", "git@example.com:team/project-a.git")
+	var repos []storage.RepoWithCount
+	var paths []string
+	for _, branch := range []string{"feature-a", "feature-b"} {
+		wt := filepath.Join(t.TempDir(), branch)
+		repo.Run("-C", bare, "worktree", "add", "-b", branch, wt)
+		paths = append(paths, wt)
+		repos = append(repos, storage.RepoWithCount{Name: branch, RootPath: wt, Count: 1})
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"repos": repos})
+	}))
+	t.Cleanup(server.Close)
+	m := newModel(testEndpointFromURL(server.URL), withExternalIODisabled())
+	m.globalCfg = &config.Config{Projects: map[string]config.ProjectConfig{
+		"example.com/team/project-a": {DisplayName: "Project A"},
+	}}
+	msg := m.fetchRepos()()
+	result, ok := msg.(reposMsg)
+	require.True(t, ok, "unexpected message: %T", msg)
+	require.Len(t, result.repos, 1)
+	assert.Equal("Project A", result.repos[0].name)
+	assert.ElementsMatch(paths, result.repos[0].rootPaths)
+	assert.Equal(2, result.repos[0].count)
+	names, ok := m.fetchRepoNames()().(repoNamesMsg)
+	require.True(t, ok)
+	assert.ElementsMatch(paths, names.names["Project A"])
+}

--- a/cmd/roborev/tui/tui.go
+++ b/cmd/roborev/tui/tui.go
@@ -1131,7 +1131,7 @@ func (m *model) getDisplayName(repoPath, defaultName string) string {
 		return defaultName
 	}
 	// Cache miss - load from config (handles reviews for repos not in jobs list)
-	displayName := config.GetDisplayName(repoPath)
+	displayName := config.GetDisplayName(repoPath, m.globalCfg)
 	m.displayNames[repoPath] = displayName
 	if displayName != "" {
 		return displayName
@@ -1144,7 +1144,7 @@ func (m *model) getDisplayName(repoPath, defaultName string) string {
 func (m *model) updateDisplayNameCache(jobs []storage.ReviewJob) {
 	for _, repoPath := range uniqueJobRepoPaths(jobs) {
 		// Always refresh to pick up config changes
-		m.displayNames[repoPath] = config.GetDisplayName(repoPath)
+		m.displayNames[repoPath] = config.GetDisplayName(repoPath, m.globalCfg)
 	}
 }
 

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -123,6 +123,13 @@ analysis tasks, `compact`, and `insights`, do not fan out into panels.
 
 ## Configuration Reference
 
+To change all primary member models for selected projects without duplicating
+panels, use global
+[project model overrides](/docs/configuration/#overriding-panel-models).
+`override_panel_models = true` makes the project's `review_model` override each
+member's model, including security and design reviewers. An optional project
+`synthesis_model` overrides synthesis separately.
+
 ### Review Table
 
 | Key | Type | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,13 +132,44 @@ checkout directory name, branch name, or `.roborev-id`. The optional
 `display_name` groups these checkouts under one project name in the TUI and its
 repository filter. An explicit repository `display_name` takes precedence.
 
-Project `review_model` applies to ordinary reviews at every reasoning level,
-including reviews from hooks and default-type panel/CI members that inherit a
-model. CLI models, experiment overrides, repository models, and explicit panel
-member models keep their priority. The project model takes precedence over
-global `review_model_<level>`, `review_model`, and `default_model`. Unmatched
-projects keep the general global defaults. Other workflows (such as fix,
-security, and design) and backup models retain their existing settings.
+By default, project `review_model` applies to ordinary reviews at every
+reasoning level, including reviews from hooks and default-type panel/CI members
+that inherit a model. CLI models, experiment overrides, repository models, and
+explicit panel member models keep their priority. The project model takes
+precedence over global `review_model_<level>`, `review_model`, and
+`default_model`. Unmatched projects keep the general global defaults. Other
+standalone workflows (such as fix, security, and design) retain their existing
+settings.
+
+### Overriding Panel Models
+
+A panel can pin a model on each member, so changing `default_model` or a project
+default alone will not change those members. To use a different model for all
+primary reviewers of selected projects, explicitly enable the override:
+
+```toml
+[projects."github.com/example/project-a"]
+review_model = "gpt-5.6-sol"
+override_panel_models = true
+synthesis_model = "gpt-6-astra" # Optional, independent synthesis override
+```
+
+`override_panel_models = true` makes the project `review_model` take precedence
+over individual panel member models and workflow defaults, including member
+models supplied by repository configuration or experiments. It applies to every
+review type, including security, design, and custom types, in both local and CI
+panels. The daemon CI poller's review matrices and automatically added design
+members follow the same policy. Enabling it without a nonempty project
+`review_model` is an error.
+
+The separate project `synthesis_model`, when set, overrides a panel's explicit
+`synthesis_model` or the CI synthesis setting. It does not require
+`override_panel_models`. When omitted, synthesis keeps its existing resolution;
+changing reviewer models alone does not change synthesis.
+
+These settings change models, not agents or providers. Use a model accepted by
+each affected agent when overriding a mixed-agent panel. Backup models retain
+their existing failover behavior. Settings for other projects are unaffected.
 
 ## Per-Repository Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,10 @@ The separate project `synthesis_model`, when set, overrides a panel's explicit
 `override_panel_models`. When omitted, synthesis keeps its existing resolution;
 changing reviewer models alone does not change synthesis.
 
+Daemon-free `roborev ci review` also honors the project `synthesis_model`, ahead
+of global `[ci].synthesis_model`, in GitHub and GitLab CI runs. If neither is
+set, it leaves synthesis model selection to the agent.
+
 These settings change models, not agents or providers. Use a model accepted by
 each affected agent when overriding a mixed-agent panel. Backup models retain
 their existing failover behavior. Settings for other projects are unaffected.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,7 @@ roborev uses a layered configuration system. Settings are resolved in this order
 1. **CLI flags** (`--agent`, `--model`, `--reasoning`)
 1. **Experiment overlay** for an enrolled review
 1. **Per-repo** `.roborev.toml` in your repository root
+1. **Project defaults** in global `projects` tables, matched by Git remote
 1. **Global** `~/.roborev/config.toml`
 1. **Defaults** (auto-detect agent, thorough reasoning for reviews)
 
@@ -96,6 +97,48 @@ overlays before any review is queued. The merged command also checks repository
 enablement overrides against their global experiment definitions. All complete
 experiment definitions are checked, including disabled experiments, so a new
 definition can be validated before it is enabled.
+
+## Project Defaults by Git Remote
+
+To use a different review model for selected projects without editing each
+checkout, add project tables to `~/.roborev/config.toml`:
+
+```toml
+review_model = "gpt-5.6-luna"
+
+[projects."github.com/example/project-a"]
+review_model = "gpt-5.6-sol"
+display_name = "Project A"
+
+[projects."github.com/example/project-b"]
+review_model = "gpt-6-astra"
+display_name = "Project B"
+```
+
+Edit these tables directly in TOML; `config set` does not traverse project map
+entries. Put top-level settings before the tables, as required by TOML.
+
+The table key is `host/owner/repository`, without a URL scheme, SSH username, or
+`.git` suffix. Matching uses `origin`, falling back to another remote when there
+is no origin. SSH and HTTPS URLs match the same key. Hostnames are lowercase;
+repository paths are case-sensitive. For example,
+`git@github.com:example/project-a.git` and
+`https://github.com/example/project-a.git` both match the first entry above.
+Repositories with only local-path remotes do not match these tables.
+
+Every checkout with that remote receives the same project settings, including
+linked worktrees created from a bare repository. Matching does not depend on the
+checkout directory name, branch name, or `.roborev-id`. The optional
+`display_name` groups these checkouts under one project name in the TUI and its
+repository filter. An explicit repository `display_name` takes precedence.
+
+Project `review_model` applies to ordinary reviews at every reasoning level,
+including reviews from hooks and default-type panel/CI members that inherit a
+model. CLI models, experiment overrides, repository models, and explicit panel
+member models keep their priority. The project model takes precedence over
+global `review_model_<level>`, `review_model`, and `default_model`. Unmatched
+projects keep the general global defaults. Other workflows (such as fix,
+security, and design) and backup models retain their existing settings.
 
 ## Per-Repository Configuration
 

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -716,6 +716,13 @@ does not rewrite the retry's configured review plan.
 
 ## Per-Repo Overrides
 
+To select models for repositories centrally, add
+[project overrides](/docs/configuration/#overriding-panel-models) to the
+daemon's global config. Set `review_model` and `override_panel_models = true`
+for each selected Git remote to replace even explicitly pinned panel member
+models. The optional project `synthesis_model` controls synthesis independently.
+These overrides apply to named panels and the implicit CI matrix.
+
 Individual repos can override the global CI settings by adding a `[ci]` section
 to their `.roborev.toml` file. This lets you run different panels, agents,
 review types, or reasoning levels for different repos.

--- a/internal/agent/model_resolution.go
+++ b/internal/agent/model_resolution.go
@@ -30,6 +30,7 @@ func ResolveWorkflowConfig(
 	globalCfg *config.Config,
 	workflow, reasoning string,
 ) (WorkflowConfig, error) {
+	globalCfg = globalCfg.ForRepo(repoPath)
 	repoCfg, _ := config.LoadRepoConfig(repoPath)
 	resolution, err := ResolveWorkflowConfigFromConfig(
 		cliAgent, repoCfg, globalCfg, workflow, reasoning,
@@ -220,6 +221,7 @@ func ResolveWorkflowModelForAgent(
 	globalCfg *config.Config,
 	workflow, level string,
 ) string {
+	globalCfg = globalCfg.ForRepo(repoPath)
 	repoCfg, _ := config.LoadRepoConfig(repoPath)
 	return ResolveWorkflowModelForAgentFromConfig(
 		selectedAgent, cliModel, repoCfg, globalCfg, workflow, level,

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -661,6 +661,17 @@ func ResolveCISynthesisAgent(
 	return resolve("", strings.TrimSpace(explicit), globalVal)
 }
 
+// ResolveCISynthesisModel returns the configured synthesis model override.
+// A scoped project override takes precedence over global [ci].synthesis_model.
+// An empty result leaves model selection to the synthesis agent.
+func ResolveCISynthesisModel(globalCfg *Config) string {
+	if globalCfg == nil {
+		return ""
+	}
+	return resolve("", strings.TrimSpace(globalCfg.project.SynthesisModel),
+		strings.TrimSpace(globalCfg.CI.SynthesisModel))
+}
+
 // ResolveCIUpsertComments determines whether CI should update an existing PR comment.
 // Priority: repo [ci].upsert_comments > global [ci].upsert_comments > false.
 func ResolveCIUpsertComments(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -531,6 +531,11 @@ func validateConfig(cfg any, acp ACPAgentConfigs) error {
 	var review ReviewConfig
 	switch typed := cfg.(type) {
 	case *Config:
+		for identity, project := range typed.Projects {
+			if project.OverridePanelModels && strings.TrimSpace(project.ReviewModel) == "" {
+				return fmt.Errorf("projects.%q: override_panel_models requires review_model", identity)
+			}
+		}
 		review = typed.Review
 	case *RepoConfig:
 		review = typed.Review

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -171,6 +171,10 @@ func (c CostConfig) ResolvedTimeout() time.Duration {
 
 // Config holds the daemon configuration
 type Config struct {
+	// project holds the remote-specific defaults selected by ForRepo.
+	project ProjectConfig
+
+	Projects                   map[string]ProjectConfig        `toml:"projects"`
 	ServerAddr                 string                          `toml:"server_addr"`
 	MaxWorkers                 int                             `toml:"max_workers"`
 	ReviewContextCount         int                             `toml:"review_context_count"`
@@ -1861,12 +1865,15 @@ func messageMatchesPatterns(
 }
 
 // GetDisplayName returns the display name for a repo, or empty if not set
-func GetDisplayName(repoPath string) string {
+func GetDisplayName(repoPath string, globalCfg *Config) string {
 	repoCfg, err := LoadRepoConfig(repoPath)
-	if err != nil || repoCfg == nil {
-		return ""
+	if err == nil && repoCfg != nil && strings.TrimSpace(repoCfg.DisplayName) != "" {
+		return repoCfg.DisplayName
 	}
-	return repoCfg.DisplayName
+	if cfg := globalCfg.ForRepo(repoPath); cfg != nil {
+		return strings.TrimSpace(cfg.project.DisplayName)
+	}
+	return ""
 }
 
 // ResolveModel determines which model to use based on config priority:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1553,7 +1553,7 @@ connect_timeout = "10s"
 func TestGetDisplayName(t *testing.T) {
 	t.Run("no config file", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		name := GetDisplayName(tmpDir)
+		name := GetDisplayName(tmpDir, nil)
 		if name != "" {
 			assert.Condition(t, func() bool {
 				return false
@@ -1563,7 +1563,7 @@ func TestGetDisplayName(t *testing.T) {
 
 	t.Run("display_name not set", func(t *testing.T) {
 		tmpDir := newTempRepo(t, `agent = "codex"`)
-		name := GetDisplayName(tmpDir)
+		name := GetDisplayName(tmpDir, nil)
 		if name != "" {
 			assert.Condition(t, func() bool {
 				return false
@@ -1573,7 +1573,7 @@ func TestGetDisplayName(t *testing.T) {
 
 	t.Run("display_name is set", func(t *testing.T) {
 		tmpDir := newTempRepo(t, `display_name = "My Cool Project"`)
-		name := GetDisplayName(tmpDir)
+		name := GetDisplayName(tmpDir, nil)
 		if name != "My Cool Project" {
 			assert.Condition(t, func() bool {
 				return false
@@ -1587,7 +1587,7 @@ agent = "claude-code"
 display_name = "Backend Service"
 excluded_branches = ["wip"]
 `)
-		name := GetDisplayName(tmpDir)
+		name := GetDisplayName(tmpDir, nil)
 		if name != "Backend Service" {
 			assert.Condition(t, func() bool {
 				return false

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -309,7 +309,7 @@ func ResolveCISynthesis(
 	panel := PanelSpec{}
 	if globalCfg != nil {
 		panel.SynthesisAgent = globalCfg.CI.SynthesisAgent
-		panel.SynthesisModel = globalCfg.CI.SynthesisModel
+		panel.SynthesisModel = ResolveCISynthesisModel(globalCfg)
 		panel.SynthesisBackupAgent = globalCfg.CI.SynthesisBackupAgent
 	}
 	synth, err := resolveSynthesisFromConfig(panel, repoCfg, globalCfg)

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -226,6 +226,7 @@ type SynthesisSpec struct {
 // panel is undefined, has no members, references an undefined subagent, or a
 // member has an invalid review_type/reasoning.
 func ResolvePanel(panelName, repoPath string, globalCfg *Config) ([]ResolvedMember, SynthesisSpec, error) {
+	globalCfg = globalCfg.ForRepo(repoPath)
 	merged := MergedReviewConfig(repoPath, globalCfg)
 	panel, ok := merged.Panels[panelName]
 	if !ok {

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -199,7 +199,7 @@ type ResolvedMember struct {
 	Agent         string `json:"agent"`
 	AgentExplicit bool   `json:"agent_explicit,omitempty"`
 	Model         string `json:"model"`
-	ModelExplicit bool   `json:"model_explicit,omitempty"`
+	ModelExplicit bool   `json:"model_explicit,omitempty"` // Set by a member model or project panel override.
 	Provider      string `json:"provider"`
 	Reasoning     string `json:"reasoning"`
 	ReviewType    string `json:"review_type"`
@@ -364,6 +364,7 @@ func resolveMemberFromConfig(
 		agent = ResolveAgentForWorkflowFromConfig("", repoCfg, globalCfg, workflow, reasoning)
 	}
 	model := spec.Model
+	modelExplicit := strings.TrimSpace(spec.Model) != ""
 	if model == "" {
 		if spec.Agent != "" {
 			model = resolveExplicitPanelAgentModelFromConfig(
@@ -373,13 +374,17 @@ func resolveMemberFromConfig(
 			model = ResolveModelForWorkflowFromConfig("", repoCfg, globalCfg, workflow, reasoning)
 		}
 	}
+	if override := globalCfg.PanelModelOverride(); override != "" {
+		model = override
+		modelExplicit = true
+	}
 	return ResolvedMember{
 		Name:          name,
 		Index:         index,
 		Agent:         agent,
 		AgentExplicit: strings.TrimSpace(spec.Agent) != "",
 		Model:         model,
-		ModelExplicit: strings.TrimSpace(spec.Model) != "",
+		ModelExplicit: modelExplicit,
 		Provider:      spec.Provider,
 		Reasoning:     reasoning,
 		ReviewType:    reviewType,
@@ -429,6 +434,11 @@ func resolveSynthesisFromConfig(
 		agent = ResolveAgentForWorkflowFromConfig("", repoCfg, globalCfg, "fix", reasoning)
 	}
 	model := panel.SynthesisModel
+	if globalCfg != nil {
+		if override := strings.TrimSpace(globalCfg.project.SynthesisModel); override != "" {
+			model = override
+		}
+	}
 	if model == "" {
 		_, configuredACP := ResolveACPAgentConfigFromConfig(
 			agent, repoCfg, globalCfg,

--- a/internal/config/projects.go
+++ b/internal/config/projects.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"net/url"
+	"strings"
+
+	"go.kenn.io/roborev/internal/git"
+)
+
+// ProjectConfig supplies machine-local defaults shared by checkouts of a remote.
+type ProjectConfig struct {
+	ReviewModel string `toml:"review_model"`
+	DisplayName string `toml:"display_name"`
+}
+
+// ForRepo returns global configuration scoped to the repository's remote.
+// It does not read tracked configuration or mutate the shared global config.
+// Callers resolving from already-loaded configs should scope their global
+// config here before passing it to the FromConfig helpers.
+func (c *Config) ForRepo(repoPath string) *Config {
+	if c == nil || len(c.Projects) == 0 || repoPath == "" {
+		return c
+	}
+	scoped := *c
+	scoped.project = c.Projects[projectRemoteIdentity(git.GetRemoteURL(repoPath, ""))]
+	return &scoped
+}
+
+// projectRemoteIdentity treats SSH and HTTPS transports as the same project.
+// Keep the repository path case-sensitive; only DNS hostnames ignore case.
+func projectRemoteIdentity(remote string) string {
+	remote = strings.TrimSpace(remote)
+	var host, repo string
+	if strings.Contains(remote, "://") {
+		u, err := url.Parse(remote)
+		if err != nil || u.Host == "" {
+			return ""
+		}
+		host, repo = u.Host, u.Path
+	} else {
+		// SCP-style remotes: [user@]host:owner/repository.git.
+		if _, after, ok := strings.Cut(remote, "@"); ok {
+			remote = after
+		}
+		var ok bool
+		host, repo, ok = strings.Cut(remote, ":")
+		if !ok || strings.ContainsAny(host, `/\`) {
+			return ""
+		}
+	}
+	repo = strings.TrimSuffix(strings.Trim(repo, "/"), ".git")
+	if host == "" || repo == "" {
+		return ""
+	}
+	return strings.ToLower(host) + "/" + repo
+}

--- a/internal/config/projects.go
+++ b/internal/config/projects.go
@@ -9,8 +9,19 @@ import (
 
 // ProjectConfig supplies machine-local defaults shared by checkouts of a remote.
 type ProjectConfig struct {
-	ReviewModel string `toml:"review_model"`
-	DisplayName string `toml:"display_name"`
+	ReviewModel         string `toml:"review_model"`
+	DisplayName         string `toml:"display_name"`
+	OverridePanelModels bool   `toml:"override_panel_models"`
+	SynthesisModel      string `toml:"synthesis_model"`
+}
+
+// PanelModelOverride returns the explicit project policy for primary panel
+// members, regardless of their review type or individual model setting.
+func (c *Config) PanelModelOverride() string {
+	if c == nil || !c.project.OverridePanelModels {
+		return ""
+	}
+	return strings.TrimSpace(c.project.ReviewModel)
 }
 
 // ForRepo returns global configuration scoped to the repository's remote.

--- a/internal/config/projects_test.go
+++ b/internal/config/projects_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -8,6 +9,70 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProjectPanelModelOverride(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		override  bool
+		synthesis string
+	}{
+		{name: "defaults"},
+		{name: "members", override: true},
+		{name: "synthesis", synthesis: "project-synthesis"},
+		{name: "members and synthesis", override: true, synthesis: "project-synthesis"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			var cfg Config
+			_, err := toml.Decode(fmt.Sprintf(`
+default_agent = "codex"
+default_model = "global-model"
+[projects."example.com/team/project-a"]
+review_model = "project-model"
+override_panel_models = %t
+synthesis_model = %q
+[review.subagents.general]
+agent = "codex"
+model = "member-model"
+[review.subagents.security-check]
+agent = "codex"
+model = "security-member-model"
+review_type = "security"
+[review.panels.panel-a]
+members = ["general", "security-check"]
+synthesis_agent = "codex"
+synthesis_model = "synthesis-model"
+`, tt.override, tt.synthesis), &cfg)
+			require.NoError(t, err)
+			root := t.TempDir()
+			execGit(t, root, "init")
+			execGit(t, root, "remote", "add", "origin", "https://example.com/team/project-a.git")
+			for _, ci := range []bool{false, true} {
+				var members []ResolvedMember
+				var synth SynthesisSpec
+				if ci {
+					members, synth, err = ResolveCIPanel("panel-a", nil, cfg.ForRepo(root))
+				} else {
+					members, synth, err = ResolvePanel("panel-a", root, &cfg)
+				}
+				require.NoError(t, err)
+				require.Len(t, members, 2)
+				if tt.override {
+					assert.Equal("project-model", members[0].Model)
+					assert.Equal("project-model", members[1].Model)
+				} else {
+					assert.Equal("member-model", members[0].Model)
+					assert.Equal("security-member-model", members[1].Model)
+				}
+				wantSynthesis := "synthesis-model"
+				if tt.synthesis != "" {
+					wantSynthesis = tt.synthesis
+				}
+				assert.Equal(wantSynthesis, synth.Model)
+			}
+		})
+	}
+}
 
 func TestProjectReviewModelWorktrees(t *testing.T) {
 	var cfg Config
@@ -66,5 +131,28 @@ func TestProjectRemoteIdentity(t *testing.T) {
 	}
 	for _, remote := range []string{"", "/tmp/project-a", "file:///tmp/project-a", "../project-a"} {
 		assert.Empty(t, projectRemoteIdentity(remote), remote)
+	}
+}
+
+func TestProjectPanelOverrideRequiresModel(t *testing.T) {
+	for _, model := range []string{"", "   ", "project-model"} {
+		cfg := DefaultConfig()
+		cfg.Projects = map[string]ProjectConfig{
+			"example.com/team/project-a": {OverridePanelModels: true, ReviewModel: model},
+		}
+		dir := t.TempDir()
+		writeTestFile(t, dir, "config.toml", fmt.Sprintf(`
+[projects."example.com/team/project-a"]
+override_panel_models = true
+review_model = %q
+`, model))
+		_, loadErr := LoadGlobalFrom(filepath.Join(dir, "config.toml"))
+		if model == "project-model" {
+			require.NoError(t, cfg.Validate())
+			require.NoError(t, loadErr)
+		} else {
+			require.ErrorContains(t, cfg.Validate(), "override_panel_models requires review_model")
+			require.ErrorContains(t, loadErr, "override_panel_models requires review_model")
+		}
 	}
 }

--- a/internal/config/projects_test.go
+++ b/internal/config/projects_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectReviewModelWorktrees(t *testing.T) {
+	var cfg Config
+	_, err := toml.Decode(`
+review_model = "default-review"
+review_model_thorough = "default-thorough"
+fix_model = "default-fix"
+[projects."example.com/team/project-a"]
+review_model = "project-review"
+display_name = "Project A"
+`, &cfg)
+	require.NoError(t, err)
+
+	for _, bare := range []bool{false, true} {
+		t.Run(map[bool]string{false: "regular", true: "bare"}[bare], func(t *testing.T) {
+			assert := assert.New(t)
+			root := t.TempDir()
+			execGit(t, root, "init")
+			execGit(t, root, "config", "user.name", "Test User")
+			execGit(t, root, "config", "user.email", "test@example.com")
+			execGit(t, root, "commit", "--allow-empty", "-m", "initial")
+			if bare {
+				bareRoot := filepath.Join(t.TempDir(), "project.git")
+				execGit(t, root, "clone", "--bare", root, bareRoot)
+				root = bareRoot
+				execGit(t, root, "remote", "remove", "origin")
+			}
+			execGit(t, root, "remote", "add", "origin", "git@example.com:team/project-a.git")
+			for _, branch := range []string{"feature-a", "feature-b"} {
+				wt := filepath.Join(t.TempDir(), branch)
+				execGit(t, root, "worktree", "add", "-b", branch, wt)
+				assert.Equal("project-review", ResolveModelForWorkflow("", wt, &cfg, "review", "thorough"))
+				assert.Equal("Project A", GetDisplayName(wt, &cfg))
+				assert.Equal("cli-review", ResolveModelForWorkflow("cli-review", wt, &cfg, "review", "thorough"))
+				assert.Equal("default-fix", ResolveModelForWorkflow("", wt, &cfg, "fix", "standard"))
+				writeRepoConfigStr(t, wt, "review_model = \"repo-review\"\ndisplay_name = \"Local name\"")
+				assert.Equal("repo-review", ResolveModelForWorkflow("", wt, &cfg, "review", "thorough"))
+				assert.Equal("Local name", GetDisplayName(wt, &cfg))
+			}
+			execGit(t, root, "remote", "set-url", "origin", "https://example.com/team/project-a.git")
+			assert.Equal("project-review", ResolveModelForWorkflow("", root, &cfg, "review", "fast"))
+			execGit(t, root, "remote", "set-url", "origin", "https://example.com/other/project-a.git")
+			assert.Equal("default-thorough", ResolveModelForWorkflow("", root, &cfg, "review", "thorough"))
+		})
+	}
+}
+
+func TestProjectRemoteIdentity(t *testing.T) {
+	for _, remote := range []string{
+		"git@example.com:team/project-a.git",
+		"ssh://git@EXAMPLE.COM/team/project-a.git",
+		"https://example.com/team/project-a/",
+		"https://user:password@example.com/team/project-a.git",
+	} {
+		assert.Equal(t, "example.com/team/project-a", projectRemoteIdentity(remote), remote)
+	}
+	for _, remote := range []string{"", "/tmp/project-a", "file:///tmp/project-a", "../project-a"} {
+		assert.Empty(t, projectRemoteIdentity(remote), remote)
+	}
+}

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -596,6 +596,7 @@ func HasWorkflowAgentOverrideFromConfig(
 // ResolveModelForWorkflow determines which model to use based on workflow and level.
 // Same priority as ResolveAgentForWorkflow, but returns empty string as default.
 func ResolveModelForWorkflow(cli, repoPath string, globalCfg *Config, workflow, level string) string {
+	globalCfg = globalCfg.ForRepo(repoPath)
 	repoCfg, _ := LoadRepoConfig(repoPath)
 	return ResolveModelForWorkflowFromConfig(cli, repoCfg, globalCfg, workflow, level)
 }
@@ -623,6 +624,7 @@ func ResolveModelForWorkflowFromConfig(
 // when the agent was overridden from a different source (e.g., CLI --agent)
 // and the generic model is likely paired with a different default agent.
 func ResolveWorkflowModel(repoPath string, globalCfg *Config, workflow, level string) string {
+	globalCfg = globalCfg.ForRepo(repoPath)
 	repoCfg, _ := LoadRepoConfig(repoPath)
 	return ResolveWorkflowModelFromConfig(repoCfg, globalCfg, workflow, level)
 }
@@ -978,6 +980,11 @@ func repoWorkflowField(r *RepoConfig, workflow, level string, isAgent bool) stri
 func globalWorkflowField(g *Config, workflow, level string, isAgent bool) string {
 	if g == nil {
 		return ""
+	}
+	if !isAgent && workflow == "review" {
+		if model := strings.TrimSpace(g.project.ReviewModel); model != "" {
+			return model
+		}
 	}
 	return lookupWorkflowField(reflect.ValueOf(*g), workflow, level, isAgent)
 }

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -537,6 +537,7 @@ func (p *CIPoller) enqueuePanelRun(ctx context.Context, ghRepo string, pr ghPR, 
 	}
 
 	// Load repo config off the PR's default branch (never the working tree, F1).
+	cfg = cfg.ForRepo(repo.RootPath)
 	repoConfig, err := p.loadCIRepoConfigFor(repo.RootPath, ghRepo)
 	if err != nil {
 		if config.IsExperimentConfigError(err) || config.IsConfigValidationError(err) {

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -974,6 +974,9 @@ func (p *CIPoller) resolveCIPanelMemberExecution(
 	if !member.ModelExplicit || !resolution.AgentMatches(resolvedAgent, member.Agent) {
 		model = resolution.ModelForSelectedAgent(resolvedAgent, "")
 	}
+	if override := cfg.PanelModelOverride(); override != "" && !resolution.UsesBackupAgent(resolvedAgent) {
+		model = override
+	}
 	backupAgent, backupModel := backupExecutionForSelectedAgent(
 		resolution, resolvedAgent, repoCfg, cfg,
 	)
@@ -1054,6 +1057,9 @@ func (p *CIPoller) resolveMatrixMemberAgent(
 	ciModel := cfg.CI.Model
 	if config.ExperimentOverridesWorkflowModel(repoCfg, workflow, reasoning) {
 		ciModel = ""
+	}
+	if override := cfg.PanelModelOverride(); override != "" && !resolution.UsesBackupAgent(resolvedAgent) {
+		ciModel = override
 	}
 	return resolvedAgent, resolution.ModelForSelectedAgent(resolvedAgent, ciModel),
 		backupAgent, backupModel, nil
@@ -1225,8 +1231,11 @@ func (p *CIPoller) maybeAppendDesignMember(
 		designAgent = agent.StorageNameFromConfig(designAgent, repoCfg, cfg)
 		var backupAgent, backupModel string
 		if resolution, err := agent.ResolveWorkflowConfigFromConfig(
-			designAgent, repoCfg, cfg, "design", reasoning,
+			"", repoCfg, cfg, "design", reasoning,
 		); err == nil {
+			if override := cfg.PanelModelOverride(); override != "" && !resolution.UsesBackupAgent(designAgent) {
+				designModel = override
+			}
 			backupAgent, backupModel = backupExecutionForSelectedAgent(
 				resolution, designAgent, repoCfg, cfg,
 			)

--- a/internal/daemon/ci_poller_test.go
+++ b/internal/daemon/ci_poller_test.go
@@ -3935,6 +3935,10 @@ func TestProcessPRCreatesPanelRun(t *testing.T) {
 func TestProcessPRAutoDesignUsesConfiguredBackupModel(t *testing.T) {
 	assert := assert.New(t)
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
+	repo.AddRemote("origin", "git@github.com:acme/api.git")
+	cfg.Projects = map[string]config.ProjectConfig{
+		"github.com/acme/api": {ReviewModel: "project-model", OverridePanelModels: true},
+	}
 
 	const primaryAgent = "ci-design-unavailable-primary"
 	agent.Register(&unavailableSynthesisCommandAgent{
@@ -4267,6 +4271,10 @@ func TestProcessPRNamedPanelACPMemberReplacesInheritedWorkflowModel(t *testing.T
 func TestProcessPRNamedPanelMemberUsesBackupModelWhenPreferredUnavailable(t *testing.T) {
 	assert := assert.New(t)
 	p, db, _, repo, cfg := newCIPanelGitHarness(t)
+	repo.AddRemote("origin", "git@github.com:acme/api.git")
+	cfg.Projects = map[string]config.ProjectConfig{
+		"github.com/acme/api": {ReviewModel: "project-model", OverridePanelModels: true},
+	}
 
 	const primaryAgent = "ci-panel-unavailable-primary"
 	agent.Register(&unavailableSynthesisCommandAgent{

--- a/internal/daemon/panel_enqueue.go
+++ b/internal/daemon/panel_enqueue.go
@@ -714,6 +714,9 @@ func resolvePanelMemberExecution(
 	if !m.ModelExplicit || !resolution.AgentMatches(selectedName, m.Agent) {
 		model = resolution.ModelForSelectedAgent(selectedName, "")
 	}
+	if override := cfg.PanelModelOverride(); override != "" && !resolution.UsesBackupAgent(selectedName) {
+		model = override
+	}
 	backupAgent, backupModel := backupExecutionForSelectedAgent(
 		resolution, selectedName, repoCfg, cfg,
 	)

--- a/internal/daemon/project_models_test.go
+++ b/internal/daemon/project_models_test.go
@@ -1,9 +1,14 @@
 package daemon
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +19,118 @@ import (
 	"go.kenn.io/roborev/internal/storage"
 	"go.kenn.io/roborev/internal/testutil"
 )
+
+func TestProjectPanelOverrideSurvivesAgentAutoDetection(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("minimal PATH setup uses POSIX symlink")
+	}
+	repo := testutil.NewTestRepoWithCommit(t)
+	repo.AddRemote("origin", "https://example.com/team/project-a.git")
+	cfg := config.DefaultConfig()
+	cfg.Projects = map[string]config.ProjectConfig{
+		"example.com/team/project-a": {ReviewModel: "project-model", OverridePanelModels: true},
+	}
+	cfg.CI.Panel = "panel-a"
+	cfg.Review = config.ReviewConfig{
+		Subagents: map[string]config.SubagentSpec{
+			"security-check": {ReviewType: "security"},
+		},
+		Panels: map[string]config.PanelSpec{
+			"panel-a": {Members: []string{"security-check"}, SynthesisAgent: "test"},
+		},
+	}
+	cfg = cfg.ForRepo(repo.Path())
+	members, _, err := config.ResolveCIPanel("panel-a", nil, cfg)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	gitPath, err := exec.LookPath("git")
+	require.NoError(t, err)
+	binDir := t.TempDir()
+	require.NoError(t, os.Symlink(gitPath, filepath.Join(binDir, "git")))
+	t.Setenv("PATH", binDir)
+	agent.Register(&agent.FakeAgent{NameStr: "project-panel-auto"})
+	t.Cleanup(func() { agent.Unregister("project-panel-auto") })
+
+	t.Run("local", func(t *testing.T) {
+		selected, model, _, _, err := resolvePanelMemberExecution(members[0], targetDescriptor{}, nil, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "project-panel-auto", selected)
+		assert.Equal(t, "project-model", model)
+	})
+	t.Run("CI", func(t *testing.T) {
+		p := &CIPoller{}
+		selected, model, _, _, err := p.resolveCIPanelMemberExecution(nil, cfg, members[0])
+		require.NoError(t, err)
+		assert.Equal(t, "project-panel-auto", selected)
+		assert.Equal(t, "project-model", model)
+	})
+}
+
+func TestCIPollerProjectPanelModelOverride(t *testing.T) {
+	for _, named := range []bool{false, true} {
+		for _, override := range []bool{false, true} {
+			t.Run(fmt.Sprintf("named=%t/override=%t", named, override), func(t *testing.T) {
+				assert := assert.New(t)
+				p, db, _, repo, cfg := newCIPanelGitHarness(t)
+				repo.AddRemote("origin", "git@github.com:acme/api.git")
+				cfg.CI.ReviewTypes = []string{"default", "security"}
+				cfg.CI.Model = "pinned-model"
+				cfg.CI.SynthesisModel = "pinned-synthesis"
+				cfg.AutoDesignReview.Enabled = true
+				cfg.DesignAgent = "test"
+				project := config.ProjectConfig{ReviewModel: "project-model", OverridePanelModels: override}
+				if override {
+					project.SynthesisModel = "project-synthesis"
+				}
+				cfg.Projects = map[string]config.ProjectConfig{"github.com/acme/api": project}
+				cfg.Review = config.ReviewConfig{
+					Subagents: map[string]config.SubagentSpec{
+						"general":        {Agent: "test", Model: "pinned-model", ReviewType: "default"},
+						"security-check": {Agent: "test", Model: "pinned-model", ReviewType: "security"},
+					},
+					Panels: map[string]config.PanelSpec{
+						"panel-a": {Members: []string{"general", "security-check"}, SynthesisAgent: "test", SynthesisModel: "pinned-synthesis"},
+					},
+				}
+				if named {
+					cfg.CI.Panel = "panel-a"
+				}
+				p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
+					return ciRepoConfigSource{Config: &config.RepoConfig{}}, nil
+				}
+				base := repo.HeadSHA()
+				head := repo.CommitFile("db/migrations/001_widgets.sql", "CREATE TABLE widgets(id INT);\n", "Add widgets table")
+				p.mergeBaseFn = func(_, _, _ string) (string, error) { return base, nil }
+				err := p.processPR(context.Background(), "acme/api", ghPR{
+					Number: 1, HeadRefOid: head, BaseRefName: "main",
+				}, cfg)
+				require.NoError(t, err)
+				panel, err := db.GetCIPanelByPRSHA("acme/api", 1, head)
+				require.NoError(t, err)
+				require.NotNil(t, panel)
+				members, err := db.GetPanelMembers(panel.PanelRunUUID)
+				require.NoError(t, err)
+				require.Len(t, members, 3)
+				want := "pinned-model"
+				if override {
+					want = "project-model"
+				}
+				for _, member := range members {
+					assert.Equal(want, member.Model, member.ReviewType)
+				}
+				require.NotNil(t, panel.SynthesisJobID)
+				synth, err := db.GetJobByID(*panel.SynthesisJobID)
+				require.NoError(t, err)
+				wantSynthesis := "pinned-synthesis"
+				if override {
+					wantSynthesis = "project-synthesis"
+				}
+				assert.Equal(wantSynthesis, synth.Model)
+				assert.Equal("pinned-model", cfg.Review.Subagents["general"].Model)
+			})
+		}
+	}
+}
 
 func TestEnqueueProjectModelFromBareWorktrees(t *testing.T) {
 	repo := testutil.NewTestRepoWithCommit(t)

--- a/internal/daemon/project_models_test.go
+++ b/internal/daemon/project_models_test.go
@@ -1,0 +1,60 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/agent"
+	"go.kenn.io/roborev/internal/config"
+	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
+)
+
+func TestEnqueueProjectModelFromBareWorktrees(t *testing.T) {
+	repo := testutil.NewTestRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "project.git")
+	repo.Run("clone", "--bare", repo.Path(), bare)
+	repo.Run("-C", bare, "remote", "set-url", "origin", "ssh://git@example.com/team/project-a.git")
+	cfg := config.DefaultConfig()
+	cfg.DefaultAgent = "test"
+	cfg.ReviewModel = "default-review"
+	cfg.Projects = map[string]config.ProjectConfig{
+		"example.com/team/project-a": {ReviewModel: "project-review", DisplayName: "Project A"},
+	}
+	db, _ := testutil.OpenTestDBWithDir(t)
+	server := NewServer(db, cfg, "")
+	t.Cleanup(func() { require.NoError(t, server.Close()) })
+
+	for _, branch := range []string{"feature-a", "feature-b"} {
+		wt := filepath.Join(t.TempDir(), branch)
+		repo.Run("-C", bare, "worktree", "add", "-b", branch, wt)
+		resolution, err := agent.ResolveWorkflowConfig("", wt, cfg, "review", "thorough")
+		require.NoError(t, err)
+		assert.Equal(t, "project-review", resolution.ModelForSelectedAgent("test", ""))
+		for _, explicit := range []string{"", "cli-review"} {
+			request := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", EnqueueRequest{
+				RepoPath: wt, GitRef: "HEAD", Agent: "test", Model: explicit,
+			})
+			response := httptest.NewRecorder()
+			server.httpServer.Handler.ServeHTTP(response, request)
+			require.Equal(t, http.StatusCreated, response.Code, response.Body.String())
+			var job storage.ReviewJob
+			testutil.DecodeJSON(t, response, &job)
+			want := "project-review"
+			if explicit != "" {
+				want = explicit
+			}
+			assert.Equal(t, want, job.Model)
+			stored, err := db.GetJobByID(job.ID)
+			require.NoError(t, err)
+			assert.Equal(t, want, stored.Model)
+		}
+		assert.Equal(t, "Project A", config.GetDisplayName(wt, cfg))
+	}
+	assert.Equal(t, "default-review", config.ResolveModelForWorkflowFromConfig("", nil, cfg, "review", "thorough"))
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2592,7 +2592,7 @@ func (s *Server) humaEnqueue(
 	if filepath.Clean(checkoutRoot) != filepath.Clean(repoRoot) {
 		worktreePath = filepath.Clean(checkoutRoot)
 	}
-	cfg := s.configWatcher.Config()
+	cfg := s.configWatcher.Config().ForRepo(checkoutRoot)
 	repoCfg, err := config.LoadRepoConfig(checkoutRoot)
 	if err != nil {
 		return rawJSONOutput(


### PR DESCRIPTION
Selected projects can use stronger review models from one global config without editing each repository or duplicating panels. Global `[projects."host/owner/repository"]` tables match normalized SSH and HTTPS remotes, so ordinary checkouts and bare-backed worktrees share a review model and optional TUI display name.

A project `review_model` normally acts as a default below CLI, experiment, repository, and explicit panel member models. Setting `override_panel_models = true` makes it replace primary member models across review types, including security and design, for local panels and the daemon CI poller's named panels and matrices. An optional project `synthesis_model` overrides synthesis independently, including daemon-free GitHub and GitLab CI runs. Standalone CI also honors global `[ci].synthesis_model` when there is no project override. Agents and configured backup models retain their existing behavior; unmatched projects keep their defaults.

The [configuration guide](https://github.com/kenn-io/roborev/blob/project-specific-models/docs/configuration.md#project-defaults-by-git-remote) documents matching, precedence, and TOML examples, with links from the CI and panel guides.
