### PR TITLE
Add a Markdown copy button to review output

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -71,8 +71,9 @@ provides:
 - close or reopen, rerun, and eligible cancellation actions; and
 - review-output copying and a comment form.
 
-Use the copy icon above the review output to copy its original Markdown,
-including headings, lists, links, and code blocks.
+Hover over the review output to reveal the copy icon in its top-right corner. It
+copies the original Markdown, including headings, lists, links, and code blocks.
+The icon also appears on keyboard focus and stays visible on touch devices.
 
 When a review agent fails before producing output, the **Review** tab shows the
 recorded failure reason so the problem can be diagnosed without leaving the

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -71,6 +71,9 @@ provides:
 - close or reopen, rerun, and eligible cancellation actions; and
 - review-output copying and a comment form.
 
+Use the copy icon above the review output to copy its original Markdown,
+including headings, lists, links, and code blocks.
+
 When a review agent fails before producing output, the **Review** tab shows the
 recorded failure reason so the problem can be diagnosed without leaving the
 browser application.

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -73,7 +73,9 @@ provides:
 
 Hover over the review output to reveal the copy icon in its top-right corner. It
 copies the original Markdown, including headings, lists, links, and code blocks.
-The icon also appears on keyboard focus and stays visible on touch devices.
+The icon floats over the content without reserving space. It also appears on
+keyboard focus and stays visible on touch devices. Release notes provide the
+same action labeled "Copy release notes as Markdown".
 
 When a review agent fails before producing output, the **Review** tab shows the
 recorded failure reason so the problem can be diagnosed without leaving the

--- a/packages/roborev-ui/src/components/ReviewContent.svelte
+++ b/packages/roborev-ui/src/components/ReviewContent.svelte
@@ -51,14 +51,15 @@
 {:else if pending}
   <div class="review-pending">Review in progress...</div>
 {:else if output}
-  <div class="review-actions">
-    <CopyButton
-      text={output}
-      ariaLabel="Copy review as Markdown"
-      title="Copy review as Markdown"
-    />
-  </div>
   <div class="review-content markdown-body" bind:this={markdownContainer}>
+    <div class="review-actions">
+      <CopyButton
+        text={output}
+        ariaLabel="Copy review as Markdown"
+        title="Copy review as Markdown"
+        revealOnHover
+      />
+    </div>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized by the Markdown renderer -->
     {@html renderedHTML}
   </div>
@@ -68,9 +69,17 @@
 
 <style>
   .review-actions {
-    display: flex;
-    justify-content: flex-end;
-    padding: 8px 20px 0;
+    position: absolute;
+    top: 16px;
+    right: 10px;
+  }
+
+  .review-content:hover .review-actions :global(.kit-copy-btn) {
+    opacity: 1;
+  }
+
+  .review-content > .review-actions + :global(*) {
+    margin-top: 0;
   }
 
   .review-loading,
@@ -83,7 +92,8 @@
   }
 
   .review-content {
-    padding: 16px 20px;
+    position: relative;
+    padding: 16px 46px 16px 20px;
   }
 
   /* Markdown prose styling */

--- a/packages/roborev-ui/src/components/ReviewContent.svelte
+++ b/packages/roborev-ui/src/components/ReviewContent.svelte
@@ -8,6 +8,7 @@
     loading?: boolean;
     pending?: boolean;
     emptyMessage?: string;
+    copyLabel?: string;
   }
 
   let {
@@ -15,6 +16,7 @@
     loading = false,
     pending = false,
     emptyMessage = "No review output available.",
+    copyLabel = "Copy review as Markdown",
   }: Props = $props();
 
   const fallbackHTML = $derived(renderMarkdownSync(output));
@@ -55,8 +57,8 @@
     <div class="review-actions">
       <CopyButton
         text={output}
-        ariaLabel="Copy review as Markdown"
-        title="Copy review as Markdown"
+        ariaLabel={copyLabel}
+        title={copyLabel}
         revealOnHover
       />
     </div>

--- a/packages/roborev-ui/src/components/ReviewContent.svelte
+++ b/packages/roborev-ui/src/components/ReviewContent.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { CopyButton } from "@kenn-io/kit-ui";
   import { initMarkdownMermaidRendering } from "@kenn-io/kit-ui/utils/markdown-mermaid";
   import { renderMarkdown, renderMarkdownSync } from "../markdown/render";
 
