### PR TITLE
Isolate generated CI agents from Git and publishing credentials

### DIFF
--- a/cmd/roborev/ci.go
+++ b/cmd/roborev/ci.go
@@ -46,6 +46,7 @@ func ciReviewCmd() *cobra.Command {
 		reasoning      string
 		minSeverity    string
 		synthesisAgent string
+		outputFile     string
 	)
 
 	cmd := &cobra.Command{
@@ -85,6 +86,7 @@ Flags override config values. When run inside GitHub ` +
 					reasoning:      reasoning,
 					minSeverity:    minSeverity,
 					synthesisAgent: synthesisAgent,
+					outputFile:     outputFile,
 				})
 		},
 	}
@@ -123,10 +125,14 @@ Flags override config values. When run inside GitHub ` +
 	cmd.Flags().StringVar(&synthesisAgent, "synthesis-agent", "",
 		"agent for synthesis (overrides config)")
 
+	cmd.Flags().StringVar(&outputFile, "output-file", "",
+		"write the GitHub comment to a file for a separate publishing job (empty without substantive output)")
+
 	return cmd
 }
 
 type ciReviewOpts struct {
+	outputFile     string
 	ref            string
 	comment        bool
 	ghRepo         string
@@ -162,6 +168,13 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 	if opts.pr < 0 {
 		return fmt.Errorf(
 			"--pr must be a positive number (got %d)", opts.pr)
+	}
+	// Clear an earlier result even when this run has no changes or fails
+	// before synthesis. Publishers must never reuse a stale comment.
+	if opts.outputFile != "" {
+		if err := os.WriteFile(opts.outputFile, nil, 0o600); err != nil {
+			return fmt.Errorf("prepare review output: %w", err)
+		}
 	}
 
 	// Determine which forge this run targets before anything
@@ -367,6 +380,16 @@ func runCIReview(ctx context.Context, opts ciReviewOpts) error {
 
 	// Output to stdout (even on all-failed, for CI logs)
 	fmt.Println(synthesis.Output)
+
+	if opts.outputFile != "" {
+		comment := ""
+		if review.HasSubstantiveOutput(results) {
+			comment = synthesis.GitHubComment
+		}
+		if err := os.WriteFile(opts.outputFile, []byte(comment), 0o600); err != nil {
+			return fmt.Errorf("write review output: %w", err)
+		}
+	}
 
 	// Post as PR/MR comment if requested
 	if opts.comment {

--- a/cmd/roborev/ci_test.go
+++ b/cmd/roborev/ci_test.go
@@ -85,11 +85,17 @@ synthesis_reasoning = %q
 			} else {
 				args = append(args, "--gh-repo", "example/project-a")
 			}
+			commentPath := filepath.Join(dataDir, "comment.md")
+			args = append(args, "--output-file", commentPath)
 			cmd := ciCmd()
 			cmd.SetArgs(args)
 			output := captureOutput(t, cmd.Execute)
 			assert.Contains(t, output, "Combined test reviews")
 			assert.Contains(t, output, "Minor naming issue.", "stdout keeps below-threshold findings")
+			comment, err := os.ReadFile(commentPath)
+			require.NoError(t, err)
+			assert.NotContains(t, string(comment), "Minor naming issue.", "artifact uses the severity-filtered GitHub comment")
+			assert.NotEmpty(t, string(comment))
 			model, err := os.ReadFile(modelPath)
 			require.NoError(t, err, "synthesis must invoke the agent")
 			assert.Equal(t, tt.want, string(model))
@@ -102,6 +108,23 @@ synthesis_reasoning = %q
 			assert.Equal(t, wantReasoning, string(reasoning))
 		})
 	}
