### PR TITLE
Make token-log recovery tests deterministic

### DIFF
--- a/cmd/roborev/backfill_tokens_test.go
+++ b/cmd/roborev/backfill_tokens_test.go
@@ -94,6 +94,12 @@ func TestBackfillTokensUsesCodexJobLogWhenAgentsviewMissing(t *testing.T) {
 			`"cached_input_tokens":2560,"output_tokens":3389}}`+"\n",
 	), 0o600))
 
+	// Filesystem write timestamps can lag the nanosecond-precision job start.
+	// Give this current-attempt fixture an explicit, whole-second timestamp.
+	require.NotNil(t, claimed.StartedAt)
+	logTime := claimed.StartedAt.Add(time.Second).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(logPath, logTime, logTime))
+
 	cmd := backfillTokensCmd()
 	cmd.SetArgs(nil)
 	require.NoError(t, cmd.Execute())

--- a/internal/daemon/token_cost_reconciler_test.go
+++ b/internal/daemon/token_cost_reconciler_test.go
@@ -99,6 +99,12 @@ func TestTokenCostReconcilerRecoversSessionFromJobLogAtStartup(t *testing.T) {
 			`{"type":"turn.completed","usage":{"input_tokens":1024,`+
 			`"output_tokens":64}}`+"\n",
 	), 0o600))
+	// Filesystem write timestamps can lag the nanosecond-precision job start.
+	// Give this current-attempt fixture an explicit, whole-second timestamp.
+	require.NotNil(t, job.StartedAt)
+	logTime := job.StartedAt.Add(time.Second).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(logPath, logTime, logTime))
+
 	tc.Pool.tokenUsageFetcher = func(_ context.Context, sessionID string) (*tokens.Usage, error) {
 		assert.Equal(t, "recovered-session", sessionID)
 		return &tokens.Usage{HasCost: true, CostUSD: 0.21}, nil


### PR DESCRIPTION
Two token-log recovery tests intermittently treated freshly written fixture logs as leftovers from an earlier attempt: filesystem modification timestamps could precede the nanosecond-precision job start.

Set each fixture's modification time explicitly to the next whole second after the claimed job start, so these tests consistently exercise current-attempt recovery. Existing stale-log rejection coverage and production behavior remain unchanged.

Fixes #1147.
