### PR TITLE
Speed up coverage by reusing prepared database fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,19 @@ jobs:
       - name: Test with coverage
         # Race coverage runs in the test and daemon-race jobs; repeating it here
         # makes the daemon package exceed its timeout without improving coverage.
-        run: go test -timeout 45m -shuffle=on -tags integration -coverprofile=coverage.out ./...
+        run: |
+          set -o pipefail
+          mkdir -p test-results
+          go test -json -timeout 45m -shuffle=on -tags integration -coverprofile=coverage.out ./... 2>&1 |
+            tee test-results/coverage.jsonl
+
+      - name: Upload coverage test timings
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coverage-test-json
+          path: test-results/coverage.jsonl
+          if-no-files-found: ignore
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0

--- a/internal/daemon/ci_display_policy_test.go
+++ b/internal/daemon/ci_display_policy_test.go
@@ -182,6 +182,7 @@ func TestSingleSurvivorDisplayPolicyHandoff(t *testing.T) {
 }
 
 func TestSuccessfulPanelSynthesisInheritsThreshold(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
 	for _, policy := range []struct {
 		name      string
 		members   []string
@@ -197,7 +198,6 @@ func TestSuccessfulPanelSynthesisInheritsThreshold(t *testing.T) {
 	} {
 		t.Run(policy.name, func(t *testing.T) {
 			assert := assert.New(t)
-			tc := newWorkerTestContext(t, 1)
 			document := json.RawMessage(`{"schema_version":2,"summary":"Combined.","verdict":"fail","findings":[{"severity":"low","problem":"Minor naming issue.","fix":"Rename it.","location":null,"sources":[1,2]}]}`)
 			a := &synthesisEntrypointTestAgent{name: "threshold-synthesis", result: string(document)}
 			agent.Register(a)
@@ -242,10 +242,10 @@ func TestSuccessfulPanelSynthesisInheritsThreshold(t *testing.T) {
 }
 
 func TestPanelProseVerdictAfterRubric(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
 	for _, boundary := range []string{"Review Findings:", "2. **Review Findings**:", "---", "", "## Details"} {
 		t.Run(boundary, func(t *testing.T) {
 			assert := assert.New(t)
-			tc := newWorkerTestContext(t, 1)
 			output := "Severity levels:\nHigh: immediate action.\nLow: minor concern.\n\n" + boundary + "\n### Low\nMinor naming issue."
 			a := &agent.FakeAgent{NameStr: "rubric-review", ReviewFn: func(context.Context, string, string, string, io.Writer) (string, error) { return output, nil }}
 			result, err := reviewpkg.RunAgentReview(context.Background(), a, tc.TmpDir, "HEAD", "Review the change.", "default", "medium", nil)
@@ -272,6 +272,7 @@ func TestPanelProseVerdictAfterRubric(t *testing.T) {
 }
 
 func TestPanelDisplayPolicyAcrossOutcomes(t *testing.T) {
+	tc := newWorkerTestContext(t, 1)
 	for _, policy := range []struct {
 		name    string
 		ci      string
@@ -286,7 +287,6 @@ func TestPanelDisplayPolicyAcrossOutcomes(t *testing.T) {
 		for _, outcome := range []string{"synthesis", "fallback"} {
 			t.Run(policy.name+"/"+outcome, func(t *testing.T) {
 				assert := assert.New(t)
-				tc := newWorkerTestContext(t, 1)
 				doc := reviewpkg.StructuredReview{SchemaVersion: 2, Verdict: "fail", Summary: "Review complete.", Findings: []reviewpkg.StructuredFinding{
 					{Severity: "low", Problem: "Low finding.", Fix: "Fix it.", Sources: []int{1}},
 					{Severity: "medium", Problem: "Medium finding.", Fix: "Fix it.", Sources: []int{1}},

--- a/internal/daemon/health_test.go
+++ b/internal/daemon/health_test.go
@@ -11,15 +11,13 @@ import (
 
 	"go.kenn.io/roborev/internal/config"
 	"go.kenn.io/roborev/internal/storage"
+	"go.kenn.io/roborev/internal/testutil"
 )
 
 // setupTestServer creates a temporary DB and Server, handling cleanup automatically.
 func setupTestServer(t *testing.T) *Server {
 	t.Helper()
-	dir := t.TempDir()
-	db, err := storage.Open(dir + "/test.db")
-	require.NoError(t, err, "Failed to open database")
-	t.Cleanup(func() { db.Close() })
+	db := testutil.OpenTestDB(t)
 
 	cfg := config.DefaultConfig()
 	server := newServerWithLogs(db, cfg, "", newTestErrorLog(), newTestActivityLog())

--- a/internal/daemon/panel_posting_test.go
+++ b/internal/daemon/panel_posting_test.go
@@ -362,9 +362,9 @@ func TestSynthesisCompletedReportsMemberExecutionStatus(t *testing.T) {
 		},
 	}
 
+	h := newCIPollerHarness(t, "https://github.com/acme/api.git")
 	for i, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := newCIPollerHarness(t, "https://github.com/acme/api.git")
 			comments := h.CaptureComments()
 			statuses := h.CaptureCommitStatuses()
 			headSHA := fmt.Sprintf("status-%d", i)

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenTestDBIsolatesFixtures(t *testing.T) {
+	first := OpenTestDB(t)
+	_, err := first.GetOrCreateRepo("/test/repo")
+	require.NoError(t, err)
+	firstID, err := first.GetDatabaseID()
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	// A later fixture must use the empty template, not an earlier test's data
+	// or database identity, and must outlive the earlier fixture's connection.
+	second := OpenTestDB(t)
+	var repos int
+	require.NoError(t, second.QueryRow("SELECT COUNT(*) FROM repos").Scan(&repos))
+	assert.Equal(t, 0, repos)
+	secondID, err := second.GetDatabaseID()
+	require.NoError(t, err)
+	assert.NotEqual(t, firstID, secondID)
+	_, err = second.GetOrCreateRepo("/test/repo")
+	require.NoError(t, err)
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -11,8 +11,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/roborev/internal/storage"
 )
@@ -152,6 +155,32 @@ func OpenTestDB(t *testing.T) *storage.DB {
 	return db
 }
 
+// Build the empty schema once per test process. Most callers exercise jobs or
+// daemon behavior, not migrations. Each caller still gets an independent,
+// file-backed database without replaying every migration for each fixture.
+var testDBTemplate = sync.OnceValues(func() ([]byte, error) {
+	dir, err := os.MkdirTemp("", "roborev-test-template-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "template.db")
+	db, err := storage.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	// Open assigns each copy its own identity instead of inheriting the template's.
+	if _, err := db.Exec("DELETE FROM sync_state WHERE key = ?", storage.SyncStateDatabaseID); err != nil {
+		return nil, err
+	}
+	// Closing checkpoints the WAL before we read the database file.
+	if err := db.Close(); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+})
+
 // OpenTestDBWithDir creates a test database and returns both the DB and the
 // temporary directory path. Useful when tests need to create repos or other
 // files in the same directory. The database is automatically closed when
@@ -162,10 +191,12 @@ func OpenTestDBWithDir(t *testing.T) (*storage.DB, string) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
+	data, err := testDBTemplate()
+	require.NoError(t, err, "create test database template")
+	require.NoError(t, os.WriteFile(dbPath, data, 0o600), "copy test database template")
+
 	db, err := storage.Open(dbPath)
-	if err != nil {
-		t.Fatalf("Failed to open test DB: %v", err)
-	}
+	require.NoError(t, err, "open test database")
 
 	t.Cleanup(func() {
 		db.Close()


### PR DESCRIPTION
The coverage test step passed in **4m49s** on [this CI run](https://github.com/kenn-io/roborev/actions/runs/34268849927), compared with **38m16s** on the [preceding review-formatting run](https://github.com/kenn-io/roborev/actions/runs/34263422083).

The shared fixture helper now reuses a prepared empty schema, as storage tests already do, while giving each test separate data and a fresh database identity. This avoids rebuilding the schema for every daemon and CLI fixture. Sequential panel test cases also reuse their database and repository.

The coverage job retains the full integration-test scope and adds a per-test timing artifact. PRs use the workflow definition from main, so the new artifact starts appearing once this change lands. Production database initialization and migration tests are unchanged.
