### PR TITLE
Select review and synthesis reasoning by project remote

### DIFF
--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -353,6 +353,7 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 		ctx, results, review.SynthesizeOpts{
 			Agent:        synthAgent,
 			Model:        config.ResolveCISynthesisModel(globalCfg),
+			Reasoning:    globalCfg.ProjectSynthesisReasoning(),
 			MinSeverity:  ciMinSev,
 			RepoPath:     root,
 			GitRef:       gitRef,

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -22,17 +22,17 @@ import (
 	"go.kenn.io/roborev/internal/testutil"
 )
 
-func TestCIReviewSynthesisModel(t *testing.T) {
+func TestCIReviewSynthesisOverrides(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("synthetic synthesis agent uses a POSIX shell script")
 	}
 	for _, tt := range []struct {
-		name, host, globalModel, projectModel, want string
+		name, host, globalModel, projectModel, want, reasoning, wantReasoning string
 	}{
-		{"agent default", "github.com", "", "", ""},
-		{"global CI model", "github.com", "ci-synthesis", "", "ci-synthesis"},
-		{"GitHub project model", "github.com", "ci-synthesis", "project-synthesis", "project-synthesis"},
-		{"GitLab project model", "gitlab.example.com", "ci-synthesis", "project-synthesis", "project-synthesis"},
+		{"agent default", "github.com", "", "", "", "", ""},
+		{"global CI model", "github.com", "ci-synthesis", "", "ci-synthesis", "", ""},
+		{"GitHub project overrides", "github.com", "ci-synthesis", "project-synthesis", "project-synthesis", "high", "high"},
+		{"GitLab project overrides", "gitlab.example.com", "ci-synthesis", "project-synthesis", "project-synthesis", "low", "low"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clearForgeCIEnv(t)
@@ -42,14 +42,21 @@ func TestCIReviewSynthesisModel(t *testing.T) {
 			t.Chdir(repo.Path())
 			modelPath := filepath.Join(dataDir, "synthesis-model")
 			t.Setenv("TEST_CI_SYNTHESIS_MODEL", modelPath)
+			reasoningPath := filepath.Join(dataDir, "synthesis-reasoning")
+			t.Setenv("TEST_CI_SYNTHESIS_REASONING", reasoningPath)
 			scriptPath := filepath.Join(dataDir, "codex-fixture")
 			require.NoError(t, os.WriteFile(scriptPath, []byte(`#!/bin/sh
+reasoning=''
 for arg in "$@"; do
+  case "$arg" in
+    model_reasoning_effort=*) reasoning="$arg" ;;
+  esac
   if [ "$arg" = "--help" ]; then
     printf '%s\n' '--sandbox --output-schema --ignore-user-config --dangerously-bypass-approvals-and-sandbox'
     exit 0
   fi
 done
+printf '%s' "$reasoning" > "$TEST_CI_SYNTHESIS_REASONING"
 model=''
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "-m" ]; then
@@ -69,7 +76,8 @@ codex_cmd = %q
 synthesis_model = %q
 [projects.%q]
 synthesis_model = %q
-`, scriptPath, tt.globalModel, tt.host+"/example/project-a", tt.projectModel)
+synthesis_reasoning = %q
+`, scriptPath, tt.globalModel, tt.host+"/example/project-a", tt.projectModel, tt.reasoning)
 			require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte(cfg), 0o600))
 			args := []string{"review", "--ref", "HEAD", "--agent", "test", "--review-types", "default,security", "--synthesis-agent", "codex"}
 			if tt.host == "gitlab.example.com" {
@@ -84,6 +92,13 @@ synthesis_model = %q
 			model, err := os.ReadFile(modelPath)
 			require.NoError(t, err, "synthesis must invoke the agent")
 			assert.Equal(t, tt.want, string(model))
+			reasoning, err := os.ReadFile(reasoningPath)
+			require.NoError(t, err)
+			wantReasoning := ""
+			if tt.wantReasoning != "" {
+				wantReasoning = `model_reasoning_effort="` + tt.wantReasoning + `"`
+			}
+			assert.Equal(t, wantReasoning, string(reasoning))
 		})
 	}
 }

--- a/cmd/roborev/local_review_test.go
+++ b/cmd/roborev/local_review_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/roborev/internal/testenv"
 	"go.kenn.io/roborev/internal/testutil"
 )
 
@@ -279,4 +281,29 @@ func TestLocalReviewSkipsDaemon(t *testing.T) {
 
 	err := h.run(runOpts{Agent: "test", Reasoning: "fast"})
 	require.NoError(t, err, "Expected --local to work without daemon, got: %v")
+}
+
+func TestLocalReviewProjectReasoning(t *testing.T) {
+	for _, explicit := range []string{"", "high"} {
+		t.Run(explicit, func(t *testing.T) {
+			h := newReviewHarness(t)
+			gitCmd := exec.Command("git", "-C", h.Dir, "remote", "add", "origin", "https://example.com/team/project-a.git")
+			gitOutput, err := gitCmd.CombinedOutput()
+			require.NoError(t, err, "%s", gitOutput)
+			dataDir := testenv.SetDataDir(t)
+			require.NoError(t, os.WriteFile(filepath.Join(dataDir, "config.toml"), []byte(`
+default_agent = "test"
+review_model_medium = "medium-model"
+review_model_high = "high-model"
+[projects."example.com/team/project-a"]
+review_reasoning = "medium"
+`), 0o600))
+			require.NoError(t, h.run(runOpts{Agent: "test", Reasoning: explicit}))
+			want := "medium"
+			if explicit != "" {
+				want = explicit
+			}
+			h.assertOutputContains("model: " + want + "-model, reasoning: " + want)
+		})
+	}
 }

--- a/cmd/roborev/quickstart.go
+++ b/cmd/roborev/quickstart.go
@@ -193,6 +193,7 @@ func checkConfiguredAgent(repoRoot string, inGitRepo bool, agent string) quickst
 	}
 	explicit := false
 	global, _ := config.LoadGlobal()
+	global = global.ForRepo(repoRoot)
 	if repoCfg, err := config.LoadRepoConfig(repoRoot); err == nil {
 		reasoning := ""
 		if resolved, resolveErr := config.ResolveReviewReasoningFromConfig("", repoCfg, global); resolveErr == nil {

--- a/cmd/roborev/review.go
+++ b/cmd/roborev/review.go
@@ -449,6 +449,7 @@ func runLocalReview(cmd *cobra.Command, repoPath, gitRef, diffContent string, di
 		return fmt.Errorf("load config: %w", err)
 	}
 
+	cfg = cfg.ForRepo(repoPath)
 	repoCfg, err := config.LoadRepoConfig(repoPath)
 	if err != nil {
 		return fmt.Errorf("load repository config: %w", err)

--- a/docs/advanced/subagent-review-panels.md
+++ b/docs/advanced/subagent-review-panels.md
@@ -128,7 +128,11 @@ panels, use global
 [project model overrides](/docs/configuration/#overriding-panel-models).
 `override_panel_models = true` makes the project's `review_model` override each
 member's model, including security and design reviewers. An optional project
-`synthesis_model` overrides synthesis separately.
+`synthesis_model` overrides synthesis separately. For reasoning, set project
+`review_reasoning` and `override_panel_reasoning = true` to replace member pins
+across every review type. Without the override flag, project reasoning supplies
+an inherited default. Project `synthesis_reasoning` controls synthesis
+independently.
 
 ### Review Table
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,14 +100,15 @@ definition can be validated before it is enabled.
 
 ## Project Defaults by Git Remote
 
-To use a different review model for selected projects without editing each
-checkout, add project tables to `~/.roborev/config.toml`:
+To use a different review model or reasoning level for selected projects without
+editing each checkout, add project tables to `~/.roborev/config.toml`:
 
 ```toml
 review_model = "gpt-5.6-luna"
 
 [projects."github.com/example/project-a"]
 review_model = "gpt-5.6-sol"
+review_reasoning = "medium"
 display_name = "Project A"
 
 [projects."github.com/example/project-b"]
@@ -141,6 +142,15 @@ precedence over global `review_model_<level>`, `review_model`, and
 standalone workflows (such as fix, security, and design) retain their existing
 settings.
 
+Project `review_reasoning` supplies a default for reviews, including `--local`
+and CI. CLI reasoning, repository settings, experiment overrides, custom review
+type reasoning, and pinned panel member reasoning keep their priority. It takes
+precedence over general global review reasoning. CI retains its existing
+`thorough` default for unmatched projects. Both exact effort names (`low`,
+`medium`, `high`, `xhigh`, `max`) and legacy levels (`fast`, `standard`,
+`thorough`, `maximum`) are accepted. The effective reasoning level also selects
+reasoning-specific model settings when no model is pinned.
+
 ### Overriding Panel Models
 
 A panel can pin a model on each member, so changing `default_model` or a project
@@ -152,6 +162,9 @@ primary reviewers of selected projects, explicitly enable the override:
 review_model = "gpt-5.6-sol"
 override_panel_models = true
 synthesis_model = "gpt-6-astra" # Optional, independent synthesis override
+review_reasoning = "medium"
+override_panel_reasoning = true
+synthesis_reasoning = "medium" # Optional, independent synthesis override
 ```
 
 `override_panel_models = true` makes the project `review_model` take precedence
@@ -171,9 +184,21 @@ Daemon-free `roborev ci review` also honors the project `synthesis_model`, ahead
 of global `[ci].synthesis_model`, in GitHub and GitLab CI runs. If neither is
 set, it leaves synthesis model selection to the agent.
 
-These settings change models, not agents or providers. Use a model accepted by
-each affected agent when overriding a mixed-agent panel. Backup models retain
-their existing failover behavior. Settings for other projects are unaffected.
+`override_panel_reasoning = true` similarly forces the project
+`review_reasoning` across panel members of every type, including pinned member
+reasoning, CI matrices, and automatically added CI design reviews. It requires a
+nonempty project `review_reasoning`. Explicit CLI reasoning keeps priority in
+daemon-free CI reviews.
+
+Project `synthesis_reasoning` independently overrides panel and CI synthesis
+reasoning, including daemon-free `roborev ci review`. It does not require
+`override_panel_reasoning`. When omitted, synthesis keeps its existing reasoning
+selection.
+
+These settings change models and reasoning, not agents or providers. Use a model
+accepted by each affected agent when overriding a mixed-agent panel. Backup
+models retain their existing failover behavior. Settings for other projects are
+unaffected.
 
 ## Per-Repository Configuration
 

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -721,7 +721,11 @@ To select models for repositories centrally, add
 daemon's global config. Set `review_model` and `override_panel_models = true`
 for each selected Git remote to replace even explicitly pinned panel member
 models. The optional project `synthesis_model` controls synthesis independently.
-These overrides apply to named panels and the implicit CI matrix.
+Set project `review_reasoning` and `override_panel_reasoning = true` to also
+replace pinned member reasoning. Project `synthesis_reasoning` selects synthesis
+reasoning independently. These overrides apply to named panels, the implicit CI
+matrix, and automatically added design reviewers. Without the override flag,
+project reasoning supplies the CI default below repository `[ci].reasoning`.
 
 Individual repos can override the global CI settings by adding a `[ci]` section
 to their `.roborev.toml` file. This lets you run different panels, agents,

--- a/internal/config/ci.go
+++ b/internal/config/ci.go
@@ -566,7 +566,7 @@ func ResolveCIReviewTypes(
 }
 
 // ResolveCIReasoning determines the reasoning level for CI review execution.
-// Priority: explicit > repo [ci].reasoning > "thorough".
+// Priority: explicit > project panel override > repo [ci].reasoning > project default > "thorough".
 func ResolveCIReasoning(
 	explicit string,
 	repoCfg *RepoConfig,
@@ -576,14 +576,23 @@ func ResolveCIReasoning(
 	if repoCfg != nil {
 		repoVal = repoCfg.CI.Reasoning
 	}
-	_ = globalCfg
-	return resolveNormalized("thorough", NormalizeReasoning, explicit, repoVal)
+	if value, ok := experimentOverlayString(repoCfg, "ci", "reasoning"); ok {
+		return resolveNormalized("thorough", NormalizeReasoning, explicit,
+			globalCfg.PanelReasoningOverride(), value)
+	}
+	var projectVal string
+	if globalCfg != nil {
+		projectVal = globalCfg.project.ReviewReasoning
+	}
+	return resolveNormalized("thorough", NormalizeReasoning, explicit,
+		globalCfg.PanelReasoningOverride(), repoVal, projectVal)
 }
 
 // ResolveCIReviewReasoningForType determines the reasoning level for one CI
 // review. An explicit CLI value or repository [ci].reasoning applies to every
-// type. Otherwise a custom type may supply its own reasoning before CI falls
-// back to "thorough".
+// type. A project panel policy overrides repository and type defaults. Otherwise
+// a custom type may supply its own reasoning before the project default and
+// CI fallback to "thorough".
 func ResolveCIReviewReasoningForType(
 	explicit string,
 	repoCfg *RepoConfig,
@@ -594,17 +603,15 @@ func ResolveCIReviewReasoningForType(
 	if repoCfg != nil {
 		repoVal = repoCfg.CI.Reasoning
 	}
-	if strings.TrimSpace(explicit) != "" || strings.TrimSpace(repoVal) != "" {
-		return resolveNormalized(
-			"thorough", NormalizeReasoning, explicit, repoVal,
-		)
+	if strings.TrimSpace(explicit) != "" || globalCfg.PanelReasoningOverride() != "" || strings.TrimSpace(repoVal) != "" {
+		return ResolveCIReasoning(explicit, repoCfg, globalCfg)
 	}
 	if resolved, ok := ResolveCustomReviewTypeFromConfig(
 		reviewType, repoCfg, globalCfg,
 	); ok && strings.TrimSpace(resolved.Spec.Reasoning) != "" {
 		return NormalizeReasoning(resolved.Spec.Reasoning)
 	}
-	return "thorough", nil
+	return ResolveCIReasoning("", repoCfg, globalCfg)
 }
 
 // ResolveCIMinSeverity determines the synthesis severity filter for CI review execution.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -532,6 +532,14 @@ func validateConfig(cfg any, acp ACPAgentConfigs) error {
 	switch typed := cfg.(type) {
 	case *Config:
 		for identity, project := range typed.Projects {
+			if project.OverridePanelReasoning && strings.TrimSpace(project.ReviewReasoning) == "" {
+				return fmt.Errorf("projects.%q: override_panel_reasoning requires review_reasoning", identity)
+			}
+			for key, value := range map[string]string{"review_reasoning": project.ReviewReasoning, "synthesis_reasoning": project.SynthesisReasoning} {
+				if _, err := NormalizeReasoning(value); err != nil {
+					return fmt.Errorf("projects.%q.%s: %w", identity, key, err)
+				}
+			}
 			if project.OverridePanelModels && strings.TrimSpace(project.ReviewModel) == "" {
 				return fmt.Errorf("projects.%q: override_panel_models requires review_model", identity)
 			}

--- a/internal/config/panels.go
+++ b/internal/config/panels.go
@@ -316,7 +316,9 @@ func ResolveCISynthesis(
 	if err != nil {
 		return SynthesisSpec{}, err
 	}
-	synth.Reasoning = ciReasoning
+	if globalCfg.ProjectSynthesisReasoning() == "" {
+		synth.Reasoning = ciReasoning
+	}
 	return synth, nil
 }
 
@@ -349,8 +351,12 @@ func resolveMemberFromConfig(
 	if err != nil {
 		return ResolvedMember{}, fmt.Errorf("subagent %q: %w", name, err)
 	}
+	memberReasoning := spec.Reasoning
+	if override := globalCfg.PanelReasoningOverride(); override != "" {
+		memberReasoning = override
+	}
 	reasoning, err := ResolveReviewReasoningForTypeFromConfig(
-		spec.Reasoning, repoCfg, globalCfg, reviewType,
+		memberReasoning, repoCfg, globalCfg, reviewType,
 	)
 	if err != nil {
 		return ResolvedMember{}, fmt.Errorf("subagent %q: %w", name, err)
@@ -425,7 +431,7 @@ func resolveSynthesisFromConfig(
 	repoCfg *RepoConfig,
 	globalCfg *Config,
 ) (SynthesisSpec, error) {
-	reasoning, err := ResolveFixReasoningFromConfig("", repoCfg, globalCfg)
+	reasoning, err := ResolveFixReasoningFromConfig(globalCfg.ProjectSynthesisReasoning(), repoCfg, globalCfg)
 	if err != nil {
 		return SynthesisSpec{}, err
 	}

--- a/internal/config/projects.go
+++ b/internal/config/projects.go
@@ -9,10 +9,13 @@ import (
 
 // ProjectConfig supplies machine-local defaults shared by checkouts of a remote.
 type ProjectConfig struct {
-	ReviewModel         string `toml:"review_model"`
-	DisplayName         string `toml:"display_name"`
-	OverridePanelModels bool   `toml:"override_panel_models"`
-	SynthesisModel      string `toml:"synthesis_model"`
+	ReviewModel            string `toml:"review_model"`
+	DisplayName            string `toml:"display_name"`
+	OverridePanelModels    bool   `toml:"override_panel_models"`
+	SynthesisModel         string `toml:"synthesis_model"`
+	ReviewReasoning        string `toml:"review_reasoning"`
+	OverridePanelReasoning bool   `toml:"override_panel_reasoning"`
+	SynthesisReasoning     string `toml:"synthesis_reasoning"`
 }
 
 // PanelModelOverride returns the explicit project policy for primary panel
@@ -22,6 +25,23 @@ func (c *Config) PanelModelOverride() string {
 		return ""
 	}
 	return strings.TrimSpace(c.project.ReviewModel)
+}
+
+// PanelReasoningOverride returns the project policy for primary panel members.
+func (c *Config) PanelReasoningOverride() string {
+	if c == nil || !c.project.OverridePanelReasoning {
+		return ""
+	}
+	return strings.TrimSpace(c.project.ReviewReasoning)
+}
+
+// ProjectSynthesisReasoning returns an independent project synthesis override.
+// An empty result preserves the caller's existing synthesis default.
+func (c *Config) ProjectSynthesisReasoning() string {
+	if c == nil {
+		return ""
+	}
+	return strings.TrimSpace(c.project.SynthesisReasoning)
 }
 
 // ForRepo returns global configuration scoped to the repository's remote.

--- a/internal/config/projects_test.go
+++ b/internal/config/projects_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProjectPanelModelOverride(t *testing.T) {
+func TestProjectPanelOverrides(t *testing.T) {
 	for _, tt := range []struct {
 		name      string
 		override  bool
@@ -31,18 +31,23 @@ default_model = "global-model"
 review_model = "project-model"
 override_panel_models = %t
 synthesis_model = %q
+review_reasoning = "medium"
+override_panel_reasoning = %t
+synthesis_reasoning = "low"
 [review.subagents.general]
 agent = "codex"
 model = "member-model"
+reasoning = "high"
 [review.subagents.security-check]
 agent = "codex"
 model = "security-member-model"
+reasoning = "high"
 review_type = "security"
 [review.panels.panel-a]
 members = ["general", "security-check"]
 synthesis_agent = "codex"
 synthesis_model = "synthesis-model"
-`, tt.override, tt.synthesis), &cfg)
+`, tt.override, tt.synthesis, tt.override), &cfg)
 			require.NoError(t, err)
 			root := t.TempDir()
 			execGit(t, root, "init")
@@ -69,6 +74,14 @@ synthesis_model = "synthesis-model"
 					wantSynthesis = tt.synthesis
 				}
 				assert.Equal(wantSynthesis, synth.Model)
+				assert.Equal("low", synth.Reasoning)
+				wantReasoning := "high"
+				if tt.override {
+					wantReasoning = "medium"
+				}
+				for _, member := range members {
+					assert.Equal(wantReasoning, member.Reasoning)
+				}
 			}
 		})
 	}
@@ -155,4 +168,147 @@ review_model = %q
 			require.ErrorContains(t, loadErr, "override_panel_models requires review_model")
 		}
 	}
+}
+
+func TestProjectReviewReasoning(t *testing.T) {
+	root := t.TempDir()
+	execGit(t, root, "init")
+	execGit(t, root, "remote", "add", "origin", "https://example.com/team/project-a.git")
+	var cfg Config
+	_, err := toml.Decode(`
+review_reasoning = "maximum"
+[projects."example.com/team/project-a"]
+review_reasoning = "medium"
+`, &cfg)
+	require.NoError(t, err)
+	for _, explicit := range []string{"", "high"} {
+		want := "medium"
+		if explicit != "" {
+			want = explicit
+		}
+		got, err := ResolveReviewReasoning(explicit, root, &cfg)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+		got, err = ResolveCIReviewReasoningForType(explicit, nil, cfg.ForRepo(root), "security")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+	writeRepoConfigStr(t, root, "review_reasoning = \"fast\"")
+	got, err := ResolveReviewReasoning("", root, &cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "fast", got)
+	execGit(t, root, "remote", "set-url", "origin", "https://example.com/team/project-b.git")
+	got, err = ResolveReviewReasoningFromConfig("", nil, cfg.ForRepo(root))
+	require.NoError(t, err)
+	assert.Equal(t, "maximum", got)
+	got, err = ResolveCIReasoning("", nil, cfg.ForRepo(root))
+	require.NoError(t, err)
+	assert.Equal(t, "thorough", got)
+}
+
+func TestProjectReasoningValidation(t *testing.T) {
+	for _, tt := range []struct{ setting, wantError string }{
+		{`review_reasoning = "medium"`, ""},
+		{`synthesis_reasoning = "high"`, ""},
+		{`review_reasoning = "invalid"`, "review_reasoning"},
+		{`synthesis_reasoning = "invalid"`, "synthesis_reasoning"},
+		{`override_panel_reasoning = true`, "override_panel_reasoning requires review_reasoning"},
+	} {
+		t.Run(tt.setting, func(t *testing.T) {
+			content := "[projects.\"example.com/team/project-a\"]\n" + tt.setting
+			dir := t.TempDir()
+			writeTestFile(t, dir, "config.toml", content)
+			var cfg Config
+			_, err := toml.Decode(content, &cfg)
+			require.NoError(t, err)
+			_, loadErr := LoadGlobalFrom(filepath.Join(dir, "config.toml"))
+			if tt.wantError == "" {
+				require.NoError(t, cfg.Validate())
+				require.NoError(t, loadErr)
+			} else {
+				require.ErrorContains(t, cfg.Validate(), tt.wantError)
+				require.ErrorContains(t, loadErr, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestProjectReasoningSelectsPanelModels(t *testing.T) {
+	root := t.TempDir()
+	execGit(t, root, "init")
+	execGit(t, root, "remote", "add", "origin", "https://example.com/team/project-a.git")
+	cfg := &Config{
+		DefaultAgent: "test", ReviewModelMedium: "review-medium", ReviewModelHigh: "review-high",
+		FixModelMedium: "fix-medium",
+		Projects: map[string]ProjectConfig{"example.com/team/project-a": {
+			ReviewReasoning: "medium", OverridePanelReasoning: true, SynthesisReasoning: "medium",
+		}},
+		Review: ReviewConfig{
+			Subagents: map[string]SubagentSpec{"member": {Reasoning: "high"}},
+			Panels:    map[string]PanelSpec{"panel-a": {Members: []string{"member"}}},
+		},
+	}
+	members, synth, err := ResolvePanel("panel-a", root, cfg)
+	require.NoError(t, err)
+	require.Len(t, members, 1)
+	assert.Equal(t, "medium", members[0].Reasoning)
+	assert.Equal(t, "review-medium", members[0].Model)
+	assert.Equal(t, "medium", synth.Reasoning)
+	assert.Equal(t, "fix-medium", synth.Model)
+}
+
+func TestProjectReasoningExperimentPrecedence(t *testing.T) {
+	for _, reasoning := range []string{"", "high"} {
+		cfg := &Config{
+			project: ProjectConfig{ReviewReasoning: "medium"},
+			Experiments: map[string]ExperimentDefinition{"reasoning-a": {
+				Enabled: new(true), Ratio: new(1.0),
+				Workflows: []ExperimentWorkflow{ExperimentWorkflowReview},
+				Config:    map[string]any{"review_reasoning": reasoning},
+			}},
+		}
+		selection, err := SelectReviewExperiment(ExperimentSelectionInput{
+			Workflow: ExperimentWorkflowReview,
+			Subject:  ExperimentSubject{Repository: "example.com/team/project-a", Branch: "feature"},
+			Global:   cfg, Repo: &RepoConfig{}, RawRepo: map[string]any{},
+		})
+		require.NoError(t, err)
+		got, err := ResolveReviewReasoningFromConfig("", selection.RepoConfig, cfg)
+		require.NoError(t, err)
+		want := reasoning
+		if want == "" {
+			want = "thorough"
+		}
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestProjectCIReasoningExperimentReset(t *testing.T) {
+	cfg := &Config{
+		project: ProjectConfig{ReviewReasoning: "medium"},
+		Experiments: map[string]ExperimentDefinition{"reasoning-a": {
+			Enabled: new(true), Ratio: new(1.0),
+			Workflows: []ExperimentWorkflow{ExperimentWorkflowCI},
+			Config:    map[string]any{"ci": map[string]any{"reasoning": ""}},
+		}},
+	}
+	selection, err := SelectReviewExperiment(ExperimentSelectionInput{
+		Workflow: ExperimentWorkflowCI,
+		Subject:  ExperimentSubject{Repository: "example.com/team/project-a", Branch: "feature"},
+		Global:   cfg, Repo: &RepoConfig{}, RawRepo: map[string]any{},
+	})
+	require.NoError(t, err)
+	got, err := ResolveCIReasoning("", selection.RepoConfig, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "thorough", got)
+	got, err = ResolveCIReviewReasoningForType("", selection.RepoConfig, cfg, "security")
+	require.NoError(t, err)
+	assert.Equal(t, "thorough", got)
+	cfg.project.OverridePanelReasoning = true
+	got, err = ResolveCIReasoning("", selection.RepoConfig, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "medium", got)
+	got, err = ResolveCIReasoning("high", selection.RepoConfig, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "high", got)
 }

--- a/internal/config/workflow.go
+++ b/internal/config/workflow.go
@@ -230,7 +230,7 @@ func SeverityInstruction(minSeverity string) string {
 }
 
 // ResolveReviewReasoning determines reasoning level for reviews.
-// Priority: explicit > per-repo config > global config > default (thorough)
+// Priority: explicit > per-repo config > project > global config > default (thorough)
 func ResolveReviewReasoning(explicit string, repoPath string, globalCfg *Config) (string, error) {
 	if strings.TrimSpace(explicit) != "" {
 		if err := validateRepoReasoningOverride(repoPath, func(cfg *RepoConfig) string {
@@ -244,11 +244,11 @@ func ResolveReviewReasoning(explicit string, repoPath string, globalCfg *Config)
 	if err != nil {
 		return "", err
 	}
-	return ResolveReviewReasoningFromConfig("", repoCfg, globalCfg)
+	return ResolveReviewReasoningFromConfig("", repoCfg, globalCfg.ForRepo(repoPath))
 }
 
 // ResolveReviewReasoningFromConfig is the config-taking core of
-// ResolveReviewReasoning: it resolves explicit > repoCfg > globalCfg > default
+// ResolveReviewReasoning: it resolves explicit > repoCfg > project > globalCfg > default
 // ("thorough") entirely from the passed configs, never reading the working
 // tree. When explicit is set it still validates the repo override field on the
 // passed repoCfg before accepting the explicit value.
@@ -273,6 +273,9 @@ func ResolveReviewReasoningFromConfig(
 	}
 	if repoCfg != nil && strings.TrimSpace(repoCfg.ReviewReasoning) != "" {
 		return NormalizeReasoning(repoCfg.ReviewReasoning)
+	}
+	if globalCfg != nil && strings.TrimSpace(globalCfg.project.ReviewReasoning) != "" {
+		return NormalizeReasoning(globalCfg.project.ReviewReasoning)
 	}
 	if globalCfg != nil && strings.TrimSpace(globalCfg.ReviewReasoning) != "" {
 		return NormalizeReasoning(globalCfg.ReviewReasoning)

--- a/internal/daemon/ci_poller.go
+++ b/internal/daemon/ci_poller.go
@@ -861,7 +861,7 @@ func (p *CIPoller) resolveCIMatrixMembers(
 	members := make([]config.ResolvedMember, 0, len(matrix))
 	for i, entry := range matrix {
 		memberReasoning := reasoning
-		if repoCfg == nil || strings.TrimSpace(repoCfg.CI.Reasoning) == "" {
+		if cfg.PanelReasoningOverride() != "" || repoCfg == nil || strings.TrimSpace(repoCfg.CI.Reasoning) == "" {
 			var err error
 			memberReasoning, err = config.ResolveCIReviewReasoningForType(
 				"", repoCfg, cfg, entry.ReviewType,
@@ -1074,7 +1074,7 @@ func resolveCIMatrix(
 	cfg *config.Config, ghRepo string,
 ) ([]config.AgentReviewType, string) {
 	matrix := cfg.CI.ResolvedReviewMatrix()
-	reasoning := "thorough"
+	reasoning := ciReasoning(repoCfg, cfg)
 	if repoCfg != nil {
 		switch {
 		case config.ExperimentOverridesCIReviews(repoCfg):
@@ -1087,12 +1087,8 @@ func resolveCIMatrix(
 			config.IsKeyInTOMLFile(rawRepoCfg, "ci.review_types"):
 			matrix = matrixFromFlatOverrides(repoCfg, cfg)
 		}
-		if strings.TrimSpace(repoCfg.CI.Reasoning) != "" {
-			if r, err := config.NormalizeReasoning(repoCfg.CI.Reasoning); err == nil && r != "" {
-				reasoning = r
-			} else if err != nil {
-				log.Printf("CI poller: invalid reasoning %q in repo config for %s, using default", repoCfg.CI.Reasoning, ghRepo)
-			}
+		if _, err := config.NormalizeReasoning(repoCfg.CI.Reasoning); err != nil {
+			log.Printf("CI poller: invalid reasoning %q in repo config for %s, using default", repoCfg.CI.Reasoning, ghRepo)
 		}
 	}
 	return canonicalizeMatrix(matrix), reasoning
@@ -1162,15 +1158,11 @@ func namedReviewType(reviewType string) string {
 	return reviewType
 }
 
-// ciReasoning returns the effective CI reasoning level for a repo: the repo's
-// [ci].reasoning when valid, else "thorough". Mirrors resolveCIMatrix's
-// reasoning derivation so the appended design member and matrix members share a
-// level.
-func ciReasoning(repoCfg *config.RepoConfig) string {
-	if repoCfg != nil && strings.TrimSpace(repoCfg.CI.Reasoning) != "" {
-		if r, err := config.NormalizeReasoning(repoCfg.CI.Reasoning); err == nil && r != "" {
-			return r
-		}
+// ciReasoning shares CI project and repository reasoning with automatically
+// appended design members, retaining the default for invalid repository values.
+func ciReasoning(repoCfg *config.RepoConfig, cfg *config.Config) string {
+	if reasoning, err := config.ResolveCIReasoning("", repoCfg, cfg); err == nil {
+		return reasoning
 	}
 	return "thorough"
 }
@@ -1180,7 +1172,7 @@ func resolveCIAutoDesignAgent(repoCfg *config.RepoConfig, cfg *config.Config) (s
 	if cfg != nil {
 		ciModel = cfg.CI.Model
 	}
-	reasoning := ciReasoning(repoCfg)
+	reasoning := ciReasoning(repoCfg, cfg)
 	if config.ExperimentOverridesWorkflowModel(repoCfg, "design", reasoning) {
 		ciModel = ""
 	}
@@ -1226,7 +1218,7 @@ func (p *CIPoller) maybeAppendDesignMember(
 		if !p.commitWarrantsDesign(ctx, repo.RootPath, sha, hh) {
 			continue
 		}
-		reasoning := ciReasoning(repoCfg)
+		reasoning := ciReasoning(repoCfg, cfg)
 		designAgent, designModel := resolveCIAutoDesignAgent(repoCfg, cfg)
 		designAgent = agent.StorageNameFromConfig(designAgent, repoCfg, cfg)
 		var backupAgent, backupModel string

--- a/internal/daemon/project_models_test.go
+++ b/internal/daemon/project_models_test.go
@@ -66,7 +66,7 @@ func TestProjectPanelOverrideSurvivesAgentAutoDetection(t *testing.T) {
 	})
 }
 
-func TestCIPollerProjectPanelModelOverride(t *testing.T) {
+func TestCIPollerProjectPanelOverrides(t *testing.T) {
 	for _, named := range []bool{false, true} {
 		for _, override := range []bool{false, true} {
 			t.Run(fmt.Sprintf("named=%t/override=%t", named, override), func(t *testing.T) {
@@ -78,15 +78,15 @@ func TestCIPollerProjectPanelModelOverride(t *testing.T) {
 				cfg.CI.SynthesisModel = "pinned-synthesis"
 				cfg.AutoDesignReview.Enabled = true
 				cfg.DesignAgent = "test"
-				project := config.ProjectConfig{ReviewModel: "project-model", OverridePanelModels: override}
+				project := config.ProjectConfig{ReviewModel: "project-model", OverridePanelModels: override, ReviewReasoning: "medium", OverridePanelReasoning: override, SynthesisReasoning: "low"}
 				if override {
 					project.SynthesisModel = "project-synthesis"
 				}
 				cfg.Projects = map[string]config.ProjectConfig{"github.com/acme/api": project}
 				cfg.Review = config.ReviewConfig{
 					Subagents: map[string]config.SubagentSpec{
-						"general":        {Agent: "test", Model: "pinned-model", ReviewType: "default"},
-						"security-check": {Agent: "test", Model: "pinned-model", ReviewType: "security"},
+						"general":        {Agent: "test", Model: "pinned-model", Reasoning: "high", ReviewType: "default"},
+						"security-check": {Agent: "test", Model: "pinned-model", Reasoning: "high", ReviewType: "security"},
 					},
 					Panels: map[string]config.PanelSpec{
 						"panel-a": {Members: []string{"general", "security-check"}, SynthesisAgent: "test", SynthesisModel: "pinned-synthesis"},
@@ -96,7 +96,7 @@ func TestCIPollerProjectPanelModelOverride(t *testing.T) {
 					cfg.CI.Panel = "panel-a"
 				}
 				p.loadRepoConfigFn = func(string) (ciRepoConfigSource, error) {
-					return ciRepoConfigSource{Config: &config.RepoConfig{}}, nil
+					return ciRepoConfigSource{Config: &config.RepoConfig{CI: config.RepoCIConfig{Reasoning: "high"}}}, nil
 				}
 				base := repo.HeadSHA()
 				head := repo.CommitFile("db/migrations/001_widgets.sql", "CREATE TABLE widgets(id INT);\n", "Add widgets table")
@@ -117,6 +117,11 @@ func TestCIPollerProjectPanelModelOverride(t *testing.T) {
 				}
 				for _, member := range members {
 					assert.Equal(want, member.Model, member.ReviewType)
+					wantReasoning := "high"
+					if override {
+						wantReasoning = "medium"
+					}
+					assert.Equal(wantReasoning, member.Reasoning, member.ReviewType)
 				}
 				require.NotNil(t, panel.SynthesisJobID)
 				synth, err := db.GetJobByID(*panel.SynthesisJobID)
@@ -126,6 +131,7 @@ func TestCIPollerProjectPanelModelOverride(t *testing.T) {
 					wantSynthesis = "project-synthesis"
 				}
 				assert.Equal(wantSynthesis, synth.Model)
+				assert.Equal("low", synth.Reasoning)
 				assert.Equal("pinned-model", cfg.Review.Subagents["general"].Model)
 			})
 		}
@@ -141,7 +147,7 @@ func TestEnqueueProjectModelFromBareWorktrees(t *testing.T) {
 	cfg.DefaultAgent = "test"
 	cfg.ReviewModel = "default-review"
 	cfg.Projects = map[string]config.ProjectConfig{
-		"example.com/team/project-a": {ReviewModel: "project-review", DisplayName: "Project A"},
+		"example.com/team/project-a": {ReviewModel: "project-review", ReviewReasoning: "medium", DisplayName: "Project A"},
 	}
 	db, _ := testutil.OpenTestDBWithDir(t)
 	server := NewServer(db, cfg, "")
@@ -154,8 +160,13 @@ func TestEnqueueProjectModelFromBareWorktrees(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "project-review", resolution.ModelForSelectedAgent("test", ""))
 		for _, explicit := range []string{"", "cli-review"} {
+			var explicitReasoning string
+			wantReasoning := "medium"
+			if explicit != "" {
+				explicitReasoning, wantReasoning = "high", "high"
+			}
 			request := testutil.MakeJSONRequest(t, http.MethodPost, "/api/enqueue", EnqueueRequest{
-				RepoPath: wt, GitRef: "HEAD", Agent: "test", Model: explicit,
+				RepoPath: wt, GitRef: "HEAD", Agent: "test", Model: explicit, Reasoning: explicitReasoning,
 			})
 			response := httptest.NewRecorder()
 			server.httpServer.Handler.ServeHTTP(response, request)
@@ -170,8 +181,35 @@ func TestEnqueueProjectModelFromBareWorktrees(t *testing.T) {
 			stored, err := db.GetJobByID(job.ID)
 			require.NoError(t, err)
 			assert.Equal(t, want, stored.Model)
+			assert.Equal(t, wantReasoning, stored.Reasoning)
 		}
 		assert.Equal(t, "Project A", config.GetDisplayName(wt, cfg))
 	}
 	assert.Equal(t, "default-review", config.ResolveModelForWorkflowFromConfig("", nil, cfg, "review", "thorough"))
+}
+
+func TestProjectCIReasoningExperimentSynthesisReset(t *testing.T) {
+	repo := testutil.NewTestRepoWithCommit(t)
+	repo.AddRemote("origin", "https://example.com/team/project-a.git")
+	cfg := config.DefaultConfig()
+	cfg.Projects = map[string]config.ProjectConfig{
+		"example.com/team/project-a": {ReviewReasoning: "medium"},
+	}
+	cfg.Experiments = map[string]config.ExperimentDefinition{"reasoning-a": {
+		Enabled: new(true), Ratio: new(1.0),
+		Workflows: []config.ExperimentWorkflow{config.ExperimentWorkflowCI},
+		Config:    map[string]any{"ci": map[string]any{"reasoning": ""}},
+	}}
+	cfg = cfg.ForRepo(repo.Path())
+	selection, err := config.SelectReviewExperiment(config.ExperimentSelectionInput{
+		Workflow: config.ExperimentWorkflowCI,
+		Subject:  config.ExperimentSubject{Repository: "example.com/team/project-a", Branch: "feature"},
+		Global:   cfg, Repo: &config.RepoConfig{}, RawRepo: map[string]any{},
+	})
+	require.NoError(t, err)
+	_, reasoning := resolveCIMatrix(selection.RepoConfig, nil, cfg, "team/project-a")
+	assert.Equal(t, "thorough", reasoning)
+	synth, err := config.ResolveCISynthesis(reasoning, selection.RepoConfig, cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "thorough", synth.Reasoning)
 }

--- a/internal/review/synthesize.go
+++ b/internal/review/synthesize.go
@@ -35,6 +35,8 @@ type SynthesizeOpts struct {
 	Agent string
 	// Model override for the synthesis agent.
 	Model string
+	// Reasoning override (empty preserves the agent default).
+	Reasoning string
 	// MinSeverity is the lowest severity that fails the combined review.
 	// Findings below it are kept in the output as information.
 	MinSeverity string
@@ -143,6 +145,14 @@ func runSynthesis(
 
 	if opts.Model != "" {
 		synthAgent = synthAgent.WithModel(opts.Model)
+	}
+
+	if opts.Reasoning != "" {
+		reasoning, err := config.NormalizeReasoning(opts.Reasoning)
+		if err != nil {
+			return "", fmt.Errorf("synthesis reasoning: %w", err)
+		}
+		synthAgent = synthAgent.WithReasoning(agent.ParseReasoningLevel(reasoning))
 	}
 
 	synthPrompt := BuildSynthesisPrompt(


### PR DESCRIPTION
Projects can now choose review reasoning alongside their model in the global config, so selected repositories can use a different effort level without changing every checkout or shared panel.

`review_reasoning` supplies the project default. Set `override_panel_reasoning = true` to replace pinned reasoning across primary panel members, CI matrices, and automatically added design reviews. `synthesis_reasoning` controls synthesis independently, including daemon-free CI. These policies are separate from model overrides, and unmatched projects retain their existing defaults.

The configuration docs explain precedence and include examples for central CI configuration.