+}
+
+func TestCIReviewFailedBatchClearsOutputFile(t *testing.T) {
+	clearForgeCIEnv(t)
+	dataDir := testenv.SetDataDir(t)
+	repo := testutil.NewTestRepoWithCommit(t)
+	t.Chdir(repo.Path())
+	outputPath := filepath.Join(dataDir, "comment.md")
+	require.NoError(t, os.WriteFile(outputPath, []byte("previous review"), 0o600))
+	err := runCIReview(context.Background(), ciReviewOpts{
+		ref: "HEAD", agents: "nonexistent-ci-agent", reviewTypes: "default",
+		outputFile: outputPath,
+	})
+	require.ErrorIs(t, err, review.ErrAllFailed)
+	output, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Empty(t, output)
 }
 
 func installFakeGHAuthToken(t *testing.T, token string) {

--- a/cmd/roborev/ghaction.go
+++ b/cmd/roborev/ghaction.go
@@ -98,8 +98,8 @@ After generating the workflow, add repository secrets ` +
 
 	cmd.Flags().StringVar(&agentFlag, "agent", "",
 		"agents to use, comma-separated "+
-			"(codex, claude-code, gemini, copilot, "+
-			"opencode, cursor, kiro, kilo, droid, pi, grok)")
+			"(codex, claude-code, gemini, "+
+			"opencode, cursor, kilo, droid, grok)")
 	cmd.Flags().StringVar(&outputPath, "output", "",
 		"output path for workflow file "+
 			"(default: .github/workflows/roborev.yml)")

--- a/cmd/roborev/ghaction_test.go
+++ b/cmd/roborev/ghaction_test.go
@@ -78,10 +78,10 @@ func TestGhActionCmd(t *testing.T) {
 			expectedContains: []string{"ANTHROPIC_API_KEY", "@kilocode/cli@latest", "different model provider", "default for kilo"},
 		},
 		{
-			name:             "kiro has no secret in env block",
-			flags:            []string{"--agent", "kiro"},
-			expectedContains: []string{"kiro.dev"},
-			notContains:      []string{"OPENAI_API_KEY:", "AWS_ACCESS_KEY_ID:"},
+			name:          "kiro requires GitHub credentials",
+			flags:         []string{"--agent", "kiro"},
+			expectError:   true,
+			errorContains: "requires GitHub credentials",
 		},
 		{
 			name:             "infers agents from repo CI config",

--- a/docs/integrations/github.md
+++ b/docs/integrations/github.md
@@ -1155,16 +1155,38 @@ Add secrets in your repository's **Settings > Secrets and variables > Actions**.
 
 The generated workflow triggers on `pull_request` events and:
 
-1. Checks out the PR branch with full history
-1. Downloads the pinned roborev binary and verifies its SHA256 checksum
-1. Runs `roborev ci review --comment` with the configured agents
-1. Posts a PR comment only when an agent produced substantive review output
+1. Checks out the PR branch with full history and disables persisted Git
+    credentials
+1. Downloads roborev and verifies its SHA256 checksum
+1. Builds an agent image using a temporary build context outside the checkout
+1. Runs reviews, capability probes, and synthesis in disposable Docker
+    containers
+1. Uploads the completed comment as an artifact
+1. Publishes that artifact from a separate job with `pull-requests: write`
 
-In GitHub Actions, `ci review` reads `GITHUB_REPOSITORY`, `GITHUB_REF`, and
-`GITHUB_EVENT_PATH` automatically, so no flags are needed beyond `--comment`. An
-all-failed or empty-output run leaves its diagnostics in the Actions log without
-making a GitHub comment request. It exits nonzero for actionable failures; an
-all-quota batch keeps its existing successful exit.
+The review job has only `contents: read`. Its agent containers receive read-only
+mounts of the checkout and prepared input files, a fresh writable home, and
+explicitly allowed provider API keys. They do not receive the runner's home, Git
+configuration, SSH sockets, askpass helpers, Docker socket, or publishing token.
+Agents can inspect Git history and diffs but cannot commit changes to the
+mounted repository. ACP agents are rejected because their terminal tools run in
+the parent process.
+
+Copilot and Kiro are rejected by the generator because their current adapters
+require GitHub credentials. Provider API keys remain readable inside the
+containers; hiding those keys from model-controlled tools requires a separate
+provider broker. The containers have network access for provider requests.
+
+The publisher checks out no code and treats the artifact as comment text. It
+always appends a comment; `upsert_comments` does not affect this generated
+workflow. An all-failed or empty-output run creates no comment. Actionable
+failures exit nonzero; an all-quota batch keeps its existing successful exit.
+
+To upgrade an existing workflow, regenerate it with
+`roborev init gh-action --force`. Use a roborev release that includes
+`ci review --output-file` and container isolation. These protections apply to
+the generated workflow, not arbitrary manual invocations of
+`ci review --comment`.
 
 ### Customizing via `.roborev.toml`
 
@@ -1187,41 +1209,16 @@ min_severity = "medium"
 
 ### Manual Workflow Setup
 
-If you prefer full control over the workflow, create
-`.github/workflows/roborev.yml` manually:
+Start with `roborev init gh-action` and edit the generated workflow. Keep
+publishing in a separate job, `persist-credentials: false` on checkout, and the
+container environment settings in the review step. The generator creates agent
+discovery stubs that fail if container isolation is disabled.
 
-```yaml
-name: roborev
-on:
-  pull_request:
-    types: [opened, synchronize]
-
-permissions:
-  contents: read
-  pull-requests: write
-
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install roborev
-        run: |
-          curl -fsSL https://roborev.io/install.sh | bash
-          echo "$HOME/.roborev/bin" >> "$GITHUB_PATH"
-
-      - name: Run review
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: roborev ci review --comment --agent claude-code
-```
-
-Adjust the agent and secrets to match your setup. For multi-agent reviews, pass
-a comma-separated list (`--agent codex,gemini`) or use `--review-types` to run
-different review types.
+For a custom publishing integration, use
+`roborev ci review --output-file comment.md` without `--comment`. The file
+contains the severity-filtered GitHub comment, or is empty when no agent
+produced substantive output. Pass the file as data to the publishing job; never
+execute it or interpolate its contents into shell code.
 
 ## See Also
 

--- a/internal/agent/acp_agent.go
+++ b/internal/agent/acp_agent.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -184,6 +185,9 @@ func (a *ACPAgent) Review(ctx context.Context, repoPath, commitSHA, prompt strin
 func (a *ACPAgent) runPrompt(
 	ctx context.Context, repoPath, prompt string, output io.Writer,
 ) (string, error) {
+	if os.Getenv("ROBOREV_CI_AGENT_IMAGE") != "" {
+		return "", fmt.Errorf("ACP terminal tools are not supported in isolated CI reviews")
+	}
 	// Set timeout context
 	var cancel context.CancelFunc
 	var err error

--- a/internal/agent/ci_container.go
+++ b/internal/agent/ci_container.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// isolateCICommand runs generated-workflow agents in disposable containers.
+// The runner prepares prompts and schemas before launch; agents can read those
+// files and the checkout, but cannot alter them or inspect the runner's home.
+// Provider keys remain available to the provider CLI. Publishing credentials
+// and Git authentication are deliberately not part of this environment.
+func isolateCICommand(cmd *exec.Cmd) {
+	image := os.Getenv("ROBOREV_CI_AGENT_IMAGE")
+	if image == "" {
+		return
+	}
+	repo := os.Getenv("ROBOREV_CI_REPO")
+	prepared := os.Getenv("TMPDIR")
+	for name, path := range map[string]string{"ROBOREV_CI_REPO": repo, "TMPDIR": prepared} {
+		if !filepath.IsAbs(path) || filepath.Clean(path) == string(filepath.Separator) || strings.Contains(path, ",") {
+			cmd.Err = fmt.Errorf("CI isolation requires an absolute, non-root %s without commas", name)
+			return
+		}
+	}
+	docker, err := exec.LookPath("docker")
+	if err != nil {
+		cmd.Err = fmt.Errorf("CI agent isolation requires docker: %w", err)
+		return
+	}
+	dir := cmd.Dir
+	if dir == "" {
+		dir = repo
+	}
+	args := []string{
+		"docker", "run", "--rm", "--init", "-i",
+		"--read-only", "--cap-drop=ALL", "--security-opt=no-new-privileges",
+		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"--tmpfs", "/tmp:rw,exec,mode=1777",
+		"--tmpfs", "/home/agent:rw,mode=1777",
+		"--mount", "type=bind,src=" + repo + ",dst=" + repo + ",readonly",
+		"--mount", "type=bind,src=" + prepared + ",dst=" + prepared + ",readonly",
+		"--workdir", dir,
+		"--env", "HOME=/home/agent",
+		"--env", "GIT_CONFIG_NOSYSTEM=1",
+		"--env", "GIT_CONFIG_GLOBAL=/dev/null",
+		"--env", "GIT_CONFIG_COUNT=3",
+		"--env", "GIT_CONFIG_KEY_0=safe.directory",
+		"--env", "GIT_CONFIG_VALUE_0=" + repo,
+		"--env", "GIT_CONFIG_KEY_1=credential.helper",
+		"--env", "GIT_CONFIG_VALUE_1=",
+		"--env", "GIT_CONFIG_KEY_2=core.hooksPath",
+		"--env", "GIT_CONFIG_VALUE_2=/dev/null",
+		"--env", "GIT_TERMINAL_PROMPT=0",
+		"--env", "GIT_OPTIONAL_LOCKS=0",
+	}
+	// Use an allowlist, not a list of known runner secrets to remove. Never
+	// pass GitHub tokens, even for adapters that normally retain them.
+	for _, entry := range cmd.Env {
+		key, _, _ := strings.Cut(entry, "=")
+		switch key {
+		case "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY", "XAI_API_KEY":
+			args = append(args, "--env", entry)
+		}
+	}
+	args = append(args, image, filepath.Base(cmd.Path))
+	args = append(args, cmd.Args[1:]...)
+	// The Docker client also gets no publishing or provider secrets in its
+	// environment. Preserve only the client connection and executable lookup.
+	cmd.Env = nil
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if key == "PATH" || key == "HOME" || strings.HasPrefix(key, "DOCKER_") {
+			cmd.Env = append(cmd.Env, entry)
+		}
+	}
+	cmd.Path = docker
+	cmd.Args = args
+}

--- a/internal/agent/ci_container_integration_test.go
+++ b/internal/agent/ci_container_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package agent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/roborev/internal/testutil"
+)
+
+// Run with ROBOREV_TEST_CI_CONTAINER_IMAGE=node:24-bookworm. No provider or
+// forge calls are made: a shell exercises the same boundary as the agent CLI.
+func TestCIContainerBoundary(t *testing.T) {
+	image := os.Getenv("ROBOREV_TEST_CI_CONTAINER_IMAGE")
+	if image == "" {
+		t.Skip("set ROBOREV_TEST_CI_CONTAINER_IMAGE to a local image with sh and git")
+	}
+	repo := testutil.NewTestRepoWithCommit(t)
+	prepared := t.TempDir()
+	snapshot := filepath.Join(prepared, "prompt.txt")
+	require.NoError(t, os.WriteFile(snapshot, []byte("prepared prompt"), 0o600))
+	private := filepath.Join(t.TempDir(), "credential")
+	require.NoError(t, os.WriteFile(private, []byte("private sentinel"), 0o600))
+	t.Setenv("ROBOREV_CI_AGENT_IMAGE", image)
+	t.Setenv("ROBOREV_CI_REPO", repo.Path())
+	t.Setenv("TMPDIR", prepared)
+	t.Setenv("GH_TOKEN", "publishing-sentinel")
+	t.Setenv("GITHUB_TOKEN", "publishing-sentinel")
+	t.Setenv("SSH_AUTH_SOCK", private)
+	t.Setenv("GIT_ASKPASS", private)
+	t.Setenv("GIT_AUTHOR_NAME", "inherited-identity")
+	t.Setenv("OPENAI_API_KEY", "provider-sentinel")
+	t.Setenv("UNLISTED_SECRET", "other-sentinel")
+	// A helper supplied by the caller must not reach the container.
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "credential.helper")
+	t.Setenv("GIT_CONFIG_VALUE_0", "!echo password=helper-sentinel")
+
+	for _, probe := range []bool{false, true} {
+		name := "review and synthesis"
+		if probe {
+			name = "capability probe"
+		}
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.CommandContext(context.Background(), "sh", "-ec", `
+git -C "$1" log -1 --format=%s
+git -C "$1" diff HEAD
+cat "$2"
+test "$OPENAI_API_KEY" = provider-sentinel
+test -z "$GH_TOKEN$GITHUB_TOKEN$SSH_AUTH_SOCK$GIT_ASKPASS$GIT_AUTHOR_NAME$UNLISTED_SECRET"
+test ! -e "$3"
+test ! -e /var/run/docker.sock
+if git -C "$1" -c user.name=Fixture -c user.email=fixture@example.com commit --allow-empty -m forbidden; then exit 10; fi
+if printf changed > "$2"; then exit 11; fi
+if printf 'protocol=https\nhost=example.com\n\n' | git -C "$1" credential fill; then exit 12; fi
+printf '\nboundary checked\n'
+`, "probe", repo.Path(), snapshot, private)
+			cmd.Dir = repo.Path()
+			if probe {
+				configureCapabilityProbe(cmd)
+			} else {
+				// Even adapters that normally retain GitHub auth must lose it.
+				configureSubprocess(cmd, withGitHubCredentials())
+			}
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "%s", out)
+			assert.Contains(t, string(out), "prepared prompt")
+			assert.Contains(t, string(out), "boundary checked")
+			assert.NotContains(t, string(out), "helper-sentinel")
+		})
+	}
+}

--- a/internal/agent/ci_container_test.go
+++ b/internal/agent/ci_container_test.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCIContainerMissingMountFailsClosed(t *testing.T) {
+	skipIfWindows(t)
+	t.Setenv("ROBOREV_CI_AGENT_IMAGE", "review-image")
+	t.Setenv("ROBOREV_CI_REPO", t.TempDir())
+	t.Setenv("TMPDIR", "")
+	cmd := exec.CommandContext(context.Background(), "sh", "-c", "echo unisolated")
+	configureSubprocess(cmd)
+	out, err := cmd.CombinedOutput()
+	require.ErrorContains(t, err, "CI isolation requires")
+	assert.Empty(t, out)
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -710,13 +710,13 @@ func (a *ClaudeAgent) ClassifyWithSchema(
 	}
 	args := a.classifyArgs(schema)
 	cmd := exec.CommandContext(ctx, a.Command, args...)
-	configureSubprocess(cmd)
 	cmd.Dir = repoPath
 	env, err := buildClaudeEnv(cmd.Environ(), model, baseURL)
 	if err != nil {
 		return nil, err
 	}
 	cmd.Env = env
+	configureSubprocess(cmd)
 	cmd.Stdin = strings.NewReader(prompt)
 
 	stdout, err := cmd.StdoutPipe()
@@ -773,13 +773,13 @@ func (a *ClaudeAgent) ReviewWithSchema(
 	args = append(args, "--json-schema", string(schema))
 
 	cmd := exec.CommandContext(ctx, a.Command, args...)
-	configureSubprocess(cmd)
 	cmd.Dir = repoPath
 	env, err := buildClaudeEnv(cmd.Environ(), model, baseURL)
 	if err != nil {
 		return nil, err
 	}
 	cmd.Env = env
+	configureSubprocess(cmd)
 	cmd.Stdin = strings.NewReader(prompt)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/forge_env.go
+++ b/internal/agent/forge_env.go
@@ -69,8 +69,8 @@ var gitlabForgeCredentialEnvKeys = []string{
 //
 // These are stripped by default, but two agent CLIs authenticate with a
 // GitHub token and cannot run without it: copilot and kiro-cli (see
-// ghaction.AgentEnvVar, which maps both to GITHUB_TOKEN, and the generated
-// workflow's hardcoded GH_TOKEN line). Those two launch sites opt out via
+// ghaction.AgentEnvVar, which maps both to GITHUB_TOKEN). Generated CI
+// workflows reject them; elsewhere those two launch sites opt out via
 // withGitHubCredentials(); every other agent gets them removed.
 var githubForgeCredentialEnvKeys = []string{
 	"GH_TOKEN",

--- a/internal/agent/process.go
+++ b/internal/agent/process.go
@@ -78,6 +78,7 @@ func configureSubprocess(cmd *exec.Cmd, opts ...subprocessOption) *subprocessTra
 		stripUntrustedEnv(cmd.Env, cfg.keepGitHubCredentials),
 		"agent "+filepath.Base(cmd.Path))
 	cmd.Env = append(cmd.Env, "GIT_OPTIONAL_LOCKS=0")
+	isolateCICommand(cmd)
 
 	tracker := &subprocessTracker{}
 	// Ensure Cancel is always set. Go's exec.CommandContext only provides a
@@ -121,6 +122,7 @@ func configureCapabilityProbe(cmd *exec.Cmd) {
 		}
 	}
 	cmd.Dir = os.TempDir()
+	isolateCICommand(cmd)
 }
 
 // closeOnContextDone closes c when ctx fires (unless stopped first). When

--- a/internal/ghaction/ghaction.go
+++ b/internal/ghaction/ghaction.go
@@ -19,8 +19,7 @@ import (
 var (
 	allowedAgents = []string{
 		"codex", "claude-code", "gemini",
-		"copilot", "opencode", "cursor",
-		"kiro", "kilo", "droid", "grok",
+		"opencode", "cursor", "kilo", "droid", "grok",
 	}
 	safeVersionRE = regexp.MustCompile(
 		`^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$`)
@@ -62,6 +61,9 @@ func (c *WorkflowConfig) Validate() error {
 		return fmt.Errorf("at least one agent is required")
 	}
 	for _, ag := range c.Agents {
+		if ag == "copilot" || ag == "kiro" {
+			return fmt.Errorf("agent %q requires GitHub credentials and cannot run in isolated CI reviews", ag)
+		}
 		if !contains(allowedAgents, ag) {
 			return fmt.Errorf(
 				"invalid agent %q (valid: %s)",
@@ -171,9 +173,8 @@ func buildAgentInfos(agents []string) []AgentInfo {
 }
 
 // envEntries deduplicates agent infos by env var so the env
-// block doesn't repeat the same variable. GITHUB_TOKEN is
-// skipped because the workflow template already provides it
-// via the hardcoded GH_TOKEN line.
+// block does not repeat the same variable. GitHub-token agents are
+// rejected by Validate; they have no provider secret entry.
 func envEntries(infos []AgentInfo) []AgentInfo {
 	seen := make(map[string]bool)
 	var entries []AgentInfo
@@ -307,7 +308,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   review:
@@ -317,6 +317,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install roborev
         run: |
@@ -338,27 +339,84 @@ jobs:
           "$HOME/.local/bin/roborev" version
 
       # TODO: Pin agent CLI versions for supply-chain safety.
-      # Replace @latest with a specific version (e.g., @1.2.3).
       - name: Install agents
         run: |
           set -euo pipefail
+          build_dir=$(mktemp -d)
+          cat > "$build_dir/Dockerfile" <<'DOCKERFILE'
+          FROM node:24-bookworm
+          RUN apt-get update && apt-get install -y --no-install-recommends git ripgrep python3-pip && rm -rf /var/lib/apt/lists/*
+          ENV PIP_BREAK_SYSTEM_PACKAGES=1
           {{- range .Agents }}
-          {{ .InstallCmd }}
+          RUN {{ .InstallCmd }}
+          {{- end }}
+          DOCKERFILE
+          docker build -t roborev-ci-agent "$build_dir"
+          rm -rf "$build_dir"
+          # Discovery stubs fail closed if the container launch is not enabled.
+          # Agent probes and executions are redirected into the image by roborev.
+          {{- range .Agents }}
+          {{- if eq .Name "claude-code" }}
+          agent_cmd=claude
+          {{- else if eq .Name "cursor" }}
+          agent_cmd=agent
+          {{- else }}
+          agent_cmd={{ .Name }}
+          {{- end }}
+          printf '#!/bin/sh\nexit 1\n' > "$HOME/.local/bin/$agent_cmd"
+          chmod +x "$HOME/.local/bin/$agent_cmd"
           {{- end }}
 
       - name: Run review
         env:
-          GH_TOKEN: ${{"{{"}} secrets.GITHUB_TOKEN {{"}}"}}
+          ROBOREV_CI_AGENT_IMAGE: roborev-ci-agent
+          ROBOREV_CI_REPO: ${{"{{"}} github.workspace {{"}}"}}
           {{- range .EnvEntries }}
           {{ .EnvVar }}: ${{"{{"}} secrets.{{ .SecretName }} {{"}}"}}
           {{- end }}
         run: |
           set -euo pipefail
+          # Only prepared schemas and snapshots belong in this directory.
+          export ROBOREV_DATA_DIR
+          ROBOREV_DATA_DIR=$(mktemp -d)
+          export TMPDIR
+          TMPDIR=$(mktemp -d)
+          mkdir -p "$RUNNER_TEMP/roborev-result"
           roborev ci review \
             --agent "{{ .AgentCSV }}" \
             --synthesis-agent "{{ .SynthesisAgent }}" \
             --ref "${{"{{"}} github.event.pull_request.base.sha {{"}}"}}..${{"{{"}} github.event.pull_request.head.sha {{"}}"}}" \
-            --comment \
-            --gh-repo "${{"{{"}} github.repository {{"}}"}}" \
-            --pr "${{"{{"}} github.event.pull_request.number {{"}}"}}"
+            --output-file "$RUNNER_TEMP/roborev-result/comment.md"
+
+      - name: Upload completed review
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: roborev-result
+          path: ${{"{{"}} runner.temp {{"}}"}}/roborev-result/comment.md
+          if-no-files-found: error
+
+  publish:
+    needs: review
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # This job never checks out or executes pull request content.
+      - name: Download completed review
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: roborev-result
+          path: result
+
+      - name: Publish review
+        env:
+          GH_TOKEN: ${{"{{"}} secrets.GITHUB_TOKEN {{"}}"}}
+          GH_REPO: ${{"{{"}} github.repository {{"}}"}}
+          PR_NUMBER: ${{"{{"}} github.event.pull_request.number {{"}}"}}
+        run: |
+          set -euo pipefail
+          if [ -s result/comment.md ]; then
+            jq -Rs '{body: .}' < result/comment.md > comment.json
+            gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" --input comment.json
+          fi
 `

--- a/internal/ghaction/ghaction_test.go
+++ b/internal/ghaction/ghaction_test.go
@@ -17,6 +17,52 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, "codex", cfg.Agents[0], "expected default agent to be codex")
 }
 
