### PR TITLE
Require evidence for build and test failure findings

### DIFF
--- a/docs/guides/reviewing-code.md
+++ b/docs/guides/reviewing-code.md
@@ -3,6 +3,19 @@ title: Reviewing Code
 description: Review branches, uncommitted changes, and commit ranges
 ---
 
+## Evidence for Build and Test Findings
+
+The built-in review prompts ask reviewers to run a focused check before claiming
+that code does not compile or a test fails. Reviewers should use the
+repository's pinned toolchain at the reviewed revision and include the command,
+version, and failure output. If execution is unavailable, they should label the
+claim unverified and explain the limitation.
+
+For missing setup findings, reviewers should trace the complete initialization
+path. A helper, export, constructor, or transaction callback may provide state
+that is not visible beside the failing operation. These instructions guide the
+reviewer; they are not a guarantee that every finding has been reproduced.
+
 ## Feature Branches
 
 Use `--branch` to review all commits since your branch diverged from main:

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -66,7 +66,11 @@ Check the manifests for each changed file's language, including every language a
 - Go: go.mod / go.sum.
 - TypeScript / JavaScript: package.json, a lockfile (yarn.lock, package-lock.json, pnpm-lock.yaml), tsconfig.json.
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
-- Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).`
+- Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
+
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.`
 
 // antiTestSlopInstruction keeps reviewers from recommending tests that cannot
 // detect a behavioral regression because their assertions restate the code.

--- a/internal/prompt/testdata/golden/design_review.golden
+++ b/internal/prompt/testdata/golden/design_review.golden
@@ -41,6 +41,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit

--- a/internal/prompt/testdata/golden/dirty_review.golden
+++ b/internal/prompt/testdata/golden/dirty_review.golden
@@ -45,6 +45,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Uncommitted Changes

--- a/internal/prompt/testdata/golden/lookahead_review.golden
+++ b/internal/prompt/testdata/golden/lookahead_review.golden
@@ -52,6 +52,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit

--- a/internal/prompt/testdata/golden/previous_reviews_with_comments.golden
+++ b/internal/prompt/testdata/golden/previous_reviews_with_comments.golden
@@ -50,6 +50,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Previous Reviews

--- a/internal/prompt/testdata/golden/range_with_in_range_reviews.golden
+++ b/internal/prompt/testdata/golden/range_with_in_range_reviews.golden
@@ -50,6 +50,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Per-Commit Reviews in This Range

--- a/internal/prompt/testdata/golden/security_review.golden
+++ b/internal/prompt/testdata/golden/security_review.golden
@@ -77,6 +77,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit

--- a/internal/prompt/testdata/golden/single_review_claude_code.golden
+++ b/internal/prompt/testdata/golden/single_review_claude_code.golden
@@ -43,6 +43,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit

--- a/internal/prompt/testdata/golden/single_review_codex.golden
+++ b/internal/prompt/testdata/golden/single_review_codex.golden
@@ -44,6 +44,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit

--- a/internal/prompt/testdata/golden/single_review_default.golden
+++ b/internal/prompt/testdata/golden/single_review_default.golden
@@ -50,6 +50,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit

--- a/internal/prompt/testdata/golden/single_review_gemini.golden
+++ b/internal/prompt/testdata/golden/single_review_gemini.golden
@@ -42,6 +42,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit

--- a/internal/prompt/testdata/golden/single_with_additional_context.golden
+++ b/internal/prompt/testdata/golden/single_with_additional_context.golden
@@ -50,6 +50,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Pull Request Discussion

--- a/internal/prompt/testdata/golden/single_with_guidelines.golden
+++ b/internal/prompt/testdata/golden/single_with_guidelines.golden
@@ -50,6 +50,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Project Guidelines

--- a/internal/prompt/testdata/golden/single_with_previous_reviews.golden
+++ b/internal/prompt/testdata/golden/single_with_previous_reviews.golden
@@ -50,6 +50,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Previous Reviews

--- a/internal/prompt/testdata/golden/single_with_severity_filter.golden
+++ b/internal/prompt/testdata/golden/single_with_severity_filter.golden
@@ -50,6 +50,10 @@ Check the manifests for each changed file's language, including every language a
 - Python: pyproject.toml, requirements.txt, uv/pixi lockfiles.
 - Other languages: the equivalent manifests (Cargo.toml, pom.xml, build.gradle, Gemfile).
 
+Before claiming that code does not compile or a test fails, run the smallest relevant check at the reviewed revision using the repository-pinned toolchain. Include the command, toolchain version, and actual failure output. If execution is unavailable, label the claim unverified and explain the limitation. A passing check is not a failure; describe any untested conditions separately. Do not replace a pinned toolchain with an older local default or infer compiler errors from remembered language rules.
+
+Before reporting missing fixture setup or initialization, trace the full setup path through helpers, exports, constructors, and transaction callbacks. Check state where it is used, not just nearby inserts. Existing calls may provision identities, defaults, or other required state. Do not request duplicate initialization when the complete path already provides it.
+
 Current date: GOLDEN_DATE (UTC)
 
 ## Current Commit


### PR DESCRIPTION
Built-in reviewers are asked to reproduce compile and test-failure claims with the repository-pinned toolchain, include the command and failure output, and label unavailable checks as unverified.

They are also asked to trace complete fixture setup before reporting missing initialization. These are review instructions, not an enforced proof requirement or a claim of measured accuracy improvement.