@@ -50,6 +51,13 @@
 {:else if pending}
   <div class="review-pending">Review in progress...</div>
 {:else if output}
+  <div class="review-actions">
+    <CopyButton
+      text={output}
+      ariaLabel="Copy review as Markdown"
+      title="Copy review as Markdown"
+    />
+  </div>
   <div class="review-content markdown-body" bind:this={markdownContainer}>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -- sanitized by the Markdown renderer -->
     {@html renderedHTML}
@@ -59,6 +67,12 @@
 {/if}
 
 <style>
+  .review-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 8px 20px 0;
+  }
+
   .review-loading,
   .review-pending,
   .review-empty {

--- a/packages/roborev-ui/src/components/ReviewContent.svelte
+++ b/packages/roborev-ui/src/components/ReviewContent.svelte
@@ -93,7 +93,7 @@
 
   .review-content {
     position: relative;
-    padding: 16px 46px 16px 20px;
+    padding: 16px 20px;
   }
 
   /* Markdown prose styling */

--- a/web/src/lib/components/ReleaseNotesModal.svelte
+++ b/web/src/lib/components/ReleaseNotesModal.svelte
@@ -9,6 +9,7 @@
   type ReleaseContentComponent = Component<{
     output: string;
     emptyMessage?: string;
+    copyLabel?: string;
   }>;
 
   interface Props {
@@ -137,6 +138,7 @@
               {#if ReleaseContent}
                 <ReleaseContent
                   output={selectedRelease.body}
+                  copyLabel="Copy release notes as Markdown"
                   emptyMessage="No release notes were provided."
                 />
               {:else if rendererError}

--- a/web/src/lib/components/ReleaseNotesModal.test.ts
+++ b/web/src/lib/components/ReleaseNotesModal.test.ts
@@ -35,6 +35,9 @@ describe("ReleaseNotesModal", () => {
     });
 
     expect(await screen.findByText("Latest notes")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy release notes as Markdown" }),
+    ).toHaveAttribute("title", "Copy release notes as Markdown");
     await fireEvent.click(screen.getByRole("button", { name: /Roborev 1.9/ }));
     expect(await screen.findByText("Earlier notes")).toBeInTheDocument();
   });

--- a/web/src/lib/components/reviews/ReviewContentLoaded.test.ts
+++ b/web/src/lib/components/reviews/ReviewContentLoaded.test.ts
@@ -1,11 +1,12 @@
 import { cleanup, render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
 import { afterEach, expect, it, vi } from "vitest";
 
 import ReviewContent from "./ReviewContent.svelte";
 
 const state = vi.hoisted(() => ({
   error: "provider rejected the request",
-  moduleResolved: false,
+  loaded: Promise.withResolvers<void>(),
 }));
 
 vi.mock("../../stores/context", () => ({
@@ -21,13 +22,12 @@ vi.mock("../../stores/context", () => ({
 
 vi.mock("@kenn-io/roborev-ui/review-content", async (importOriginal) => {
   const module = await importOriginal();
-  state.moduleResolved = true;
+  state.loaded.resolve();
   return module;
 });
 
 afterEach(() => {
   cleanup();
-  state.moduleResolved = false;
   vi.unstubAllGlobals();
 });
 
@@ -42,8 +42,8 @@ it("keeps the failure reason visible after the rich renderer loads", async () =>
   vi.stubGlobal("cancelIdleCallback", vi.fn());
   render(ReviewContent);
 
-  await vi.waitFor(() => expect(state.moduleResolved).toBe(true));
-  await Promise.resolve();
+  await state.loaded.promise;
+  await tick();
   expect(screen.getByRole("alert")).toHaveTextContent("Review failed");
   expect(screen.getByRole("alert")).toHaveTextContent(state.error);
 });

--- a/web/src/lib/components/reviews/ReviewDrawer.svelte
+++ b/web/src/lib/components/reviews/ReviewDrawer.svelte
@@ -2,7 +2,6 @@
   import { BottomDock, Button, FitStages, IconButton } from "@kenn-io/kit-ui";
   import BanIcon from "@lucide/svelte/icons/ban";
   import CircleCheckIcon from "@lucide/svelte/icons/circle-check";
-  import CopyIcon from "@lucide/svelte/icons/copy";
   import RefreshIcon from "@lucide/svelte/icons/refresh-cw";
   import Undo2Icon from "@lucide/svelte/icons/undo-2";
   import { getReviewStores } from "../../stores/context";
@@ -52,10 +51,6 @@
   function shortRef(ref: string): string {
     if (ref.length > 10) return ref.slice(0, 8);
     return ref;
-  }
-
-  function copyOutput(): void {
-    stores.roborevReview?.copyOutput();
   }
 
   function handleCloseReview(): void {
@@ -298,12 +293,6 @@
             label="Cancel"
           />
         {/if}
-        <Button
-          size="sm"
-          onclick={copyOutput}
-          title="Copy review output"
-          label="Copy Output"
-        />
       </div>
     {/snippet}
     {#snippet iconActions()}
@@ -344,14 +333,6 @@
             <BanIcon size={14} aria-hidden="true" />
           </IconButton>
         {/if}
-        <IconButton
-          size="sm"
-          ariaLabel="Copy Output"
-          title="Copy review output"
-          onclick={copyOutput}
-        >
-          <CopyIcon size={14} aria-hidden="true" />
-        </IconButton>
       </div>
     {/snippet}
     <div class="review-dock-footer">

--- a/web/src/lib/components/reviews/ReviewDrawer.test.ts
+++ b/web/src/lib/components/reviews/ReviewDrawer.test.ts
@@ -213,18 +213,13 @@ describe("ReviewDrawer", () => {
 
     const group = screen.getByRole("group", { name: "Review actions" });
     const buttons = [...group.children] as HTMLElement[];
-    expect(buttons.map((el) => el.tagName)).toEqual([
-      "BUTTON",
-      "BUTTON",
-      "BUTTON",
-    ]);
+    expect(buttons.map((el) => el.tagName)).toEqual(["BUTTON", "BUTTON"]);
     expect(buttons.every((el) => el.classList.contains("kit-button"))).toBe(
       true,
     );
     expect(buttons.map((el) => el.textContent?.trim())).toEqual([
       "Close Review",
       "Rerun",
-      "Copy Output",
     ]);
   });
 
@@ -239,9 +234,6 @@ describe("ReviewDrawer", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: "Close Review" }));
     expect(state.closeReview).toHaveBeenCalledWith(42);
-
-    await fireEvent.click(screen.getByRole("button", { name: "Copy Output" }));
-    expect(state.copyOutput).toHaveBeenCalledTimes(1);
   });
 
   it("shows rerun only for rerunnable jobs", () => {

--- a/web/src/lib/components/reviews/roborev-ui.test.ts
+++ b/web/src/lib/components/reviews/roborev-ui.test.ts
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/svelte";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   ReviewProjectionView,
@@ -52,6 +52,7 @@ const projection: ReviewProjection = {
 
 describe("@kenn-io/roborev-ui", () => {
   it("renders the complete read-only review projection", async () => {
+    const writeText = vi.spyOn(navigator.clipboard, "writeText");
     const view = render(ReviewProjectionView, { projection });
 
     expect(screen.getByText("project-a")).toBeInTheDocument();
@@ -59,6 +60,11 @@ describe("@kenn-io/roborev-ui", () => {
     expect(screen.getByText("correctness")).toBeInTheDocument();
     expect(screen.getByText("Confirmed")).toBeInTheDocument();
     await screen.findByRole("heading", { name: "Result" });
+    await fireEvent.click(
+      screen.getByRole("button", { name: "Copy review as Markdown" }),
+    );
+    expect(writeText).toHaveBeenCalledWith(projection.review?.output);
+    writeText.mockRestore();
     expect(view.container.innerHTML).not.toContain("<script");
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Add KitUI's floating copy button to review output so users can share the original Markdown without relying on HTML paste support. It appears on hover or keyboard focus and stays visible on touch devices, using KitUI's existing copied feedback.

Screenshot uses sample review data.

<img width="1425" height="278" alt="Floating Markdown copy button beside the review heading" src="https://github.com/user-attachments/assets/e36f848e-54bd-433b-938a-3d890cb318f6" />

Fixes #1160.