+func TestGenerateCredentialSeparation(t *testing.T) {
+	for _, name := range append([]string{"copilot", "kiro"}, allowedAgents...) {
+		t.Run(name, func(t *testing.T) {
+			out, err := Generate(WorkflowConfig{Agents: []string{name}})
+			if name == "copilot" || name == "kiro" {
+				require.ErrorContains(t, err, "requires GitHub credentials")
+				return
+			}
+			require.NoError(t, err)
+			var workflow struct {
+				Permissions map[string]string `yaml:"permissions"`
+				Jobs        map[string]struct {
+					Needs       string            `yaml:"needs"`
+					Permissions map[string]string `yaml:"permissions"`
+					Steps       []struct {
+						Name string            `yaml:"name"`
+						Uses string            `yaml:"uses"`
+						Env  map[string]string `yaml:"env"`
+						With map[string]any    `yaml:"with"`
+					} `yaml:"steps"`
+				} `yaml:"jobs"`
+			}
+			require.NoError(t, yaml.Unmarshal([]byte(out), &workflow))
+			assert := assert.New(t)
+			assert.Equal(map[string]string{"contents": "read"}, workflow.Permissions)
+			for _, step := range workflow.Jobs["review"].Steps {
+				assert.NotContains(step.Env, "GH_TOKEN")
+				assert.NotContains(step.Env, "GITHUB_TOKEN")
+				if step.Name == "Checkout" {
+					assert.Equal(false, step.With["persist-credentials"])
+				}
+				if step.Name == "Run review" {
+					assert.Equal("roborev-ci-agent", step.Env["ROBOREV_CI_AGENT_IMAGE"])
+				}
+			}
+			publisher := workflow.Jobs["publish"]
+			assert.Equal("review", publisher.Needs)
+			assert.Equal(map[string]string{"pull-requests": "write"}, publisher.Permissions)
+			for _, step := range publisher.Steps {
+				assert.NotContains(step.Uses, "actions/checkout")
+				assert.NotContains(step.Env, AgentEnvVar(name))
+			}
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -34,8 +80,9 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "valid kiro agent",
-			cfg:  WorkflowConfig{Agents: []string{"kiro"}},
+			name:    "kiro requires forge credentials",
+			cfg:     WorkflowConfig{Agents: []string{"kiro"}},
+			wantErr: "requires GitHub credentials",
 		},
 		{
 			name: "valid kilo agent",
@@ -79,8 +126,8 @@ func TestValidate(t *testing.T) {
 				require.Error(t, err, "expected error")
 				require.ErrorContains(t, err, tt.wantErr, "unexpected error")
 
-			} else if err != nil {
-				require.Failf(t, "unexpected error", "%v", err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -105,9 +152,7 @@ func TestGenerate(t *testing.T) {
 				"Run review",
 				"roborev ci review",
 				"--ref",
-				"--comment",
-				"--gh-repo",
-				"--pr",
+				"--output-file",
 				"OPENAI_API_KEY",
 				"actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
 				"sha256sum --check",
@@ -185,19 +230,6 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 		{
-			name: "copilot agent",
-			cfg: WorkflowConfig{
-				Agents: []string{"copilot"},
-			},
-			wantStrs: []string{
-				"@github/copilot@latest",
-				"GH_TOKEN:",
-			},
-			envChecks: func(t *testing.T, env map[string]string) {
-				assert.NotContains(t, env, "GITHUB_TOKEN", "env block should not contain bare GITHUB_TOKEN: entry for copilot")
-			},
-		},
-		{
 			name: "pinned version",
 			cfg: WorkflowConfig{
 				Agents:         []string{"codex"},
@@ -245,20 +277,6 @@ func TestGenerate(t *testing.T) {
 			},
 			envChecks: func(t *testing.T, env map[string]string) {
 				assert.Contains(t, env, "ANTHROPIC_API_KEY", "expected ANTHROPIC_API_KEY in env")
-			},
-		},
-		{
-			name: "kiro skipped from env entries",
-			cfg: WorkflowConfig{
-				Agents: []string{"kiro"},
-			},
-			wantStrs: []string{
-				"kiro.dev",
-			},
-			notWantStrs: []string{
-				"OPENAI_API_KEY",
-				"ANTHROPIC_API_KEY",
-				"AWS_ACCESS_KEY_ID",
 			},
 		},
 		{


### PR DESCRIPTION
Generated CI reviews now run agents in disposable Docker containers, keeping the runner's Git credentials and publishing token out of reach of model-controlled tools. Agent commands, capability probes, and synthesis receive read-only mounts of the checkout and prepared inputs, a fresh home, and explicitly allowed provider API keys.

A separate job publishes the completed comment artifact without checking out PR code or running agents. Checkout no longer persists Git credentials. The publisher always appends a comment, so `upsert_comments` does not affect generated workflows.

Copilot and Kiro are rejected because their adapters require GitHub credentials. ACP agents are rejected because their terminal tools execute in the parent process. Existing workflows need regeneration with a release that includes `ci review --output-file` and container isolation.

Provider API keys remain readable inside agent containers. This addresses the Git and publishing boundary in #1022; the provider broker remains follow-up work, so this PR does not close that issue.
